### PR TITLE
Add Conductor workspace config (setup, run scripts, files to copy)

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -1,0 +1,18 @@
+"$schema" = "https://conductor.build/schemas/settings.repo.schema.json"
+
+[scripts]
+setup = "python3 -m venv venv && venv/bin/pip install -r requirements.txt"
+run_mode = "concurrent"
+
+[scripts.run.dashboard]
+command = "FLASK_APP=app.py venv/bin/flask run --port $CONDUCTOR_PORT --debug"
+default = true
+icon = "monitor"
+
+[scripts.run.generate]
+command = "venv/bin/python generate.py"
+icon = "sparkles"
+
+[scripts.run.website]
+command = "cd website && ../venv/bin/python build.py"
+icon = "globe"

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,5 @@
+.env
+config.yaml
+dashboard_data.json
+static/*.jpg
+static/*.png


### PR DESCRIPTION
Adds `.conductor/settings.toml` so this repo works in [Conductor](https://conductor.build/docs/reference/scripts): a setup script that creates the venv and installs requirements, plus three run scripts — the Flask dashboard on `$CONDUCTOR_PORT` (default, with `--debug` auto-reload), `generate.py`, and the website build — with concurrent run mode since each workspace gets its own port. Also adds `.worktreeinclude` so the gitignored personal files (`.env`, `config.yaml`, `dashboard_data.json`, family photos) are copied into each new workspace and the dashboard renders real content. Verified end-to-end: setup builds the venv cleanly, the dashboard serves `/` and `/preview` with 200 on the assigned port, and the website build produces no diff in `docs/`. Note the dashboard script binds localhost instead of `0.0.0.0` (LAN exposure is only needed on the Pi).

🤖 Generated with [Claude Code](https://claude.com/claude-code)