### PR TITLE
Add Raspberry Pi calendar guide, expand DIY page

### DIFF
--- a/docs/best-digital-family-calendar/index.html
+++ b/docs/best-digital-family-calendar/index.html
@@ -377,6 +377,7 @@
             <a href="/hearth-vs-skylight/">Hearth vs Skylight</a>
             <a href="/skylight-calendar-subscription/">Skylight subscription costs</a>
             <a href="/diy-skylight-calendar/">DIY digital calendar</a>
+            <a href="/raspberry-pi-family-calendar/">Raspberry Pi calendar</a>
             <a href="/digital-calendar-and-chore-chart/">Calendar + chore chart</a>
             <a href="/best-digital-family-calendar/">Best family calendars</a>
             <a href="/morning-routine/">Morning routines</a>

--- a/docs/digital-calendar-and-chore-chart/index.html
+++ b/docs/digital-calendar-and-chore-chart/index.html
@@ -349,6 +349,7 @@
             <a href="/hearth-vs-skylight/">Hearth vs Skylight</a>
             <a href="/skylight-calendar-subscription/">Skylight subscription costs</a>
             <a href="/diy-skylight-calendar/">DIY digital calendar</a>
+            <a href="/raspberry-pi-family-calendar/">Raspberry Pi calendar</a>
             <a href="/digital-calendar-and-chore-chart/">Calendar + chore chart</a>
             <a href="/best-digital-family-calendar/">Best family calendars</a>
             <a href="/morning-routine/">Morning routines</a>

--- a/docs/diy-skylight-calendar/index.html
+++ b/docs/diy-skylight-calendar/index.html
@@ -335,7 +335,12 @@
 </tr>
 </tbody>
 </table>
-<p>The Raspberry Pi route is the classic: it draws a couple of watts, mounts cleanly on a wall or shelf, and boots straight into the dashboard in kiosk mode. The old-tablet route is the fastest way to find out whether your family will actually use a wall calendar.</p>
+<p>The Raspberry Pi route is the classic: it draws well under 10 watts, mounts cleanly on a wall or shelf, and boots straight into the dashboard in kiosk mode. Our <a href="/raspberry-pi-family-calendar/">Raspberry Pi family calendar guide</a> covers which Pi and screen to buy, with a full parts list.</p>
+<p>The old-tablet route is the fastest way to find out whether your family will actually use a wall calendar — and that's the real question, not which hardware to buy.</p>
+<h2>Start with the screen you already own</h2>
+<p>Before spending anything, prop up an old tablet or spare monitor in the kitchen and run the dashboard on it for two weeks.</p>
+<p>This sounds like a hedge, but it's the single most useful thing you can do. A family calendar only works if it's somewhere everyone walks past at the right time of day, and you will almost certainly get that spot wrong on the first try. Finding out with a tablet on a cookbook stand costs nothing. Finding out after mounting a Pi behind drywall is annoying.</p>
+<p>If it sticks, buy the hardware. If it doesn't, you've lost an evening instead of $629.</p>
 <h2>The build, in five steps</h2>
 <p>The <a href="/getting-started/">full getting-started guide</a> has copy-paste commands for every step. The short version:</p>
 <ol>
@@ -345,6 +350,15 @@
 <li><strong>Set the 6am schedule</strong> — one cron line generates a fresh dashboard every morning before anyone wakes up.</li>
 <li><strong>Point your screen at it</strong> — on a Pi, Chromium launches fullscreen at boot; on a tablet or TV, just open the dashboard URL in the browser.</li>
 </ol>
+<p>Realistically: an evening for the first build if you're comfortable in a terminal, and about ten minutes whenever you want to change a chore rotation afterwards.</p>
+<h2>Mounting it on the wall</h2>
+<p>Three things decide whether this gets looked at:</p>
+<ul>
+<li><strong>Height and place.</strong> Eye level, on the route between the coffee machine and the door. Kitchens beat hallways; hallways beat home offices.</li>
+<li><strong>Power.</strong> This is the part people underestimate. A wall-mounted screen needs a cable to somewhere, and the honest options are a nearby outlet, a surface-mounted cable channel, or a shelf instead of a wall. Pick the spot with power in mind rather than solving it afterwards.</li>
+<li><strong>Glare.</strong> A screen facing a window is unreadable for two hours a day. Turn it perpendicular to the light.</li>
+</ul>
+<p>A cheap tablet wall mount, a picture ledge, or a small easel stand all work. None of this needs to be permanent — and it shouldn't be, until you're sure about the location.</p>
 <h2>DIY vs Skylight, honestly</h2>
 <p><strong>What you give up:</strong> the slick touch interface for editing events on the screen itself (you edit in Google Calendar instead), the polished companion app, and someone to email when things break.</p>
 <p><strong>What you gain:</strong></p>
@@ -390,9 +404,22 @@
 </tbody>
 </table>
 <p><em>Prices checked July 2026.</em></p>
+<h2>Questions people ask</h2>
+<p><strong>Is there a monthly fee for a DIY calendar?</strong>
+No subscription. The only running cost is the Anthropic API key for the daily brief, which comes to a few cents a month — roughly $0.20–0.40 for a typical family. Skip the AI brief and it's free. (For what Skylight itself charges, see our <a href="/skylight-calendar-subscription/">Skylight subscription breakdown</a>.)</p>
+<p><strong>Do I need to know how to code?</strong>
+No, but you need to be willing to copy commands into a terminal and read an error message without panicking. If you've ever followed a Raspberry Pi tutorial, you're comfortably over the bar. If the word "terminal" is a dealbreaker, buy the Skylight — that's a legitimate answer.</p>
+<p><strong>What actually goes wrong?</strong>
+Two things, both fixable in a minute. Chromium sometimes starts before the server is ready and shows a connection error at boot — the startup script waits for the server to fix this. And emoji render as empty boxes until you install the emoji font package. Both are covered in the <a href="/getting-started/">troubleshooting section</a>.</p>
+<p><strong>What happens if the internet goes down?</strong>
+The dashboard keeps showing yesterday's data. The AI brief is generated once each morning and saved to a file, so the screen never depends on a live connection to display something.</p>
+<p><strong>Can the kids break it?</strong>
+There's nothing to tap. It's a read-only display — events are edited in Google Calendar on your phone, so there's no way to delete next week from the wall.</p>
+<p><strong>Is DIY actually worth it versus just buying one?</strong>
+If your time is worth more than about $500 an evening, no. If you already own a spare screen, enjoy this sort of project, or specifically want your family's data staying on your own hardware, yes. Both are reasonable — see <a href="/skylight-calendar-alternatives/">all the Skylight alternatives</a> including no-setup options.</p>
 <h2>Start here</h2>
-<p>If you can copy commands into a terminal, you can have this on your kitchen wall by Sunday: <strong><a href="/getting-started/">the complete setup guide</a></strong>. Rather skip the setup entirely? A hosted version is coming — <a href="https://fffwryhvses.typeform.com/to/yxMMhmFs">join the waitlist</a>.</p>
-<p>Not sure DIY is for you? See <a href="/skylight-calendar-alternatives/">all the Skylight alternatives</a>, including no-setup options.</p>
+<p>If you can copy commands into a terminal, you can have this on your kitchen wall by Sunday: <strong><a href="/getting-started/">the complete setup guide</a></strong>. Buying hardware for it? Start with the <a href="/raspberry-pi-family-calendar/">Raspberry Pi build guide</a>.</p>
+<p>Rather skip the setup entirely? A hosted version is coming — <a href="https://fffwryhvses.typeform.com/to/yxMMhmFs">join the waitlist</a>.</p>
 </div>
 
 </main>
@@ -404,6 +431,7 @@
             <a href="/hearth-vs-skylight/">Hearth vs Skylight</a>
             <a href="/skylight-calendar-subscription/">Skylight subscription costs</a>
             <a href="/diy-skylight-calendar/">DIY digital calendar</a>
+            <a href="/raspberry-pi-family-calendar/">Raspberry Pi calendar</a>
             <a href="/digital-calendar-and-chore-chart/">Calendar + chore chart</a>
             <a href="/best-digital-family-calendar/">Best family calendars</a>
             <a href="/morning-routine/">Morning routines</a>

--- a/docs/family-dashboard/index.html
+++ b/docs/family-dashboard/index.html
@@ -342,6 +342,7 @@
             <a href="/hearth-vs-skylight/">Hearth vs Skylight</a>
             <a href="/skylight-calendar-subscription/">Skylight subscription costs</a>
             <a href="/diy-skylight-calendar/">DIY digital calendar</a>
+            <a href="/raspberry-pi-family-calendar/">Raspberry Pi calendar</a>
             <a href="/digital-calendar-and-chore-chart/">Calendar + chore chart</a>
             <a href="/best-digital-family-calendar/">Best family calendars</a>
             <a href="/morning-routine/">Morning routines</a>

--- a/docs/getting-started/index.html
+++ b/docs/getting-started/index.html
@@ -553,6 +553,7 @@ journalctl -u dinkydash -f           # View logs
             <a href="/hearth-vs-skylight/">Hearth vs Skylight</a>
             <a href="/skylight-calendar-subscription/">Skylight subscription costs</a>
             <a href="/diy-skylight-calendar/">DIY digital calendar</a>
+            <a href="/raspberry-pi-family-calendar/">Raspberry Pi calendar</a>
             <a href="/digital-calendar-and-chore-chart/">Calendar + chore chart</a>
             <a href="/best-digital-family-calendar/">Best family calendars</a>
             <a href="/morning-routine/">Morning routines</a>

--- a/docs/hearth-vs-skylight/index.html
+++ b/docs/hearth-vs-skylight/index.html
@@ -363,6 +363,7 @@
             <a href="/hearth-vs-skylight/">Hearth vs Skylight</a>
             <a href="/skylight-calendar-subscription/">Skylight subscription costs</a>
             <a href="/diy-skylight-calendar/">DIY digital calendar</a>
+            <a href="/raspberry-pi-family-calendar/">Raspberry Pi calendar</a>
             <a href="/digital-calendar-and-chore-chart/">Calendar + chore chart</a>
             <a href="/best-digital-family-calendar/">Best family calendars</a>
             <a href="/morning-routine/">Morning routines</a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1049,6 +1049,7 @@
             <a href="/hearth-vs-skylight/">Hearth vs Skylight</a>
             <a href="/skylight-calendar-subscription/">Skylight subscription costs</a>
             <a href="/diy-skylight-calendar/">DIY digital calendar</a>
+            <a href="/raspberry-pi-family-calendar/">Raspberry Pi calendar</a>
             <a href="/digital-calendar-and-chore-chart/">Calendar + chore chart</a>
             <a href="/best-digital-family-calendar/">Best family calendars</a>
             <a href="/morning-routine/">Morning routines</a>

--- a/docs/morning-routine/index.html
+++ b/docs/morning-routine/index.html
@@ -335,6 +335,7 @@
             <a href="/hearth-vs-skylight/">Hearth vs Skylight</a>
             <a href="/skylight-calendar-subscription/">Skylight subscription costs</a>
             <a href="/diy-skylight-calendar/">DIY digital calendar</a>
+            <a href="/raspberry-pi-family-calendar/">Raspberry Pi calendar</a>
             <a href="/digital-calendar-and-chore-chart/">Calendar + chore chart</a>
             <a href="/best-digital-family-calendar/">Best family calendars</a>
             <a href="/morning-routine/">Morning routines</a>

--- a/docs/office-dashboard/index.html
+++ b/docs/office-dashboard/index.html
@@ -334,6 +334,7 @@
             <a href="/hearth-vs-skylight/">Hearth vs Skylight</a>
             <a href="/skylight-calendar-subscription/">Skylight subscription costs</a>
             <a href="/diy-skylight-calendar/">DIY digital calendar</a>
+            <a href="/raspberry-pi-family-calendar/">Raspberry Pi calendar</a>
             <a href="/digital-calendar-and-chore-chart/">Calendar + chore chart</a>
             <a href="/best-digital-family-calendar/">Best family calendars</a>
             <a href="/morning-routine/">Morning routines</a>

--- a/docs/raspberry-pi-family-calendar/index.html
+++ b/docs/raspberry-pi-family-calendar/index.html
@@ -3,14 +3,14 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>About DinkyDash — DinkyDash</title>
-    <meta name="description" content="DinkyDash is a free, open-source digital family calendar that runs on screens you already own — with an AI-written daily brief for your family.">
-    <link rel="canonical" href="https://dinkydash.co/about/">
-    <meta property="og:title" content="About DinkyDash — DinkyDash">
+    <title>Raspberry Pi Family Calendar: Build a Wall Dashboard That Updates Itself — DinkyDash</title>
+    <meta name="description" content="How to turn a Raspberry Pi into a wall-mounted family calendar and dashboard — today&#39;s events, rotating chores, birthday countdowns and an AI daily brief, for about $100 in parts and no subscription.">
+    <link rel="canonical" href="https://dinkydash.co/raspberry-pi-family-calendar/">
+    <meta property="og:title" content="Raspberry Pi Family Calendar: Build a Wall Dashboard That Updates Itself — DinkyDash">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://dinkydash.co/about/">
+    <meta property="og:url" content="https://dinkydash.co/raspberry-pi-family-calendar/">
     <meta property="og:image" content="https://dinkydash.co/images/hero-kitchen.png">
-    <meta property="og:description" content="DinkyDash is a free, open-source digital family calendar that runs on screens you already own — with an AI-written daily brief for your family.">
+    <meta property="og:description" content="How to turn a Raspberry Pi into a wall-mounted family calendar and dashboard — today&#39;s events, rotating chores, birthday countdowns and an AI daily brief, for about $100 in parts and no subscription.">
     <meta name="twitter:card" content="summary_large_image">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -295,44 +295,124 @@
 <main>
     
 <div class="container page-content">
-    <h1>About DinkyDash</h1>
-    <p>DinkyDash is a free, open-source <strong>digital family calendar for screens you already own</strong>. Point a TV, an old tablet, or a Raspberry Pi at it and your family gets one glanceable screen with today's calendar, a self-rotating chore chart, countdowns to the big days — and a daily brief written fresh every morning by AI.</p>
-<p>It was built by <a href="https://casparwre.de">Caspar</a>, an indie developer in Berlin, for his own kids — and open-sourced because a family calendar shouldn't cost $629 plus a subscription.</p>
-<h2>Why an AI-written dashboard?</h2>
-<p>Most family calendar displays show static information that someone has to curate. DinkyDash takes a different approach: you describe your family once, and AI does the rest.</p>
-<p>Every morning at 6am, DinkyDash automatically:</p>
+    <h1>Raspberry Pi Family Calendar: Build a Wall Dashboard That Updates Itself</h1>
+    <p>A Raspberry Pi, a small touchscreen and some open-source software make a genuinely good family calendar: it hangs on the kitchen wall, shows today's schedule at a glance, updates itself every morning, and costs about <strong>$100 in parts with nothing monthly</strong>.</p>
+<p>This page covers the hardware side — which Pi, which screen, what it draws, what it costs. The <a href="/getting-started/">full setup guide</a> has the copy-paste commands.</p>
+<p><img alt="A Raspberry Pi with a small touchscreen showing a family dashboard, sitting on a kitchen shelf" src="/images/diy-raspberry-pi-calendar.png" /></p>
+<h2>What ends up on the screen</h2>
+<p><a href="https://github.com/caspii/dinkydash">DinkyDash</a> is a free, open-source, MIT-licensed family dashboard built for exactly this. On the display you get:</p>
 <ul>
-<li>Fetches your Google Calendar events (any iCal link works)</li>
-<li>Figures out whose turn it is for each chore</li>
-<li>Calculates countdowns to birthdays, holidays, and special dates</li>
-<li>Sends all of this to Claude, which writes a personalized dashboard</li>
+<li><strong>Today's events</strong>, pulled from Google Calendar or any calendar with an iCal link</li>
+<li><strong>A chore chart</strong> that rotates between family members automatically each day</li>
+<li><strong>Countdowns</strong> to birthdays, holidays and vacations</li>
+<li><strong>A daily brief written by Claude</strong> — a fresh greeting, fun fact and family challenge every morning, written around your actual family</li>
 </ul>
-<p>The result is a screen that feels alive. It knows it's someone's birthday week. It writes a different fun fact and family challenge every day, tuned to your kids' interests. Kids check it voluntarily — which is the entire battle.</p>
-<h2>What the dashboard shows</h2>
+<p>No touch interaction is required. It's a display, not an app — which is the point, and also why a modest Pi is plenty.</p>
+<h2>Which Raspberry Pi</h2>
+<table>
+<thead>
+<tr>
+<th>Model</th>
+<th>Verdict</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>Pi 4 (2GB)</strong></td>
+<td>The sweet spot. Runs Chromium in kiosk mode comfortably, cheap, widely available second-hand. This is what we'd pick.</td>
+</tr>
+<tr>
+<td><strong>Pi 5</strong></td>
+<td>Works fine and boots faster, but it's more money and more heat for a job that's mostly idle. Overkill here.</td>
+</tr>
+<tr>
+<td><strong>Pi Zero 2 W</strong></td>
+<td>Tempting at the price, but Chromium is a heavy browser and the Zero struggles. Workable if you're patient; frustrating if you're not.</td>
+</tr>
+<tr>
+<td><strong>Pi 3</strong></td>
+<td>Fine if you already own one. Slow to boot, but it only boots once.</td>
+</tr>
+</tbody>
+</table>
+<p>2GB of RAM is enough. The dashboard is a single static page that refreshes every five minutes — there's no database and no continuous rendering.</p>
+<h2>Which display</h2>
+<p>The software targets <strong>800×480</strong>, which is the resolution of the official Raspberry Pi 7″ Touch Display. That's the path of least resistance.</p>
 <ul>
-<li><strong>A daily headline</strong> — a cheerful, AI-written greeting for your family</li>
-<li><strong>Person cards</strong> — each family member with their photo and key info</li>
-<li><strong>Chore rotation</strong> — who does what today, rotated automatically and fairly</li>
-<li><strong>Countdowns</strong> — days until birthdays, holidays, vacations, and special events</li>
-<li><strong>Calendar events</strong> — what's happening today, pulled from your shared calendar</li>
-<li><strong>Fun facts and challenges</strong> — something new to read every morning</li>
-<li><strong>Pet corner</strong> — because pets are family too</li>
+<li><strong>Official 7″ Touch Display</strong> — connects over DSI (one ribbon cable, no HDMI), powered from the Pi itself. Around $60–80.</li>
+<li><strong>Any HDMI monitor</strong> — works, and a bigger screen reads better from across a room. You'll want to adjust the layout, and you're now managing two power supplies.</li>
+<li><strong>An old monitor you already own</strong> — free, and honestly the best way to test whether your family will actually look at it before you spend anything.</li>
 </ul>
-<h2>The principles</h2>
+<p>Touch is optional. The dashboard is read-only by design; you edit events in Google Calendar on your phone, the way you already do.</p>
+<h2>Parts list</h2>
+<table>
+<thead>
+<tr>
+<th>Part</th>
+<th>Approximate cost</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Raspberry Pi 4 (2GB)</td>
+<td>$45–60</td>
+</tr>
+<tr>
+<td>Official 7″ Touch Display</td>
+<td>$60–80</td>
+</tr>
+<tr>
+<td>MicroSD card (16GB+)</td>
+<td>$8–12</td>
+</tr>
+<tr>
+<td>USB-C power supply</td>
+<td>$8–12</td>
+</tr>
+<tr>
+<td>Case or stand</td>
+<td>$0–20</td>
+</tr>
+<tr>
+<td><strong>Total</strong></td>
+<td><strong>~$120–185 new, well under $100 with parts you own or buy used</strong></td>
+</tr>
+</tbody>
+</table>
+<p><em>Prices are approximate and vary by retailer — checked August 2026.</em></p>
+<p>Second-hand Pis are abundant and this workload will never stress one, so the used market is a genuinely good idea here.</p>
+<h2>How it actually works</h2>
+<p>The architecture is deliberately boring, which is why it keeps running:</p>
+<ol>
+<li><strong>A cron job at 6am</strong> runs a generation script. It fetches your calendar, works out ages, birthday countdowns and whose turn it is for each chore, sends all of that to the Claude API, and writes the result to a single JSON file.</li>
+<li><strong>A small Flask server</strong> reads that JSON file and renders the page.</li>
+<li><strong>Chromium launches fullscreen at boot</strong> in kiosk mode and refreshes every five minutes.</li>
+</ol>
+<p>The API call happens <strong>once a day</strong>, not on every page load. That matters for two reasons: the dashboard stays instant because it's only ever serving a static file, and your Anthropic bill is a few cents a month rather than a few dollars.</p>
+<p>If the network drops or the API call fails, the previous day's JSON is still on disk and the screen keeps showing it. A stale dashboard beats a blank one.</p>
+<h2>Power draw and leaving it on</h2>
+<p>A Pi 4 with the 7″ display sits <strong>under 10 watts</strong>. Left on around the clock that's roughly 60 kWh a year — call it $10 at typical US rates.</p>
+<p>You can cut that roughly in half with two cron lines that switch the display off overnight and back on before breakfast:</p>
+<pre><code>0 22 * * * /home/pi/screen_control.sh off
+0 7 * * * /home/pi/screen_control.sh on
+</code></pre>
+<p>The Pi stays up; only the panel sleeps. The <a href="/getting-started/">setup guide</a> has the script.</p>
+<h2>Kiosk mode</h2>
+<p>The one part people usually get wrong is the boot sequence: Chromium starts before Flask is ready and you get "localhost refused to connect" on the wall every morning. The startup script in the setup guide polls the server for up to 60 seconds before launching the browser, which fixes it.</p>
+<p>Two other things worth knowing before you start:</p>
 <ul>
-<li><strong>Bring your own screen.</strong> Anything with a browser works — no proprietary hardware, ever.</li>
-<li><strong>No subscription.</strong> MIT-licensed, free forever. You bring your own AI API key; a day's dashboard costs a few cents.</li>
-<li><strong>Private by design.</strong> Your family's details live in one config file on your own device — not in our cloud, because there isn't one.</li>
-<li><strong>Boring, reliable tech.</strong> Python, a cron job, and a web page: <code>generate.py</code> builds the day's dashboard as JSON each morning, and a tiny Flask app renders it. It's fixable with a search engine and an afternoon.</li>
+<li>Install <code>fonts-noto-color-emoji</code>, or the dashboard renders as empty boxes.</li>
+<li>On Raspberry Pi OS Bookworm the boot config lives at <code>/boot/firmware/config.txt</code>, not <code>/boot/config.txt</code> — this trips up a lot of older tutorials.</li>
 </ul>
-<h2>Where to start</h2>
-<ul>
-<li><a href="/getting-started/">Getting started guide</a> — from zero to a dashboard on your wall</li>
-<li><a href="/diy-skylight-calendar/">The ~$100 DIY build</a> — the Raspberry Pi + touchscreen route</li>
-<li><a href="/skylight-calendar-alternatives/">How it compares to Skylight, Hearth &amp; co.</a></li>
-<li><a href="https://github.com/caspii/dinkydash">The code, on GitHub</a></li>
-</ul>
-<p>Want DinkyDash without the setup? A hosted version is in the works — <a href="https://fffwryhvses.typeform.com/to/yxMMhmFs">join the waitlist</a>.</p>
+<p>Both are covered, with fixes, in the <a href="/getting-started/">troubleshooting section</a>.</p>
+<h2>Why build one instead of buying</h2>
+<p>A Skylight Calendar Max is $629, plus $79 a year for the Plus features. A Hearth Display is $699 plus $9 a month. They're nicely made, and if you want something that works out of the box with a support line, they're reasonable purchases.</p>
+<p>But a digital family calendar is fundamentally a screen showing a web page. If you're comfortable with a terminal, the Pi version costs about a sixth as much, has no subscription, keeps your family's data on your own device, and does one thing the $629 hardware doesn't: writes you a fresh daily brief every morning.</p>
+<p>The full cost comparison is on the <a href="/diy-skylight-calendar/">DIY Skylight calendar page</a>.</p>
+<h2>Start building</h2>
+<p>Everything you need is in the <a href="/getting-started/">setup guide</a> — install, config, cron, systemd service and kiosk mode, with the commands to copy. Budget an evening for the first build.</p>
+<p>The code is on <a href="https://github.com/caspii/dinkydash">GitHub</a> under an MIT licence. Stars and issues welcome.</p>
+<p>Want the dashboard without the Pi? A hosted version is coming — <a href="https://fffwryhvses.typeform.com/to/yxMMhmFs">join the waitlist</a>.</p>
 </div>
 
 </main>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -41,6 +41,10 @@
     <lastmod>2026-07-13</lastmod>
   </url>
   <url>
+    <loc>https://dinkydash.co/raspberry-pi-family-calendar/</loc>
+    <lastmod>2026-07-13</lastmod>
+  </url>
+  <url>
     <loc>https://dinkydash.co/skylight-calendar-alternatives/</loc>
     <lastmod>2026-07-13</lastmod>
   </url>

--- a/docs/skylight-calendar-alternatives/index.html
+++ b/docs/skylight-calendar-alternatives/index.html
@@ -397,6 +397,7 @@
             <a href="/hearth-vs-skylight/">Hearth vs Skylight</a>
             <a href="/skylight-calendar-subscription/">Skylight subscription costs</a>
             <a href="/diy-skylight-calendar/">DIY digital calendar</a>
+            <a href="/raspberry-pi-family-calendar/">Raspberry Pi calendar</a>
             <a href="/digital-calendar-and-chore-chart/">Calendar + chore chart</a>
             <a href="/best-digital-family-calendar/">Best family calendars</a>
             <a href="/morning-routine/">Morning routines</a>

--- a/docs/skylight-calendar-subscription/index.html
+++ b/docs/skylight-calendar-subscription/index.html
@@ -353,6 +353,7 @@
             <a href="/hearth-vs-skylight/">Hearth vs Skylight</a>
             <a href="/skylight-calendar-subscription/">Skylight subscription costs</a>
             <a href="/diy-skylight-calendar/">DIY digital calendar</a>
+            <a href="/raspberry-pi-family-calendar/">Raspberry Pi calendar</a>
             <a href="/digital-calendar-and-chore-chart/">Calendar + chore chart</a>
             <a href="/best-digital-family-calendar/">Best family calendars</a>
             <a href="/morning-routine/">Morning routines</a>

--- a/website/content/diy-skylight-calendar.md
+++ b/website/content/diy-skylight-calendar.md
@@ -29,7 +29,17 @@ That last one is something even the $629 hardware doesn't do.
 | **Raspberry Pi build** | Pi 4 or 5, 7″ touchscreen, SD card, power supply | ~$100–130 |
 | **Spare monitor or TV** | Any screen with a browser, or one connected to any computer | ~$0 |
 
-The Raspberry Pi route is the classic: it draws a couple of watts, mounts cleanly on a wall or shelf, and boots straight into the dashboard in kiosk mode. The old-tablet route is the fastest way to find out whether your family will actually use a wall calendar.
+The Raspberry Pi route is the classic: it draws well under 10 watts, mounts cleanly on a wall or shelf, and boots straight into the dashboard in kiosk mode. Our [Raspberry Pi family calendar guide](/raspberry-pi-family-calendar/) covers which Pi and screen to buy, with a full parts list.
+
+The old-tablet route is the fastest way to find out whether your family will actually use a wall calendar — and that's the real question, not which hardware to buy.
+
+## Start with the screen you already own
+
+Before spending anything, prop up an old tablet or spare monitor in the kitchen and run the dashboard on it for two weeks.
+
+This sounds like a hedge, but it's the single most useful thing you can do. A family calendar only works if it's somewhere everyone walks past at the right time of day, and you will almost certainly get that spot wrong on the first try. Finding out with a tablet on a cookbook stand costs nothing. Finding out after mounting a Pi behind drywall is annoying.
+
+If it sticks, buy the hardware. If it doesn't, you've lost an evening instead of $629.
 
 ## The build, in five steps
 
@@ -40,6 +50,18 @@ The [full getting-started guide](/getting-started/) has copy-paste commands for 
 3. **Add an Anthropic API key** — this powers the daily AI brief. A day's dashboard costs a few cents.
 4. **Set the 6am schedule** — one cron line generates a fresh dashboard every morning before anyone wakes up.
 5. **Point your screen at it** — on a Pi, Chromium launches fullscreen at boot; on a tablet or TV, just open the dashboard URL in the browser.
+
+Realistically: an evening for the first build if you're comfortable in a terminal, and about ten minutes whenever you want to change a chore rotation afterwards.
+
+## Mounting it on the wall
+
+Three things decide whether this gets looked at:
+
+- **Height and place.** Eye level, on the route between the coffee machine and the door. Kitchens beat hallways; hallways beat home offices.
+- **Power.** This is the part people underestimate. A wall-mounted screen needs a cable to somewhere, and the honest options are a nearby outlet, a surface-mounted cable channel, or a shelf instead of a wall. Pick the spot with power in mind rather than solving it afterwards.
+- **Glare.** A screen facing a window is unreadable for two hours a day. Turn it perpendicular to the light.
+
+A cheap tablet wall mount, a picture ledge, or a small easel stand all work. None of this needs to be permanent — and it shouldn't be, until you're sure about the location.
 
 ## DIY vs Skylight, honestly
 
@@ -58,8 +80,28 @@ The [full getting-started guide](/getting-started/) has copy-paste commands for 
 
 *Prices checked July 2026.*
 
+## Questions people ask
+
+**Is there a monthly fee for a DIY calendar?**
+No subscription. The only running cost is the Anthropic API key for the daily brief, which comes to a few cents a month — roughly $0.20–0.40 for a typical family. Skip the AI brief and it's free. (For what Skylight itself charges, see our [Skylight subscription breakdown](/skylight-calendar-subscription/).)
+
+**Do I need to know how to code?**
+No, but you need to be willing to copy commands into a terminal and read an error message without panicking. If you've ever followed a Raspberry Pi tutorial, you're comfortably over the bar. If the word "terminal" is a dealbreaker, buy the Skylight — that's a legitimate answer.
+
+**What actually goes wrong?**
+Two things, both fixable in a minute. Chromium sometimes starts before the server is ready and shows a connection error at boot — the startup script waits for the server to fix this. And emoji render as empty boxes until you install the emoji font package. Both are covered in the [troubleshooting section](/getting-started/).
+
+**What happens if the internet goes down?**
+The dashboard keeps showing yesterday's data. The AI brief is generated once each morning and saved to a file, so the screen never depends on a live connection to display something.
+
+**Can the kids break it?**
+There's nothing to tap. It's a read-only display — events are edited in Google Calendar on your phone, so there's no way to delete next week from the wall.
+
+**Is DIY actually worth it versus just buying one?**
+If your time is worth more than about $500 an evening, no. If you already own a spare screen, enjoy this sort of project, or specifically want your family's data staying on your own hardware, yes. Both are reasonable — see [all the Skylight alternatives](/skylight-calendar-alternatives/) including no-setup options.
+
 ## Start here
 
-If you can copy commands into a terminal, you can have this on your kitchen wall by Sunday: **[the complete setup guide](/getting-started/)**. Rather skip the setup entirely? A hosted version is coming — [join the waitlist](https://fffwryhvses.typeform.com/to/yxMMhmFs).
+If you can copy commands into a terminal, you can have this on your kitchen wall by Sunday: **[the complete setup guide](/getting-started/)**. Buying hardware for it? Start with the [Raspberry Pi build guide](/raspberry-pi-family-calendar/).
 
-Not sure DIY is for you? See [all the Skylight alternatives](/skylight-calendar-alternatives/), including no-setup options.
+Rather skip the setup entirely? A hosted version is coming — [join the waitlist](https://fffwryhvses.typeform.com/to/yxMMhmFs).

--- a/website/content/raspberry-pi-family-calendar.md
+++ b/website/content/raspberry-pi-family-calendar.md
@@ -1,0 +1,110 @@
+---
+title: "Raspberry Pi Family Calendar: Build a Wall Dashboard That Updates Itself"
+template: page.html
+description: How to turn a Raspberry Pi into a wall-mounted family calendar and dashboard — today's events, rotating chores, birthday countdowns and an AI daily brief, for about $100 in parts and no subscription.
+---
+
+A Raspberry Pi, a small touchscreen and some open-source software make a genuinely good family calendar: it hangs on the kitchen wall, shows today's schedule at a glance, updates itself every morning, and costs about **$100 in parts with nothing monthly**.
+
+This page covers the hardware side — which Pi, which screen, what it draws, what it costs. The [full setup guide](/getting-started/) has the copy-paste commands.
+
+![A Raspberry Pi with a small touchscreen showing a family dashboard, sitting on a kitchen shelf](/images/diy-raspberry-pi-calendar.png)
+
+## What ends up on the screen
+
+[DinkyDash](https://github.com/caspii/dinkydash) is a free, open-source, MIT-licensed family dashboard built for exactly this. On the display you get:
+
+- **Today's events**, pulled from Google Calendar or any calendar with an iCal link
+- **A chore chart** that rotates between family members automatically each day
+- **Countdowns** to birthdays, holidays and vacations
+- **A daily brief written by Claude** — a fresh greeting, fun fact and family challenge every morning, written around your actual family
+
+No touch interaction is required. It's a display, not an app — which is the point, and also why a modest Pi is plenty.
+
+## Which Raspberry Pi
+
+| Model | Verdict |
+|---|---|
+| **Pi 4 (2GB)** | The sweet spot. Runs Chromium in kiosk mode comfortably, cheap, widely available second-hand. This is what we'd pick. |
+| **Pi 5** | Works fine and boots faster, but it's more money and more heat for a job that's mostly idle. Overkill here. |
+| **Pi Zero 2 W** | Tempting at the price, but Chromium is a heavy browser and the Zero struggles. Workable if you're patient; frustrating if you're not. |
+| **Pi 3** | Fine if you already own one. Slow to boot, but it only boots once. |
+
+2GB of RAM is enough. The dashboard is a single static page that refreshes every five minutes — there's no database and no continuous rendering.
+
+## Which display
+
+The software targets **800×480**, which is the resolution of the official Raspberry Pi 7″ Touch Display. That's the path of least resistance.
+
+- **Official 7″ Touch Display** — connects over DSI (one ribbon cable, no HDMI), powered from the Pi itself. Around $60–80.
+- **Any HDMI monitor** — works, and a bigger screen reads better from across a room. You'll want to adjust the layout, and you're now managing two power supplies.
+- **An old monitor you already own** — free, and honestly the best way to test whether your family will actually look at it before you spend anything.
+
+Touch is optional. The dashboard is read-only by design; you edit events in Google Calendar on your phone, the way you already do.
+
+## Parts list
+
+| Part | Approximate cost |
+|---|---|
+| Raspberry Pi 4 (2GB) | $45–60 |
+| Official 7″ Touch Display | $60–80 |
+| MicroSD card (16GB+) | $8–12 |
+| USB-C power supply | $8–12 |
+| Case or stand | $0–20 |
+| **Total** | **~$120–185 new, well under $100 with parts you own or buy used** |
+
+*Prices are approximate and vary by retailer — checked August 2026.*
+
+Second-hand Pis are abundant and this workload will never stress one, so the used market is a genuinely good idea here.
+
+## How it actually works
+
+The architecture is deliberately boring, which is why it keeps running:
+
+1. **A cron job at 6am** runs a generation script. It fetches your calendar, works out ages, birthday countdowns and whose turn it is for each chore, sends all of that to the Claude API, and writes the result to a single JSON file.
+2. **A small Flask server** reads that JSON file and renders the page.
+3. **Chromium launches fullscreen at boot** in kiosk mode and refreshes every five minutes.
+
+The API call happens **once a day**, not on every page load. That matters for two reasons: the dashboard stays instant because it's only ever serving a static file, and your Anthropic bill is a few cents a month rather than a few dollars.
+
+If the network drops or the API call fails, the previous day's JSON is still on disk and the screen keeps showing it. A stale dashboard beats a blank one.
+
+## Power draw and leaving it on
+
+A Pi 4 with the 7″ display sits **under 10 watts**. Left on around the clock that's roughly 60 kWh a year — call it $10 at typical US rates.
+
+You can cut that roughly in half with two cron lines that switch the display off overnight and back on before breakfast:
+
+```
+0 22 * * * /home/pi/screen_control.sh off
+0 7 * * * /home/pi/screen_control.sh on
+```
+
+The Pi stays up; only the panel sleeps. The [setup guide](/getting-started/) has the script.
+
+## Kiosk mode
+
+The one part people usually get wrong is the boot sequence: Chromium starts before Flask is ready and you get "localhost refused to connect" on the wall every morning. The startup script in the setup guide polls the server for up to 60 seconds before launching the browser, which fixes it.
+
+Two other things worth knowing before you start:
+
+- Install `fonts-noto-color-emoji`, or the dashboard renders as empty boxes.
+- On Raspberry Pi OS Bookworm the boot config lives at `/boot/firmware/config.txt`, not `/boot/config.txt` — this trips up a lot of older tutorials.
+
+Both are covered, with fixes, in the [troubleshooting section](/getting-started/).
+
+## Why build one instead of buying
+
+A Skylight Calendar Max is $629, plus $79 a year for the Plus features. A Hearth Display is $699 plus $9 a month. They're nicely made, and if you want something that works out of the box with a support line, they're reasonable purchases.
+
+But a digital family calendar is fundamentally a screen showing a web page. If you're comfortable with a terminal, the Pi version costs about a sixth as much, has no subscription, keeps your family's data on your own device, and does one thing the $629 hardware doesn't: writes you a fresh daily brief every morning.
+
+The full cost comparison is on the [DIY Skylight calendar page](/diy-skylight-calendar/).
+
+## Start building
+
+Everything you need is in the [setup guide](/getting-started/) — install, config, cron, systemd service and kiosk mode, with the commands to copy. Budget an evening for the first build.
+
+The code is on [GitHub](https://github.com/caspii/dinkydash) under an MIT licence. Stars and issues welcome.
+
+Want the dashboard without the Pi? A hosted version is coming — [join the waitlist](https://fffwryhvses.typeform.com/to/yxMMhmFs).

--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -303,6 +303,7 @@
             <a href="/hearth-vs-skylight/">Hearth vs Skylight</a>
             <a href="/skylight-calendar-subscription/">Skylight subscription costs</a>
             <a href="/diy-skylight-calendar/">DIY digital calendar</a>
+            <a href="/raspberry-pi-family-calendar/">Raspberry Pi calendar</a>
             <a href="/digital-calendar-and-chore-chart/">Calendar + chore chart</a>
             <a href="/best-digital-family-calendar/">Best family calendars</a>
             <a href="/morning-routine/">Morning routines</a>


### PR DESCRIPTION
## What's here

**New: `/raspberry-pi-family-calendar/`** (1,120 words) — targets ~800 searches/mo across `raspberry pi dashboard` (300), `raspberry pi calendar` (250), `raspberry pi calendar display` (150), `raspberry pi family calendar` (100), KD 4–7.

Written hardware-first for the r/raspberry_pi audience, which also makes it the artifact for the Show HN launch: model-by-model verdicts (Pi 4 is the pick, Pi 5 is overkill, Zero 2 W struggles with Chromium), display options, parts list, real power figures, and an explanation of the cron→JSON→Flask architecture — including why it's built that way (one API call a day, so the screen stays instant, the bill stays at cents, and a failed call leaves yesterday's dashboard up rather than a blank screen).

**Expanded: `/diy-skylight-calendar/`** 617 → 1,221 words. Keeps the cost-comparison framing and hands hardware depth to the new page so they don't cannibalise. Adds:

- *"Start with the screen you already own"* — argues for a two-week tablet trial before buying anything.
- A wall-mounting section, with power routing called out as the thing people underestimate.
- A six-question FAQ built from the actual People Also Ask boxes on the Skylight SERPs. Best shot at AI Overview citations — LLM referrals (ChatGPT, Copilot) are up 26x this window.

Also adds the new page to the footer nav, and corrects "a couple of watts" to "well under 10 watts" — a Pi 4 plus a 7" display is realistically 5–8W, and that page's audience will check.

