### PR TITLE
Make stacking discoverable, share countdowns full screen

### DIFF
--- a/docs/about/index.html
+++ b/docs/about/index.html
@@ -6,6 +6,7 @@
     <title>About DinkyDash — DinkyDash</title>
     <meta name="description" content="DinkyDash is a free, open-source digital family calendar that runs on screens you already own — with an AI-written daily brief for your family.">
     <link rel="canonical" href="https://dinkydash.co/about/">
+    
     <meta property="og:title" content="About DinkyDash — DinkyDash">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://dinkydash.co/about/">

--- a/docs/best-digital-family-calendar/index.html
+++ b/docs/best-digital-family-calendar/index.html
@@ -6,6 +6,7 @@
     <title>The Best Digital Family Calendar in 2026: Buy One, or Use a Screen You Own — DinkyDash</title>
     <meta name="description" content="An honest guide to choosing a digital family calendar in 2026 — dedicated displays like Skylight and Hearth vs free software on a screen you already own.">
     <link rel="canonical" href="https://dinkydash.co/best-digital-family-calendar/">
+    
     <meta property="og:title" content="The Best Digital Family Calendar in 2026: Buy One, or Use a Screen You Own — DinkyDash">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://dinkydash.co/best-digital-family-calendar/">

--- a/docs/birthday-countdown/display/index.html
+++ b/docs/birthday-countdown/display/index.html
@@ -1,0 +1,372 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Birthday countdown</title>
+    <meta name="description" content="A full-screen birthday countdown.">
+    <link rel="canonical" href="https://dinkydash.co/birthday-countdown/display/">
+    
+    <meta name="robots" content="noindex, follow">
+    <meta property="og:title" content="Birthday countdown">
+    <meta property="og:type" content="website">
+    <meta property="og:image" content="https://dinkydash.co/images/hero-kitchen.png">
+    <meta property="og:description" content="A full-screen birthday countdown.">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="theme-color" content="#fffaf5">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800&display=swap" rel="stylesheet">
+    <style>
+        *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
+
+        :root {
+            --bg: #fffaf5;
+            --surface-warm: #fff5ec;
+            --border: #f0e6da;
+            --text: #2d2319;
+            --text-mid: #5c4a3a;
+            --text-muted: #9a8677;
+            --accent: #e85d24;
+            --purple: #7c5cbf;
+        }
+
+        html, body { height: 100%; }
+        body {
+            font-family: 'Nunito', system-ui, -apple-system, sans-serif;
+            background: var(--bg);
+            color: var(--text);
+            -webkit-font-smoothing: antialiased;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            padding: 4vmin 4vw;
+            text-align: center;
+            overflow: hidden;
+        }
+
+        /* Hero — sized in viewport units so it fills a phone, a tablet on the
+           wall, or a TV without needing breakpoints. */
+        .d-days {
+            font-size: clamp(5rem, 26vmin, 22rem);
+            font-weight: 800;
+            line-height: 0.92;
+            letter-spacing: -0.05em;
+            color: var(--accent);
+            font-variant-numeric: tabular-nums;
+        }
+        .d-label {
+            font-size: clamp(1.1rem, 3.6vmin, 2.4rem);
+            font-weight: 800;
+            margin-top: 2vmin;
+            line-height: 1.2;
+            text-wrap: balance;
+        }
+        .d-clock {
+            font-size: clamp(0.9rem, 2.2vmin, 1.5rem);
+            font-weight: 700;
+            color: var(--text-muted);
+            font-variant-numeric: tabular-nums;
+            margin-top: 1.4vmin;
+        }
+        .d-meta {
+            font-size: clamp(0.85rem, 2vmin, 1.3rem);
+            color: var(--text-mid);
+            margin-top: 0.6vmin;
+        }
+        .d-today { color: var(--accent); font-size: clamp(3rem, 15vmin, 12rem); line-height: 1.05; }
+
+        /* The others */
+        .d-rest {
+            display: flex;
+            flex-wrap: wrap;
+            justify-content: center;
+            gap: 1.4vmin 3vmin;
+            margin-top: 5vmin;
+            padding-top: 4vmin;
+            border-top: 1px solid var(--border);
+            max-width: 1100px;
+        }
+        .d-chip { display: flex; align-items: baseline; gap: 0.8vmin; }
+        .d-chip-days {
+            font-size: clamp(1.3rem, 4vmin, 2.6rem);
+            font-weight: 800;
+            color: var(--purple);
+            font-variant-numeric: tabular-nums;
+        }
+        .d-chip-name {
+            font-size: clamp(0.8rem, 2vmin, 1.2rem);
+            font-weight: 700;
+            color: var(--text-mid);
+        }
+
+        .d-empty { max-width: 30rem; }
+        .d-empty p { color: var(--text-mid); margin-bottom: 1.2rem; font-size: 1.05rem; }
+        .d-empty a { color: var(--accent); font-weight: 700; }
+
+        /* Attribution. Deliberately quiet, but present — a shared countdown is
+           the only place a recipient learns where it came from. */
+        .d-mark {
+            position: fixed;
+            bottom: 2.4vmin;
+            left: 0;
+            right: 0;
+            font-size: clamp(0.7rem, 1.5vmin, 0.95rem);
+            font-weight: 700;
+            color: var(--text-muted);
+            opacity: 0.55;
+            text-decoration: none;
+            transition: opacity 0.15s;
+        }
+        .d-mark:hover { opacity: 1; color: var(--accent); }
+
+        @media (prefers-color-scheme: dark) {
+            :root {
+                --bg: #1c1613;
+                --surface-warm: #241d18;
+                --border: #3a2f27;
+                --text: #f6ede4;
+                --text-mid: #cbb9a8;
+                --text-muted: #9a8677;
+            }
+        }
+    </style>
+</head>
+<body>
+    <main id="d-root">
+        <div class="d-empty">
+            <p>Loading countdown…</p>
+        </div>
+    </main>
+
+    <a class="d-mark" href="/birthday-countdown/">Made with DinkyDash</a>
+
+
+<script>
+window.DDCountdown = (function () {
+    'use strict';
+
+    var MONTHS = ['January', 'February', 'March', 'April', 'May', 'June',
+                  'July', 'August', 'September', 'October', 'November', 'December'];
+    var SEP = '~';
+
+    function isLeap(y) { return (y % 4 === 0 && y % 100 !== 0) || y % 400 === 0; }
+
+    function daysInMonth(month, year) {
+        if (month === 2) { return isLeap(year || 2024) ? 29 : 28; }
+        return [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31][month - 1];
+    }
+
+    // Mirrors anniversary() in generate.py: February 29 is observed on
+    // February 28 in common years, so leap-day birthdays land on a real date
+    // instead of silently rolling into March.
+    function anniversary(year, month, day) {
+        if (month === 2 && day === 29 && !isLeap(year)) { return new Date(year, 1, 28); }
+        return new Date(year, month - 1, day);
+    }
+
+    function todayMidnight() {
+        var n = new Date();
+        return new Date(n.getFullYear(), n.getMonth(), n.getDate());
+    }
+
+    function nextOccurrence(month, day, from) {
+        var thisYear = anniversary(from.getFullYear(), month, day);
+        if (thisYear >= from) { return thisYear; }
+        return anniversary(from.getFullYear() + 1, month, day);
+    }
+
+    // Round rather than floor: clock changes make some local days 23 or 25
+    // hours long, and only whole days matter here.
+    function daysUntil(target, from) {
+        return Math.round((target - from) / 86400000);
+    }
+
+    function ageOn(birthYear, month, day, when) {
+        var age = when.getFullYear() - birthYear;
+        if (when < anniversary(when.getFullYear(), month, day)) { age -= 1; }
+        return age;
+    }
+
+    function parsePerson(raw) {
+        var bits = String(raw).split(SEP);
+        var md = (bits[1] || '').split('-');
+        var month = parseInt(md[0], 10);
+        var day = parseInt(md[1], 10);
+        if (!month || !day || month < 1 || month > 12 || day < 1 || day > daysInMonth(month, 2024)) {
+            return null;
+        }
+        var year = parseInt(bits[2], 10);
+        return {
+            name: (bits[0] || '').slice(0, 24),
+            month: month,
+            day: day,
+            year: (year >= 1900 && year <= 2100) ? year : null
+        };
+    }
+
+    function encodePerson(p) {
+        var pad = function (n) { return (n < 10 ? '0' : '') + n; };
+        return [p.name, pad(p.month) + '-' + pad(p.day), p.year || ''].join(SEP);
+    }
+
+    function query(people) {
+        return people.map(function (p) {
+            return 'p=' + encodeURIComponent(encodePerson(p));
+        }).join('&');
+    }
+
+    function readFromUrl() {
+        return new URLSearchParams(window.location.search)
+            .getAll('p').map(parsePerson).filter(Boolean);
+    }
+
+    function describe(p, now) {
+        var target = nextOccurrence(p.month, p.day, now);
+        var days = daysUntil(target, now);
+        var meta = MONTHS[target.getMonth()] + ' ' + target.getDate();
+        if (p.year) { meta += ' · turning ' + ageOn(p.year, p.month, p.day, target); }
+        if (p.month === 2 && p.day === 29 && target.getDate() === 28) {
+            meta += ' · leap-day birthday, observed the 28th';
+        }
+        return {
+            target: target,
+            days: days,
+            possessive: p.name ? (p.name + "'s") : 'your',
+            meta: meta
+        };
+    }
+
+    // Soonest first — "whose birthday is next" is the question a countdown
+    // exists to answer, so insertion order would be the wrong emphasis.
+    function bySoonest(people, now) {
+        return people.slice().sort(function (a, b) {
+            return describe(a, now).days - describe(b, now).days;
+        });
+    }
+
+    function clockText(target) {
+        var ms = target - new Date();
+        if (ms <= 0) { return ''; }
+        var total = Math.floor(ms / 1000);
+        var pad = function (n) { return (n < 10 ? '0' : '') + n; };
+        return pad(Math.floor(total / 3600) % 24) + 'h '
+             + pad(Math.floor(total / 60) % 60) + 'm '
+             + pad(total % 60) + 's';
+    }
+
+    return {
+        MONTHS: MONTHS,
+        daysInMonth: daysInMonth,
+        anniversary: anniversary,
+        todayMidnight: todayMidnight,
+        nextOccurrence: nextOccurrence,
+        daysUntil: daysUntil,
+        ageOn: ageOn,
+        parsePerson: parsePerson,
+        encodePerson: encodePerson,
+        query: query,
+        readFromUrl: readFromUrl,
+        describe: describe,
+        bySoonest: bySoonest,
+        clockText: clockText
+    };
+})();
+</script>
+<script>
+(function () {
+    'use strict';
+
+    var C = window.DDCountdown;
+    var root = document.getElementById('d-root');
+    var people = C.readFromUrl();
+    var primary = null;
+
+    function empty() {
+        root.innerHTML = '';
+        var box = document.createElement('div');
+        box.className = 'd-empty';
+        var p = document.createElement('p');
+        p.textContent = 'This countdown link has no birthdays in it.';
+        var a = document.createElement('a');
+        a.href = '/birthday-countdown/';
+        a.textContent = 'Make your own birthday countdown →';
+        box.appendChild(p);
+        box.appendChild(a);
+        root.appendChild(box);
+    }
+
+    function text(cls, value) {
+        var d = document.createElement('div');
+        d.className = cls;
+        d.textContent = value;
+        return d;
+    }
+
+    function render() {
+        var now = C.todayMidnight();
+        var sorted = C.bySoonest(people, now);
+        primary = sorted[0];
+        var d = C.describe(primary, now);
+
+        root.innerHTML = '';
+
+        if (d.days === 0) {
+            root.appendChild(text('d-days d-today', '🎉'));
+            root.appendChild(text('d-label',
+                'Happy birthday' + (primary.name ? ', ' + primary.name : '') + '!'));
+        } else {
+            root.appendChild(text('d-days', String(d.days)));
+            root.appendChild(text('d-label',
+                'day' + (d.days === 1 ? '' : 's') + ' until ' + d.possessive + ' birthday'));
+            root.appendChild(text('d-clock', C.clockText(d.target)));
+        }
+        root.appendChild(text('d-meta', d.meta));
+
+        if (sorted.length > 1) {
+            var rest = document.createElement('div');
+            rest.className = 'd-rest';
+            sorted.slice(1).forEach(function (p) {
+                var pd = C.describe(p, now);
+                var chip = document.createElement('div');
+                chip.className = 'd-chip';
+                chip.appendChild(text('d-chip-days', pd.days === 0 ? '🎉' : String(pd.days)));
+                chip.appendChild(text('d-chip-name', p.name || 'birthday'));
+                rest.appendChild(chip);
+            });
+            root.appendChild(rest);
+        }
+    }
+
+    if (!people.length) {
+        empty();
+        return;
+    }
+
+    render();
+    document.title = (function () {
+        var d = C.describe(C.bySoonest(people, C.todayMidnight())[0], C.todayMidnight());
+        return d.days === 0
+            ? 'Today! · Birthday countdown'
+            : d.days + ' days until ' + d.possessive + ' birthday';
+    })();
+
+    // Tick the clock without rebuilding the DOM.
+    setInterval(function () {
+        var clock = root.querySelector('.d-clock');
+        if (!clock || !primary) { return; }
+        clock.textContent = C.clockText(
+            C.nextOccurrence(primary.month, primary.day, C.todayMidnight()));
+    }, 1000);
+
+    // A display left running on a wall needs to notice midnight.
+    setInterval(function () {
+        var shown = root.querySelector('.d-days');
+        var d = C.describe(C.bySoonest(people, C.todayMidnight())[0], C.todayMidnight());
+        if (!shown || shown.textContent !== String(d.days)) { render(); }
+    }, 60000);
+})();
+</script>
+</body>
+</html>

--- a/docs/birthday-countdown/index.html
+++ b/docs/birthday-countdown/index.html
@@ -6,6 +6,7 @@
     <title>Birthday Countdown: How Many Days Until Your Birthday? — DinkyDash</title>
     <meta name="description" content="A free birthday countdown timer. Enter a birthday and see exactly how many days, hours, minutes and seconds are left — add the whole family, and share the countdown with a link. No sign-up.">
     <link rel="canonical" href="https://dinkydash.co/birthday-countdown/">
+    
     <meta property="og:title" content="Birthday Countdown: How Many Days Until Your Birthday? — DinkyDash">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://dinkydash.co/birthday-countdown/">
@@ -324,14 +325,20 @@
     }
 
     /* Form */
+    .bc-form-head {
+        margin-top: 26px;
+        padding-top: 22px;
+        border-top: 1px solid var(--border);
+        font-size: 0.95rem;
+        font-weight: 800;
+        color: var(--text);
+    }
     .bc-form {
         display: flex;
         flex-wrap: wrap;
         gap: 10px;
         align-items: flex-end;
-        margin-top: 24px;
-        padding-top: 24px;
-        border-top: 1px solid var(--border);
+        margin-top: 12px;
     }
     .bc-field { display: flex; flex-direction: column; gap: 5px; flex: 1 1 130px; }
     .bc-field label {
@@ -367,8 +374,10 @@
         padding: 11px 20px;
         cursor: pointer;
         white-space: nowrap;
+        text-decoration: none;
+        display: inline-block;
     }
-    .bc-btn:hover { filter: brightness(1.06); }
+    .bc-btn:hover { filter: brightness(1.06); text-decoration: none; }
     .bc-btn-ghost {
         background: transparent;
         color: var(--text-mid);
@@ -380,13 +389,15 @@
         flex-wrap: wrap;
         gap: 8px;
         justify-content: center;
-        margin-top: 20px;
+        margin-top: 22px;
+        padding-top: 20px;
+        border-top: 1px solid var(--border);
     }
-    .bc-hint { font-size: 0.8rem; color: var(--text-muted); margin-top: 10px; text-align: center; }
+    .bc-hint { font-size: 0.8rem; color: var(--text-muted); margin-top: 10px; }
     .bc-error { color: #c2410c; font-size: 0.85rem; font-weight: 600; margin-top: 10px; }
 
     /* Extra people */
-    .bc-list { display: grid; gap: 10px; margin-top: 16px; }
+    .bc-list { display: grid; gap: 10px; margin-top: 18px; }
     .bc-row {
         display: flex;
         align-items: center;
@@ -441,6 +452,7 @@
         .bc-card { padding: 22px 16px; }
         .bc-field { flex: 1 1 100%; }
         .bc-form .bc-btn { width: 100%; }
+        .bc-actions .bc-btn { flex: 1 1 100%; text-align: center; }
     }
 </style>
 
@@ -476,6 +488,7 @@
                 <div class="bc-sub" id="bc-sub">Enter a birthday below to start the countdown.</div>
             </div>
 
+            <div class="bc-form-head" id="bc-form-head">Start a countdown</div>
             <form class="bc-form" id="bc-form">
                 <div class="bc-field">
                     <label for="bc-name">Name</label>
@@ -496,11 +509,12 @@
                 <button type="submit" class="bc-btn" id="bc-submit">Start countdown</button>
             </form>
             <div class="bc-error" id="bc-error" hidden></div>
-            <div class="bc-hint">Add a year and it will show the age they're turning. Nothing is uploaded — it all stays in your browser.</div>
+            <div class="bc-hint" id="bc-hint">Add a year and it will show the age they're turning. Nothing is uploaded — it all stays in your browser.</div>
 
             <div class="bc-list" id="bc-list"></div>
 
             <div class="bc-actions" id="bc-actions" hidden>
+                <a class="bc-btn" id="bc-fullscreen" href="/birthday-countdown/display/">Open full screen</a>
                 <button type="button" class="bc-btn bc-btn-ghost" id="bc-share">Copy shareable link</button>
                 <button type="button" class="bc-btn bc-btn-ghost" id="bc-clear">Clear all</button>
             </div>
@@ -513,7 +527,7 @@
                 chart that rotates itself, and a short daily brief written for your family —
                 on any old tablet, TV or Raspberry Pi you already own. Free and open source.
             </p>
-            <a class="bc-btn" href="/diy-skylight-calendar/" style="display:inline-block">See how it works</a>
+            <a class="bc-btn" href="/diy-skylight-calendar/">See how it works</a>
         </div>
     </div>
 
@@ -522,9 +536,13 @@
 <h2>How many days until my birthday?</h2>
 <p>Count from today to your next birthday. If it's already been this year, you're counting to next year's — which is why the number can jump from 1 to 364 overnight.</p>
 <p>The counter above does this for you, but the arithmetic that trips people up is the year boundary: from 20 August to 15 March is 207 days, not the 158 you'd get by subtracting the dates and ignoring the year change.</p>
+<h2>Adding the whole family</h2>
+<p>You're not limited to one. Add a birthday, then add another — everyone stacks up in the same countdown, sorted so the next one coming is always the big number at the top.</p>
+<p>That's the point at which it stops being a countdown and starts being a calendar, which is rather the idea.</p>
 <h2>Sharing a countdown</h2>
-<p>Every countdown you build gets its own link. Copy it and whoever opens it sees the same numbers you do, counting down live from their own clock.</p>
-<p>The link holds the name and the date, so nothing is stored on our end and nothing expires. A countdown you share today still works next year — it'll just be counting to the next birthday.</p>
+<p>Every countdown you build gets its own link, and that link opens <strong>full screen</strong> — just the numbers, no menus and no page around them. It's meant to be sent to someone, or left open on a spare tablet or TV.</p>
+<p>Copy it and whoever opens it sees the same countdown you do, ticking live from their own clock. Use <strong>Open full screen</strong> to put it up on your own screen.</p>
+<p>The link holds the names and dates, so nothing is stored on our end and nothing expires. A countdown you share today still works next year — it'll just be counting to the next birthday.</p>
 <p>If you'd rather not put a birth year in a shared link, leave the year blank. You'll still get the countdown, just without the "turning 12" line.</p>
 <h2>What about 29 February?</h2>
 <p>Leap-day birthdays get counted properly here, which is more than a lot of countdown tools manage — plenty of them either crash or quietly skip to 1 March.</p>
@@ -583,22 +601,14 @@ Once the page has loaded, yes. All the arithmetic happens in your browser.</p>
 <script src="https://analytics.ahrefs.com/analytics.js" data-key="NInZX5cjFNqKC44BBPaEBA" async></script>
 <!-- / Ahrefs analytics -->
 
+
 <script>
-(function () {
+window.DDCountdown = (function () {
     'use strict';
 
     var MONTHS = ['January', 'February', 'March', 'April', 'May', 'June',
                   'July', 'August', 'September', 'October', 'November', 'December'];
-    var STORAGE_KEY = 'dinkydash.birthdays';
     var SEP = '~';
-
-    var el = function (id) { return document.getElementById(id); };
-    var people = [];
-
-    // --- date helpers -------------------------------------------------------
-    // Mirrors anniversary() in generate.py: February 29 is observed on
-    // February 28 in common years, so leap-day birthdays still land on a real
-    // date instead of silently rolling into March.
 
     function isLeap(y) { return (y % 4 === 0 && y % 100 !== 0) || y % 400 === 0; }
 
@@ -607,6 +617,9 @@ Once the page has loaded, yes. All the arithmetic happens in your browser.</p>
         return [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31][month - 1];
     }
 
+    // Mirrors anniversary() in generate.py: February 29 is observed on
+    // February 28 in common years, so leap-day birthdays land on a real date
+    // instead of silently rolling into March.
     function anniversary(year, month, day) {
         if (month === 2 && day === 29 && !isLeap(year)) { return new Date(year, 1, 28); }
         return new Date(year, month - 1, day);
@@ -635,10 +648,8 @@ Once the page has loaded, yes. All the arithmetic happens in your browser.</p>
         return age;
     }
 
-    // --- state --------------------------------------------------------------
-
     function parsePerson(raw) {
-        var bits = raw.split(SEP);
+        var bits = String(raw).split(SEP);
         var md = (bits[1] || '').split('-');
         var month = parseInt(md[0], 10);
         var day = parseInt(md[1], 10);
@@ -659,90 +670,144 @@ Once the page has loaded, yes. All the arithmetic happens in your browser.</p>
         return [p.name, pad(p.month) + '-' + pad(p.day), p.year || ''].join(SEP);
     }
 
-    function readFromUrl() {
-        var params = new URLSearchParams(window.location.search);
-        return params.getAll('p').map(parsePerson).filter(Boolean);
+    function query(people) {
+        return people.map(function (p) {
+            return 'p=' + encodeURIComponent(encodePerson(p));
+        }).join('&');
     }
+
+    function readFromUrl() {
+        return new URLSearchParams(window.location.search)
+            .getAll('p').map(parsePerson).filter(Boolean);
+    }
+
+    function describe(p, now) {
+        var target = nextOccurrence(p.month, p.day, now);
+        var days = daysUntil(target, now);
+        var meta = MONTHS[target.getMonth()] + ' ' + target.getDate();
+        if (p.year) { meta += ' · turning ' + ageOn(p.year, p.month, p.day, target); }
+        if (p.month === 2 && p.day === 29 && target.getDate() === 28) {
+            meta += ' · leap-day birthday, observed the 28th';
+        }
+        return {
+            target: target,
+            days: days,
+            possessive: p.name ? (p.name + "'s") : 'your',
+            meta: meta
+        };
+    }
+
+    // Soonest first — "whose birthday is next" is the question a countdown
+    // exists to answer, so insertion order would be the wrong emphasis.
+    function bySoonest(people, now) {
+        return people.slice().sort(function (a, b) {
+            return describe(a, now).days - describe(b, now).days;
+        });
+    }
+
+    function clockText(target) {
+        var ms = target - new Date();
+        if (ms <= 0) { return ''; }
+        var total = Math.floor(ms / 1000);
+        var pad = function (n) { return (n < 10 ? '0' : '') + n; };
+        return pad(Math.floor(total / 3600) % 24) + 'h '
+             + pad(Math.floor(total / 60) % 60) + 'm '
+             + pad(total % 60) + 's';
+    }
+
+    return {
+        MONTHS: MONTHS,
+        daysInMonth: daysInMonth,
+        anniversary: anniversary,
+        todayMidnight: todayMidnight,
+        nextOccurrence: nextOccurrence,
+        daysUntil: daysUntil,
+        ageOn: ageOn,
+        parsePerson: parsePerson,
+        encodePerson: encodePerson,
+        query: query,
+        readFromUrl: readFromUrl,
+        describe: describe,
+        bySoonest: bySoonest,
+        clockText: clockText
+    };
+})();
+</script>
+<script>
+(function () {
+    'use strict';
+
+    var C = window.DDCountdown;
+    var STORAGE_KEY = 'dinkydash.birthdays';
+    var DISPLAY_PATH = '/birthday-countdown/display/';
+
+    var el = function (id) { return document.getElementById(id); };
+    var people = [];
+
+    // --- state --------------------------------------------------------------
 
     function readFromStorage() {
         try {
             var raw = window.localStorage.getItem(STORAGE_KEY);
-            return raw ? JSON.parse(raw).map(parsePerson).filter(Boolean) : [];
+            return raw ? JSON.parse(raw).map(C.parsePerson).filter(Boolean) : [];
         } catch (e) { return []; }
+    }
+
+    function displayUrl() {
+        return window.location.origin + DISPLAY_PATH
+            + (people.length ? '?' + C.query(people) : '');
     }
 
     function persist() {
         try {
-            window.localStorage.setItem(STORAGE_KEY, JSON.stringify(people.map(encodePerson)));
+            window.localStorage.setItem(STORAGE_KEY, JSON.stringify(people.map(C.encodePerson)));
         } catch (e) { /* private browsing — the tool still works for this visit */ }
         var url = people.length
-            ? window.location.pathname + '?' + people.map(function (p) {
-                  return 'p=' + encodeURIComponent(encodePerson(p));
-              }).join('&')
+            ? window.location.pathname + '?' + C.query(people)
             : window.location.pathname;
         window.history.replaceState(null, '', url);
     }
 
     // --- rendering ----------------------------------------------------------
 
-    function describe(p, now) {
-        var target = nextOccurrence(p.month, p.day, now);
-        var days = daysUntil(target, now);
-        var possessive = p.name ? (p.name + "'s") : 'your';
-        var dateText = MONTHS[target.getMonth()] + ' ' + target.getDate();
-        var meta = dateText;
-        if (p.year) { meta += ' · turning ' + (ageOn(p.year, p.month, p.day, target) ); }
-        if (p.month === 2 && p.day === 29 && target.getDate() === 28) {
-            meta += ' · leap-day birthday, observed the 28th';
-        }
-        return { target: target, days: days, possessive: possessive, meta: meta };
-    }
-
-    function renderHero(now) {
-        if (!people.length) {
+    function renderHero(sorted, now) {
+        if (!sorted.length) {
+            el('bc-days').className = 'bc-days';
             el('bc-days').textContent = '—';
             el('bc-label').textContent = 'days until your birthday';
             el('bc-clock').textContent = '';
             el('bc-sub').textContent = 'Enter a birthday below to start the countdown.';
             return;
         }
-        var d = describe(people[0], now);
+        var d = C.describe(sorted[0], now);
         var hero = el('bc-days');
         if (d.days === 0) {
             hero.className = 'bc-today';
             hero.textContent = '🎉 Today!';
-            el('bc-label').textContent = 'Happy birthday' + (people[0].name ? ', ' + people[0].name : '') + '!';
+            el('bc-label').textContent =
+                'Happy birthday' + (sorted[0].name ? ', ' + sorted[0].name : '') + '!';
+            el('bc-clock').textContent = '';
         } else {
             hero.className = 'bc-days';
-            hero.textContent = d.days;
-            el('bc-label').textContent = 'day' + (d.days === 1 ? '' : 's') + ' until ' + d.possessive + ' birthday';
+            hero.textContent = String(d.days);
+            el('bc-label').textContent =
+                'day' + (d.days === 1 ? '' : 's') + ' until ' + d.possessive + ' birthday';
+            el('bc-clock').textContent = C.clockText(d.target);
         }
         el('bc-sub').textContent = d.meta;
-        renderClock(d.target);
     }
 
-    function renderClock(target) {
-        var ms = target - new Date();
-        if (ms <= 0) { el('bc-clock').textContent = ''; return; }
-        var total = Math.floor(ms / 1000);
-        var h = Math.floor(total / 3600) % 24;
-        var m = Math.floor(total / 60) % 60;
-        var s = total % 60;
-        var pad = function (n) { return (n < 10 ? '0' : '') + n; };
-        el('bc-clock').textContent = pad(h) + 'h ' + pad(m) + 'm ' + pad(s) + 's';
-    }
-
-    function renderList(now) {
+    function renderList(sorted, now) {
         var list = el('bc-list');
         list.textContent = '';
-        people.slice(1).forEach(function (p, i) {
-            var d = describe(p, now);
+        sorted.slice(1).forEach(function (p) {
+            var d = C.describe(p, now);
             var row = document.createElement('div');
             row.className = 'bc-row';
 
             var days = document.createElement('div');
             days.className = 'bc-row-days';
-            days.textContent = d.days === 0 ? '🎉' : d.days;
+            days.textContent = d.days === 0 ? '🎉' : String(d.days);
 
             var body = document.createElement('div');
             body.className = 'bc-row-body';
@@ -761,7 +826,10 @@ Once the page has loaded, yes. All the arithmetic happens in your browser.</p>
             remove.setAttribute('aria-label', 'Remove ' + (p.name || 'this birthday'));
             remove.textContent = '×';
             remove.addEventListener('click', function () {
-                people.splice(i + 1, 1);
+                // Sorted is a shallow copy, so identity still maps back to the
+                // insertion-ordered array that gets persisted.
+                var i = people.indexOf(p);
+                if (i !== -1) { people.splice(i, 1); }
                 persist();
                 render();
             });
@@ -773,11 +841,19 @@ Once the page has loaded, yes. All the arithmetic happens in your browser.</p>
         });
     }
 
+    function renderFormAffordance() {
+        var has = people.length > 0;
+        // The original wording left no hint that a second birthday could be
+        // added, so nobody tried. Say it plainly once there is one.
+        el('bc-form-head').textContent = has ? 'Add another birthday' : 'Start a countdown';
+        el('bc-submit').textContent = has ? 'Add birthday' : 'Start countdown';
+        el('bc-hint').textContent = has
+            ? 'Add everyone — the whole family stacks up in one countdown you can share.'
+            : "Add a year and it will show the age they're turning. Nothing is uploaded — it all stays in your browser.";
+    }
+
     function renderPitch() {
-        var pitch = el('bc-pitch');
-        pitch.hidden = people.length === 0;
-        // Once there's a family on screen the page is already a DinkyDash
-        // preview, so say so plainly rather than repeating the generic pitch.
+        el('bc-pitch').hidden = people.length === 0;
         if (people.length > 1) {
             el('bc-pitch-title').textContent = "You've just built a family dashboard";
             el('bc-pitch-body').textContent =
@@ -789,18 +865,21 @@ Once the page has loaded, yes. All the arithmetic happens in your browser.</p>
     }
 
     function render() {
-        var now = todayMidnight();
-        renderHero(now);
-        renderList(now);
+        var now = C.todayMidnight();
+        var sorted = C.bySoonest(people, now);
+        renderHero(sorted, now);
+        renderList(sorted, now);
+        renderFormAffordance();
         renderPitch();
         el('bc-actions').hidden = people.length === 0;
+        el('bc-fullscreen').href = displayUrl();
     }
 
     // --- form ---------------------------------------------------------------
 
     function buildSelects() {
         var monthSel = el('bc-month');
-        MONTHS.forEach(function (name, i) {
+        C.MONTHS.forEach(function (name, i) {
             var o = document.createElement('option');
             o.value = String(i + 1);
             o.textContent = name;
@@ -817,7 +896,7 @@ Once the page has loaded, yes. All the arithmetic happens in your browser.</p>
         var month = parseInt(el('bc-month').value, 10);
         var current = preselect || parseInt(daySel.value, 10) || 1;
         // 29 stays selectable in February so leap-day birthdays can be entered.
-        var max = daysInMonth(month, 2024);
+        var max = C.daysInMonth(month, 2024);
         daySel.textContent = '';
         for (var d = 1; d <= max; d++) {
             var o = document.createElement('option');
@@ -836,20 +915,21 @@ Once the page has loaded, yes. All the arithmetic happens in your browser.</p>
 
     el('bc-form').addEventListener('submit', function (e) {
         e.preventDefault();
-        var month = parseInt(el('bc-month').value, 10);
-        var day = parseInt(el('bc-day').value, 10);
         var yearRaw = el('bc-year').value.trim();
         var year = yearRaw ? parseInt(yearRaw, 10) : null;
 
-        if (year !== null) {
-            if (isNaN(year) || year < 1900 || year > new Date().getFullYear()) {
-                showError('That birth year does not look right — leave it blank if you would rather not say.');
-                return;
-            }
+        if (year !== null && (isNaN(year) || year < 1900 || year > new Date().getFullYear())) {
+            showError('That birth year does not look right — leave it blank if you would rather not say.');
+            return;
         }
         showError('');
 
-        people.push({ name: el('bc-name').value.trim(), month: month, day: day, year: year });
+        people.push({
+            name: el('bc-name').value.trim(),
+            month: parseInt(el('bc-month').value, 10),
+            day: parseInt(el('bc-day').value, 10),
+            year: year
+        });
         el('bc-name').value = '';
         el('bc-year').value = '';
         persist();
@@ -864,7 +944,9 @@ Once the page has loaded, yes. All the arithmetic happens in your browser.</p>
 
     el('bc-share').addEventListener('click', function () {
         var btn = el('bc-share');
-        var url = window.location.href;
+        // Share the full-screen view, not the editor — what a recipient wants
+        // is the countdown, not the form that made it.
+        var url = displayUrl();
         var done = function () {
             btn.textContent = 'Link copied';
             setTimeout(function () { btn.textContent = 'Copy shareable link'; }, 2000);
@@ -881,25 +963,29 @@ Once the page has loaded, yes. All the arithmetic happens in your browser.</p>
     // --- boot ---------------------------------------------------------------
 
     buildSelects();
-    // A shared link wins over whatever is in storage — the visitor followed it
-    // to see that countdown, not their own.
-    var fromUrl = readFromUrl();
+    // A shared link wins over storage — the visitor followed it to see that
+    // countdown, not their own.
+    var fromUrl = C.readFromUrl();
     people = fromUrl.length ? fromUrl : readFromStorage();
     render();
     if (people.length) { persist(); }
 
     setInterval(function () {
         if (!people.length) { return; }
-        var now = todayMidnight();
-        renderClock(nextOccurrence(people[0].month, people[0].day, now));
+        var now = C.todayMidnight();
+        var soonest = C.bySoonest(people, now)[0];
+        var d = C.describe(soonest, now);
+        if (d.days > 0) {
+            el('bc-clock').textContent = C.clockText(d.target);
+        }
     }, 1000);
 
     // Recompute at local midnight so a tab left open overnight is not stale.
     setInterval(function () {
         if (!people.length) { return; }
+        var d = C.describe(C.bySoonest(people, C.todayMidnight())[0], C.todayMidnight());
         var shown = el('bc-days').textContent;
-        var d = describe(people[0], todayMidnight());
-        if (String(d.days) !== shown && !(d.days === 0 && shown.indexOf('Today') !== -1)) {
+        if (shown !== String(d.days) && !(d.days === 0 && shown.indexOf('Today') !== -1)) {
             render();
         }
     }, 60000);

--- a/docs/digital-calendar-and-chore-chart/index.html
+++ b/docs/digital-calendar-and-chore-chart/index.html
@@ -6,6 +6,7 @@
     <title>A Digital Calendar and Chore Chart in One Screen — DinkyDash</title>
     <meta name="description" content="Combine the family calendar and the kids&#39; chore chart on one wall screen — with chores that rotate automatically every day. No $300 hardware, no subscription, no nagging.">
     <link rel="canonical" href="https://dinkydash.co/digital-calendar-and-chore-chart/">
+    
     <meta property="og:title" content="A Digital Calendar and Chore Chart in One Screen — DinkyDash">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://dinkydash.co/digital-calendar-and-chore-chart/">

--- a/docs/diy-skylight-calendar/index.html
+++ b/docs/diy-skylight-calendar/index.html
@@ -6,6 +6,7 @@
     <title>DIY Skylight Calendar: Build a Digital Family Calendar for About $100 — DinkyDash</title>
     <meta name="description" content="How to build your own Skylight-style digital family calendar with a Raspberry Pi or an old tablet — free, open-source software, no subscription, about $100 in hardware (or $0 if you have a spare screen).">
     <link rel="canonical" href="https://dinkydash.co/diy-skylight-calendar/">
+    
     <meta property="og:title" content="DIY Skylight Calendar: Build a Digital Family Calendar for About $100 — DinkyDash">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://dinkydash.co/diy-skylight-calendar/">

--- a/docs/family-dashboard/index.html
+++ b/docs/family-dashboard/index.html
@@ -6,6 +6,7 @@
     <title>The AI-Powered Family Dashboard — DinkyDash</title>
     <meta name="description" content="How DinkyDash uses AI to create a daily family dashboard with calendars, chores, countdowns, and personalized content.">
     <link rel="canonical" href="https://dinkydash.co/family-dashboard/">
+    
     <meta property="og:title" content="The AI-Powered Family Dashboard — DinkyDash">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://dinkydash.co/family-dashboard/">

--- a/docs/getting-started/index.html
+++ b/docs/getting-started/index.html
@@ -6,6 +6,7 @@
     <title>Getting Started with DinkyDash — DinkyDash</title>
     <meta name="description" content="Step-by-step guide to setting up DinkyDash on your Raspberry Pi — from first install to a working family dashboard.">
     <link rel="canonical" href="https://dinkydash.co/getting-started/">
+    
     <meta property="og:title" content="Getting Started with DinkyDash — DinkyDash">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://dinkydash.co/getting-started/">

--- a/docs/hearth-vs-skylight/index.html
+++ b/docs/hearth-vs-skylight/index.html
@@ -6,6 +6,7 @@
     <title>Hearth vs Skylight (2026): Prices, Subscriptions, and Which to Buy — DinkyDash</title>
     <meta name="description" content="Hearth Display ($699 + $9/mo) vs Skylight Calendar ($299–$629 + optional $79/yr) compared honestly — plus the third option both companies would rather you didn&#39;t know about.">
     <link rel="canonical" href="https://dinkydash.co/hearth-vs-skylight/">
+    
     <meta property="og:title" content="Hearth vs Skylight (2026): Prices, Subscriptions, and Which to Buy — DinkyDash">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://dinkydash.co/hearth-vs-skylight/">

--- a/docs/index.html
+++ b/docs/index.html
@@ -6,6 +6,7 @@
     <title>DinkyDash — The Digital Family Calendar for Screens You Already Own</title>
     <meta name="description" content="A free, open-source alternative to Skylight and Hearth. Turn any TV, tablet, or Raspberry Pi into a shared family calendar with a chore chart, countdowns, and an AI-written daily brief.">
     <link rel="canonical" href="https://dinkydash.co/">
+    
     <meta property="og:title" content="DinkyDash — The Digital Family Calendar for Screens You Already Own">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://dinkydash.co/">

--- a/docs/morning-routine/index.html
+++ b/docs/morning-routine/index.html
@@ -6,6 +6,7 @@
     <title>Transform Your Family&#39;s Morning Routine — DinkyDash</title>
     <meta name="description" content="How DinkyDash helps families start the day organized with an AI-generated morning dashboard.">
     <link rel="canonical" href="https://dinkydash.co/morning-routine/">
+    
     <meta property="og:title" content="Transform Your Family&#39;s Morning Routine — DinkyDash">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://dinkydash.co/morning-routine/">

--- a/docs/office-dashboard/index.html
+++ b/docs/office-dashboard/index.html
@@ -6,6 +6,7 @@
     <title>DinkyDash for Offices and Shared Spaces — DinkyDash</title>
     <meta name="description" content="Use DinkyDash as an AI-powered information display for offices, co-working spaces, and shared areas.">
     <link rel="canonical" href="https://dinkydash.co/office-dashboard/">
+    
     <meta property="og:title" content="DinkyDash for Offices and Shared Spaces — DinkyDash">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://dinkydash.co/office-dashboard/">

--- a/docs/raspberry-pi-family-calendar/index.html
+++ b/docs/raspberry-pi-family-calendar/index.html
@@ -6,6 +6,7 @@
     <title>Raspberry Pi Family Calendar: Build a Wall Dashboard That Updates Itself — DinkyDash</title>
     <meta name="description" content="How to turn a Raspberry Pi into a wall-mounted family calendar and dashboard — today&#39;s events, rotating chores, birthday countdowns and an AI daily brief, for about $100 in parts and no subscription.">
     <link rel="canonical" href="https://dinkydash.co/raspberry-pi-family-calendar/">
+    
     <meta property="og:title" content="Raspberry Pi Family Calendar: Build a Wall Dashboard That Updates Itself — DinkyDash">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://dinkydash.co/raspberry-pi-family-calendar/">

--- a/docs/skylight-calendar-alternatives/index.html
+++ b/docs/skylight-calendar-alternatives/index.html
@@ -6,6 +6,7 @@
     <title>The 7 Best Skylight Calendar Alternatives in 2026 — DinkyDash</title>
     <meta name="description" content="Looking for a Skylight Calendar alternative without the $299–$629 price tag or the $79/year subscription? Here are 7 options — including free ones that run on screens you already own.">
     <link rel="canonical" href="https://dinkydash.co/skylight-calendar-alternatives/">
+    
     <meta property="og:title" content="The 7 Best Skylight Calendar Alternatives in 2026 — DinkyDash">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://dinkydash.co/skylight-calendar-alternatives/">

--- a/docs/skylight-calendar-subscription/index.html
+++ b/docs/skylight-calendar-subscription/index.html
@@ -6,6 +6,7 @@
     <title>Does the Skylight Calendar Require a Subscription? (2026) — DinkyDash</title>
     <meta name="description" content="Short answer: no for the basics, but the good stuff costs $79/year. Here&#39;s exactly what Skylight Plus covers in 2026, the real first-year math, and the subscription-free alternatives.">
     <link rel="canonical" href="https://dinkydash.co/skylight-calendar-subscription/">
+    
     <meta property="og:title" content="Does the Skylight Calendar Require a Subscription? (2026) — DinkyDash">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://dinkydash.co/skylight-calendar-subscription/">

--- a/website/build.py
+++ b/website/build.py
@@ -106,11 +106,16 @@ def copy_images():
 
 
 def generate_pages():
-    """Render every Markdown file, returning (url_path, source_files) per page."""
+    """Render every Markdown file.
+
+    Returns (sitemap_pages, written_count). These differ because `noindex`
+    pages are still rendered, just kept out of the sitemap.
+    """
     # Ensure output directory exists
     os.makedirs(OUTPUT_DIR, exist_ok=True)
 
     pages = []
+    written = 0
 
     for root, dirs, files in os.walk('content'):
         for file in files:
@@ -146,10 +151,16 @@ def generate_pages():
                 # Write output
                 with open(output_path, 'w') as f:
                     f.write(output)
+                written += 1
 
-                pages.append((url_path, (file_path, os.path.join('templates', template_name))))
+                # `noindex: true` pages stay out of the sitemap and carry a
+                # robots meta tag. Used for pages whose content only exists once
+                # query parameters are supplied — indexing the bare URL would
+                # just add a thin page.
+                if not front_matter.get('noindex'):
+                    pages.append((url_path, (file_path, os.path.join('templates', template_name))))
 
-    return pages
+    return pages, written
 
 
 def preserve_cname():
@@ -176,7 +187,7 @@ if __name__ == '__main__':
     if os.path.exists(OUTPUT_DIR):
         shutil.rmtree(OUTPUT_DIR)
 
-    pages = generate_pages()
+    pages, written = generate_pages()
     generate_sitemap(pages)
     generate_robots()
     copy_images()
@@ -184,4 +195,5 @@ if __name__ == '__main__':
     # Restore CNAME file
     restore_cname(cname_content)
 
-    print(f"Site generated in {OUTPUT_DIR} ({len(pages)} pages)")
+    print(f"Site generated in {OUTPUT_DIR} "
+          f"({written} pages, {len(pages)} in sitemap)")

--- a/website/content/birthday-countdown.md
+++ b/website/content/birthday-countdown.md
@@ -14,11 +14,19 @@ Count from today to your next birthday. If it's already been this year, you're c
 
 The counter above does this for you, but the arithmetic that trips people up is the year boundary: from 20 August to 15 March is 207 days, not the 158 you'd get by subtracting the dates and ignoring the year change.
 
+## Adding the whole family
+
+You're not limited to one. Add a birthday, then add another — everyone stacks up in the same countdown, sorted so the next one coming is always the big number at the top.
+
+That's the point at which it stops being a countdown and starts being a calendar, which is rather the idea.
+
 ## Sharing a countdown
 
-Every countdown you build gets its own link. Copy it and whoever opens it sees the same numbers you do, counting down live from their own clock.
+Every countdown you build gets its own link, and that link opens **full screen** — just the numbers, no menus and no page around them. It's meant to be sent to someone, or left open on a spare tablet or TV.
 
-The link holds the name and the date, so nothing is stored on our end and nothing expires. A countdown you share today still works next year — it'll just be counting to the next birthday.
+Copy it and whoever opens it sees the same countdown you do, ticking live from their own clock. Use **Open full screen** to put it up on your own screen.
+
+The link holds the names and dates, so nothing is stored on our end and nothing expires. A countdown you share today still works next year — it'll just be counting to the next birthday.
 
 If you'd rather not put a birth year in a shared link, leave the year blank. You'll still get the countdown, just without the "turning 12" line.
 

--- a/website/content/birthday-countdown/display.md
+++ b/website/content/birthday-countdown/display.md
@@ -1,0 +1,6 @@
+---
+title: "Birthday countdown"
+template: birthday-countdown-display.html
+description: A full-screen birthday countdown.
+noindex: true
+---

--- a/website/templates/_countdown-lib.html
+++ b/website/templates/_countdown-lib.html
@@ -1,0 +1,134 @@
+{# Shared countdown logic for the tool page and the full-screen display page.
+   Included by both so the date arithmetic has one definition — the display
+   page and the editor must never disagree about how many days are left. #}
+<script>
+window.DDCountdown = (function () {
+    'use strict';
+
+    var MONTHS = ['January', 'February', 'March', 'April', 'May', 'June',
+                  'July', 'August', 'September', 'October', 'November', 'December'];
+    var SEP = '~';
+
+    function isLeap(y) { return (y % 4 === 0 && y % 100 !== 0) || y % 400 === 0; }
+
+    function daysInMonth(month, year) {
+        if (month === 2) { return isLeap(year || 2024) ? 29 : 28; }
+        return [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31][month - 1];
+    }
+
+    // Mirrors anniversary() in generate.py: February 29 is observed on
+    // February 28 in common years, so leap-day birthdays land on a real date
+    // instead of silently rolling into March.
+    function anniversary(year, month, day) {
+        if (month === 2 && day === 29 && !isLeap(year)) { return new Date(year, 1, 28); }
+        return new Date(year, month - 1, day);
+    }
+
+    function todayMidnight() {
+        var n = new Date();
+        return new Date(n.getFullYear(), n.getMonth(), n.getDate());
+    }
+
+    function nextOccurrence(month, day, from) {
+        var thisYear = anniversary(from.getFullYear(), month, day);
+        if (thisYear >= from) { return thisYear; }
+        return anniversary(from.getFullYear() + 1, month, day);
+    }
+
+    // Round rather than floor: clock changes make some local days 23 or 25
+    // hours long, and only whole days matter here.
+    function daysUntil(target, from) {
+        return Math.round((target - from) / 86400000);
+    }
+
+    function ageOn(birthYear, month, day, when) {
+        var age = when.getFullYear() - birthYear;
+        if (when < anniversary(when.getFullYear(), month, day)) { age -= 1; }
+        return age;
+    }
+
+    function parsePerson(raw) {
+        var bits = String(raw).split(SEP);
+        var md = (bits[1] || '').split('-');
+        var month = parseInt(md[0], 10);
+        var day = parseInt(md[1], 10);
+        if (!month || !day || month < 1 || month > 12 || day < 1 || day > daysInMonth(month, 2024)) {
+            return null;
+        }
+        var year = parseInt(bits[2], 10);
+        return {
+            name: (bits[0] || '').slice(0, 24),
+            month: month,
+            day: day,
+            year: (year >= 1900 && year <= 2100) ? year : null
+        };
+    }
+
+    function encodePerson(p) {
+        var pad = function (n) { return (n < 10 ? '0' : '') + n; };
+        return [p.name, pad(p.month) + '-' + pad(p.day), p.year || ''].join(SEP);
+    }
+
+    function query(people) {
+        return people.map(function (p) {
+            return 'p=' + encodeURIComponent(encodePerson(p));
+        }).join('&');
+    }
+
+    function readFromUrl() {
+        return new URLSearchParams(window.location.search)
+            .getAll('p').map(parsePerson).filter(Boolean);
+    }
+
+    function describe(p, now) {
+        var target = nextOccurrence(p.month, p.day, now);
+        var days = daysUntil(target, now);
+        var meta = MONTHS[target.getMonth()] + ' ' + target.getDate();
+        if (p.year) { meta += ' · turning ' + ageOn(p.year, p.month, p.day, target); }
+        if (p.month === 2 && p.day === 29 && target.getDate() === 28) {
+            meta += ' · leap-day birthday, observed the 28th';
+        }
+        return {
+            target: target,
+            days: days,
+            possessive: p.name ? (p.name + "'s") : 'your',
+            meta: meta
+        };
+    }
+
+    // Soonest first — "whose birthday is next" is the question a countdown
+    // exists to answer, so insertion order would be the wrong emphasis.
+    function bySoonest(people, now) {
+        return people.slice().sort(function (a, b) {
+            return describe(a, now).days - describe(b, now).days;
+        });
+    }
+
+    function clockText(target) {
+        var ms = target - new Date();
+        if (ms <= 0) { return ''; }
+        var total = Math.floor(ms / 1000);
+        var pad = function (n) { return (n < 10 ? '0' : '') + n; };
+        return pad(Math.floor(total / 3600) % 24) + 'h '
+             + pad(Math.floor(total / 60) % 60) + 'm '
+             + pad(total % 60) + 's';
+    }
+
+    return {
+        MONTHS: MONTHS,
+        daysInMonth: daysInMonth,
+        anniversary: anniversary,
+        todayMidnight: todayMidnight,
+        nextOccurrence: nextOccurrence,
+        daysUntil: daysUntil,
+        ageOn: ageOn,
+        parsePerson: parsePerson,
+        encodePerson: encodePerson,
+        query: query,
+        readFromUrl: readFromUrl,
+        describe: describe,
+        bySoonest: bySoonest,
+        clockText: clockText
+    };
+})();
+</script>

--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -6,6 +6,7 @@
     <title>{% block title %}DinkyDash — The digital family calendar for screens you already own{% endblock %}</title>
     <meta name="description" content="{% block description %}Turn any TV, tablet, or Raspberry Pi into a shared family calendar with a chore chart, countdowns, and an AI-written daily brief. Free and open source.{% endblock %}">
     <link rel="canonical" href="{{ canonical_url }}">
+    {% if noindex %}<meta name="robots" content="noindex, follow">{% endif %}
     <meta property="og:title" content="{% block og_title %}DinkyDash — The digital family calendar for screens you already own{% endblock %}">
     <meta property="og:type" content="website">
     <meta property="og:url" content="{{ canonical_url }}">

--- a/website/templates/birthday-countdown-display.html
+++ b/website/templates/birthday-countdown-display.html
@@ -1,0 +1,243 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{{ title }}</title>
+    <meta name="description" content="{{ description }}">
+    <link rel="canonical" href="{{ canonical_url }}">
+    {# The bare URL has nothing on it — the countdown lives in ?p= parameters —
+       so there is nothing here worth indexing. build.py also keeps it out of
+       the sitemap. #}
+    <meta name="robots" content="noindex, follow">
+    <meta property="og:title" content="Birthday countdown">
+    <meta property="og:type" content="website">
+    <meta property="og:image" content="https://dinkydash.co/images/hero-kitchen.png">
+    <meta property="og:description" content="{{ description }}">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="theme-color" content="#fffaf5">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800&display=swap" rel="stylesheet">
+    <style>
+        *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
+
+        :root {
+            --bg: #fffaf5;
+            --surface-warm: #fff5ec;
+            --border: #f0e6da;
+            --text: #2d2319;
+            --text-mid: #5c4a3a;
+            --text-muted: #9a8677;
+            --accent: #e85d24;
+            --purple: #7c5cbf;
+        }
+
+        html, body { height: 100%; }
+        body {
+            font-family: 'Nunito', system-ui, -apple-system, sans-serif;
+            background: var(--bg);
+            color: var(--text);
+            -webkit-font-smoothing: antialiased;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            padding: 4vmin 4vw;
+            text-align: center;
+            overflow: hidden;
+        }
+
+        /* Hero — sized in viewport units so it fills a phone, a tablet on the
+           wall, or a TV without needing breakpoints. */
+        .d-days {
+            font-size: clamp(5rem, 26vmin, 22rem);
+            font-weight: 800;
+            line-height: 0.92;
+            letter-spacing: -0.05em;
+            color: var(--accent);
+            font-variant-numeric: tabular-nums;
+        }
+        .d-label {
+            font-size: clamp(1.1rem, 3.6vmin, 2.4rem);
+            font-weight: 800;
+            margin-top: 2vmin;
+            line-height: 1.2;
+            text-wrap: balance;
+        }
+        .d-clock {
+            font-size: clamp(0.9rem, 2.2vmin, 1.5rem);
+            font-weight: 700;
+            color: var(--text-muted);
+            font-variant-numeric: tabular-nums;
+            margin-top: 1.4vmin;
+        }
+        .d-meta {
+            font-size: clamp(0.85rem, 2vmin, 1.3rem);
+            color: var(--text-mid);
+            margin-top: 0.6vmin;
+        }
+        .d-today { color: var(--accent); font-size: clamp(3rem, 15vmin, 12rem); line-height: 1.05; }
+
+        /* The others */
+        .d-rest {
+            display: flex;
+            flex-wrap: wrap;
+            justify-content: center;
+            gap: 1.4vmin 3vmin;
+            margin-top: 5vmin;
+            padding-top: 4vmin;
+            border-top: 1px solid var(--border);
+            max-width: 1100px;
+        }
+        .d-chip { display: flex; align-items: baseline; gap: 0.8vmin; }
+        .d-chip-days {
+            font-size: clamp(1.3rem, 4vmin, 2.6rem);
+            font-weight: 800;
+            color: var(--purple);
+            font-variant-numeric: tabular-nums;
+        }
+        .d-chip-name {
+            font-size: clamp(0.8rem, 2vmin, 1.2rem);
+            font-weight: 700;
+            color: var(--text-mid);
+        }
+
+        .d-empty { max-width: 30rem; }
+        .d-empty p { color: var(--text-mid); margin-bottom: 1.2rem; font-size: 1.05rem; }
+        .d-empty a { color: var(--accent); font-weight: 700; }
+
+        /* Attribution. Deliberately quiet, but present — a shared countdown is
+           the only place a recipient learns where it came from. */
+        .d-mark {
+            position: fixed;
+            bottom: 2.4vmin;
+            left: 0;
+            right: 0;
+            font-size: clamp(0.7rem, 1.5vmin, 0.95rem);
+            font-weight: 700;
+            color: var(--text-muted);
+            opacity: 0.55;
+            text-decoration: none;
+            transition: opacity 0.15s;
+        }
+        .d-mark:hover { opacity: 1; color: var(--accent); }
+
+        @media (prefers-color-scheme: dark) {
+            :root {
+                --bg: #1c1613;
+                --surface-warm: #241d18;
+                --border: #3a2f27;
+                --text: #f6ede4;
+                --text-mid: #cbb9a8;
+                --text-muted: #9a8677;
+            }
+        }
+    </style>
+</head>
+<body>
+    <main id="d-root">
+        <div class="d-empty">
+            <p>Loading countdown…</p>
+        </div>
+    </main>
+
+    <a class="d-mark" href="/birthday-countdown/">Made with DinkyDash</a>
+
+{% include "_countdown-lib.html" %}
+<script>
+(function () {
+    'use strict';
+
+    var C = window.DDCountdown;
+    var root = document.getElementById('d-root');
+    var people = C.readFromUrl();
+    var primary = null;
+
+    function empty() {
+        root.innerHTML = '';
+        var box = document.createElement('div');
+        box.className = 'd-empty';
+        var p = document.createElement('p');
+        p.textContent = 'This countdown link has no birthdays in it.';
+        var a = document.createElement('a');
+        a.href = '/birthday-countdown/';
+        a.textContent = 'Make your own birthday countdown →';
+        box.appendChild(p);
+        box.appendChild(a);
+        root.appendChild(box);
+    }
+
+    function text(cls, value) {
+        var d = document.createElement('div');
+        d.className = cls;
+        d.textContent = value;
+        return d;
+    }
+
+    function render() {
+        var now = C.todayMidnight();
+        var sorted = C.bySoonest(people, now);
+        primary = sorted[0];
+        var d = C.describe(primary, now);
+
+        root.innerHTML = '';
+
+        if (d.days === 0) {
+            root.appendChild(text('d-days d-today', '🎉'));
+            root.appendChild(text('d-label',
+                'Happy birthday' + (primary.name ? ', ' + primary.name : '') + '!'));
+        } else {
+            root.appendChild(text('d-days', String(d.days)));
+            root.appendChild(text('d-label',
+                'day' + (d.days === 1 ? '' : 's') + ' until ' + d.possessive + ' birthday'));
+            root.appendChild(text('d-clock', C.clockText(d.target)));
+        }
+        root.appendChild(text('d-meta', d.meta));
+
+        if (sorted.length > 1) {
+            var rest = document.createElement('div');
+            rest.className = 'd-rest';
+            sorted.slice(1).forEach(function (p) {
+                var pd = C.describe(p, now);
+                var chip = document.createElement('div');
+                chip.className = 'd-chip';
+                chip.appendChild(text('d-chip-days', pd.days === 0 ? '🎉' : String(pd.days)));
+                chip.appendChild(text('d-chip-name', p.name || 'birthday'));
+                rest.appendChild(chip);
+            });
+            root.appendChild(rest);
+        }
+    }
+
+    if (!people.length) {
+        empty();
+        return;
+    }
+
+    render();
+    document.title = (function () {
+        var d = C.describe(C.bySoonest(people, C.todayMidnight())[0], C.todayMidnight());
+        return d.days === 0
+            ? 'Today! · Birthday countdown'
+            : d.days + ' days until ' + d.possessive + ' birthday';
+    })();
+
+    // Tick the clock without rebuilding the DOM.
+    setInterval(function () {
+        var clock = root.querySelector('.d-clock');
+        if (!clock || !primary) { return; }
+        clock.textContent = C.clockText(
+            C.nextOccurrence(primary.month, primary.day, C.todayMidnight()));
+    }, 1000);
+
+    // A display left running on a wall needs to notice midnight.
+    setInterval(function () {
+        var shown = root.querySelector('.d-days');
+        var d = C.describe(C.bySoonest(people, C.todayMidnight())[0], C.todayMidnight());
+        if (!shown || shown.textContent !== String(d.days)) { render(); }
+    }, 60000);
+})();
+</script>
+</body>
+</html>

--- a/website/templates/birthday-countdown.html
+++ b/website/templates/birthday-countdown.html
@@ -53,14 +53,20 @@
     }
 
     /* Form */
+    .bc-form-head {
+        margin-top: 26px;
+        padding-top: 22px;
+        border-top: 1px solid var(--border);
+        font-size: 0.95rem;
+        font-weight: 800;
+        color: var(--text);
+    }
     .bc-form {
         display: flex;
         flex-wrap: wrap;
         gap: 10px;
         align-items: flex-end;
-        margin-top: 24px;
-        padding-top: 24px;
-        border-top: 1px solid var(--border);
+        margin-top: 12px;
     }
     .bc-field { display: flex; flex-direction: column; gap: 5px; flex: 1 1 130px; }
     .bc-field label {
@@ -96,8 +102,10 @@
         padding: 11px 20px;
         cursor: pointer;
         white-space: nowrap;
+        text-decoration: none;
+        display: inline-block;
     }
-    .bc-btn:hover { filter: brightness(1.06); }
+    .bc-btn:hover { filter: brightness(1.06); text-decoration: none; }
     .bc-btn-ghost {
         background: transparent;
         color: var(--text-mid);
@@ -109,13 +117,15 @@
         flex-wrap: wrap;
         gap: 8px;
         justify-content: center;
-        margin-top: 20px;
+        margin-top: 22px;
+        padding-top: 20px;
+        border-top: 1px solid var(--border);
     }
-    .bc-hint { font-size: 0.8rem; color: var(--text-muted); margin-top: 10px; text-align: center; }
+    .bc-hint { font-size: 0.8rem; color: var(--text-muted); margin-top: 10px; }
     .bc-error { color: #c2410c; font-size: 0.85rem; font-weight: 600; margin-top: 10px; }
 
     /* Extra people */
-    .bc-list { display: grid; gap: 10px; margin-top: 16px; }
+    .bc-list { display: grid; gap: 10px; margin-top: 18px; }
     .bc-row {
         display: flex;
         align-items: center;
@@ -170,6 +180,7 @@
         .bc-card { padding: 22px 16px; }
         .bc-field { flex: 1 1 100%; }
         .bc-form .bc-btn { width: 100%; }
+        .bc-actions .bc-btn { flex: 1 1 100%; text-align: center; }
     }
 </style>
 {% endblock %}
@@ -189,6 +200,7 @@
                 <div class="bc-sub" id="bc-sub">Enter a birthday below to start the countdown.</div>
             </div>
 
+            <div class="bc-form-head" id="bc-form-head">Start a countdown</div>
             <form class="bc-form" id="bc-form">
                 <div class="bc-field">
                     <label for="bc-name">Name</label>
@@ -209,11 +221,12 @@
                 <button type="submit" class="bc-btn" id="bc-submit">Start countdown</button>
             </form>
             <div class="bc-error" id="bc-error" hidden></div>
-            <div class="bc-hint">Add a year and it will show the age they're turning. Nothing is uploaded — it all stays in your browser.</div>
+            <div class="bc-hint" id="bc-hint">Add a year and it will show the age they're turning. Nothing is uploaded — it all stays in your browser.</div>
 
             <div class="bc-list" id="bc-list"></div>
 
             <div class="bc-actions" id="bc-actions" hidden>
+                <a class="bc-btn" id="bc-fullscreen" href="/birthday-countdown/display/">Open full screen</a>
                 <button type="button" class="bc-btn bc-btn-ghost" id="bc-share">Copy shareable link</button>
                 <button type="button" class="bc-btn bc-btn-ghost" id="bc-clear">Clear all</button>
             </div>
@@ -226,7 +239,7 @@
                 chart that rotates itself, and a short daily brief written for your family —
                 on any old tablet, TV or Raspberry Pi you already own. Free and open source.
             </p>
-            <a class="bc-btn" href="/diy-skylight-calendar/" style="display:inline-block">See how it works</a>
+            <a class="bc-btn" href="/diy-skylight-calendar/">See how it works</a>
         </div>
     </div>
 
@@ -235,166 +248,82 @@
 {% endblock %}
 
 {% block extra_js %}
+{% include "_countdown-lib.html" %}
 <script>
 (function () {
     'use strict';
 
-    var MONTHS = ['January', 'February', 'March', 'April', 'May', 'June',
-                  'July', 'August', 'September', 'October', 'November', 'December'];
+    var C = window.DDCountdown;
     var STORAGE_KEY = 'dinkydash.birthdays';
-    var SEP = '~';
+    var DISPLAY_PATH = '/birthday-countdown/display/';
 
     var el = function (id) { return document.getElementById(id); };
     var people = [];
 
-    // --- date helpers -------------------------------------------------------
-    // Mirrors anniversary() in generate.py: February 29 is observed on
-    // February 28 in common years, so leap-day birthdays still land on a real
-    // date instead of silently rolling into March.
-
-    function isLeap(y) { return (y % 4 === 0 && y % 100 !== 0) || y % 400 === 0; }
-
-    function daysInMonth(month, year) {
-        if (month === 2) { return isLeap(year || 2024) ? 29 : 28; }
-        return [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31][month - 1];
-    }
-
-    function anniversary(year, month, day) {
-        if (month === 2 && day === 29 && !isLeap(year)) { return new Date(year, 1, 28); }
-        return new Date(year, month - 1, day);
-    }
-
-    function todayMidnight() {
-        var n = new Date();
-        return new Date(n.getFullYear(), n.getMonth(), n.getDate());
-    }
-
-    function nextOccurrence(month, day, from) {
-        var thisYear = anniversary(from.getFullYear(), month, day);
-        if (thisYear >= from) { return thisYear; }
-        return anniversary(from.getFullYear() + 1, month, day);
-    }
-
-    // Round rather than floor: clock changes make some local days 23 or 25
-    // hours long, and only whole days matter here.
-    function daysUntil(target, from) {
-        return Math.round((target - from) / 86400000);
-    }
-
-    function ageOn(birthYear, month, day, when) {
-        var age = when.getFullYear() - birthYear;
-        if (when < anniversary(when.getFullYear(), month, day)) { age -= 1; }
-        return age;
-    }
-
     // --- state --------------------------------------------------------------
-
-    function parsePerson(raw) {
-        var bits = raw.split(SEP);
-        var md = (bits[1] || '').split('-');
-        var month = parseInt(md[0], 10);
-        var day = parseInt(md[1], 10);
-        if (!month || !day || month < 1 || month > 12 || day < 1 || day > daysInMonth(month, 2024)) {
-            return null;
-        }
-        var year = parseInt(bits[2], 10);
-        return {
-            name: (bits[0] || '').slice(0, 24),
-            month: month,
-            day: day,
-            year: (year >= 1900 && year <= 2100) ? year : null
-        };
-    }
-
-    function encodePerson(p) {
-        var pad = function (n) { return (n < 10 ? '0' : '') + n; };
-        return [p.name, pad(p.month) + '-' + pad(p.day), p.year || ''].join(SEP);
-    }
-
-    function readFromUrl() {
-        var params = new URLSearchParams(window.location.search);
-        return params.getAll('p').map(parsePerson).filter(Boolean);
-    }
 
     function readFromStorage() {
         try {
             var raw = window.localStorage.getItem(STORAGE_KEY);
-            return raw ? JSON.parse(raw).map(parsePerson).filter(Boolean) : [];
+            return raw ? JSON.parse(raw).map(C.parsePerson).filter(Boolean) : [];
         } catch (e) { return []; }
+    }
+
+    function displayUrl() {
+        return window.location.origin + DISPLAY_PATH
+            + (people.length ? '?' + C.query(people) : '');
     }
 
     function persist() {
         try {
-            window.localStorage.setItem(STORAGE_KEY, JSON.stringify(people.map(encodePerson)));
+            window.localStorage.setItem(STORAGE_KEY, JSON.stringify(people.map(C.encodePerson)));
         } catch (e) { /* private browsing — the tool still works for this visit */ }
         var url = people.length
-            ? window.location.pathname + '?' + people.map(function (p) {
-                  return 'p=' + encodeURIComponent(encodePerson(p));
-              }).join('&')
+            ? window.location.pathname + '?' + C.query(people)
             : window.location.pathname;
         window.history.replaceState(null, '', url);
     }
 
     // --- rendering ----------------------------------------------------------
 
-    function describe(p, now) {
-        var target = nextOccurrence(p.month, p.day, now);
-        var days = daysUntil(target, now);
-        var possessive = p.name ? (p.name + "'s") : 'your';
-        var dateText = MONTHS[target.getMonth()] + ' ' + target.getDate();
-        var meta = dateText;
-        if (p.year) { meta += ' · turning ' + (ageOn(p.year, p.month, p.day, target) ); }
-        if (p.month === 2 && p.day === 29 && target.getDate() === 28) {
-            meta += ' · leap-day birthday, observed the 28th';
-        }
-        return { target: target, days: days, possessive: possessive, meta: meta };
-    }
-
-    function renderHero(now) {
-        if (!people.length) {
+    function renderHero(sorted, now) {
+        if (!sorted.length) {
+            el('bc-days').className = 'bc-days';
             el('bc-days').textContent = '—';
             el('bc-label').textContent = 'days until your birthday';
             el('bc-clock').textContent = '';
             el('bc-sub').textContent = 'Enter a birthday below to start the countdown.';
             return;
         }
-        var d = describe(people[0], now);
+        var d = C.describe(sorted[0], now);
         var hero = el('bc-days');
         if (d.days === 0) {
             hero.className = 'bc-today';
             hero.textContent = '🎉 Today!';
-            el('bc-label').textContent = 'Happy birthday' + (people[0].name ? ', ' + people[0].name : '') + '!';
+            el('bc-label').textContent =
+                'Happy birthday' + (sorted[0].name ? ', ' + sorted[0].name : '') + '!';
+            el('bc-clock').textContent = '';
         } else {
             hero.className = 'bc-days';
-            hero.textContent = d.days;
-            el('bc-label').textContent = 'day' + (d.days === 1 ? '' : 's') + ' until ' + d.possessive + ' birthday';
+            hero.textContent = String(d.days);
+            el('bc-label').textContent =
+                'day' + (d.days === 1 ? '' : 's') + ' until ' + d.possessive + ' birthday';
+            el('bc-clock').textContent = C.clockText(d.target);
         }
         el('bc-sub').textContent = d.meta;
-        renderClock(d.target);
     }
 
-    function renderClock(target) {
-        var ms = target - new Date();
-        if (ms <= 0) { el('bc-clock').textContent = ''; return; }
-        var total = Math.floor(ms / 1000);
-        var h = Math.floor(total / 3600) % 24;
-        var m = Math.floor(total / 60) % 60;
-        var s = total % 60;
-        var pad = function (n) { return (n < 10 ? '0' : '') + n; };
-        el('bc-clock').textContent = pad(h) + 'h ' + pad(m) + 'm ' + pad(s) + 's';
-    }
-
-    function renderList(now) {
+    function renderList(sorted, now) {
         var list = el('bc-list');
         list.textContent = '';
-        people.slice(1).forEach(function (p, i) {
-            var d = describe(p, now);
+        sorted.slice(1).forEach(function (p) {
+            var d = C.describe(p, now);
             var row = document.createElement('div');
             row.className = 'bc-row';
 
             var days = document.createElement('div');
             days.className = 'bc-row-days';
-            days.textContent = d.days === 0 ? '🎉' : d.days;
+            days.textContent = d.days === 0 ? '🎉' : String(d.days);
 
             var body = document.createElement('div');
             body.className = 'bc-row-body';
@@ -413,7 +342,10 @@
             remove.setAttribute('aria-label', 'Remove ' + (p.name || 'this birthday'));
             remove.textContent = '×';
             remove.addEventListener('click', function () {
-                people.splice(i + 1, 1);
+                // Sorted is a shallow copy, so identity still maps back to the
+                // insertion-ordered array that gets persisted.
+                var i = people.indexOf(p);
+                if (i !== -1) { people.splice(i, 1); }
                 persist();
                 render();
             });
@@ -425,11 +357,19 @@
         });
     }
 
+    function renderFormAffordance() {
+        var has = people.length > 0;
+        // The original wording left no hint that a second birthday could be
+        // added, so nobody tried. Say it plainly once there is one.
+        el('bc-form-head').textContent = has ? 'Add another birthday' : 'Start a countdown';
+        el('bc-submit').textContent = has ? 'Add birthday' : 'Start countdown';
+        el('bc-hint').textContent = has
+            ? 'Add everyone — the whole family stacks up in one countdown you can share.'
+            : "Add a year and it will show the age they're turning. Nothing is uploaded — it all stays in your browser.";
+    }
+
     function renderPitch() {
-        var pitch = el('bc-pitch');
-        pitch.hidden = people.length === 0;
-        // Once there's a family on screen the page is already a DinkyDash
-        // preview, so say so plainly rather than repeating the generic pitch.
+        el('bc-pitch').hidden = people.length === 0;
         if (people.length > 1) {
             el('bc-pitch-title').textContent = "You've just built a family dashboard";
             el('bc-pitch-body').textContent =
@@ -441,18 +381,21 @@
     }
 
     function render() {
-        var now = todayMidnight();
-        renderHero(now);
-        renderList(now);
+        var now = C.todayMidnight();
+        var sorted = C.bySoonest(people, now);
+        renderHero(sorted, now);
+        renderList(sorted, now);
+        renderFormAffordance();
         renderPitch();
         el('bc-actions').hidden = people.length === 0;
+        el('bc-fullscreen').href = displayUrl();
     }
 
     // --- form ---------------------------------------------------------------
 
     function buildSelects() {
         var monthSel = el('bc-month');
-        MONTHS.forEach(function (name, i) {
+        C.MONTHS.forEach(function (name, i) {
             var o = document.createElement('option');
             o.value = String(i + 1);
             o.textContent = name;
@@ -469,7 +412,7 @@
         var month = parseInt(el('bc-month').value, 10);
         var current = preselect || parseInt(daySel.value, 10) || 1;
         // 29 stays selectable in February so leap-day birthdays can be entered.
-        var max = daysInMonth(month, 2024);
+        var max = C.daysInMonth(month, 2024);
         daySel.textContent = '';
         for (var d = 1; d <= max; d++) {
             var o = document.createElement('option');
@@ -488,20 +431,21 @@
 
     el('bc-form').addEventListener('submit', function (e) {
         e.preventDefault();
-        var month = parseInt(el('bc-month').value, 10);
-        var day = parseInt(el('bc-day').value, 10);
         var yearRaw = el('bc-year').value.trim();
         var year = yearRaw ? parseInt(yearRaw, 10) : null;
 
-        if (year !== null) {
-            if (isNaN(year) || year < 1900 || year > new Date().getFullYear()) {
-                showError('That birth year does not look right — leave it blank if you would rather not say.');
-                return;
-            }
+        if (year !== null && (isNaN(year) || year < 1900 || year > new Date().getFullYear())) {
+            showError('That birth year does not look right — leave it blank if you would rather not say.');
+            return;
         }
         showError('');
 
-        people.push({ name: el('bc-name').value.trim(), month: month, day: day, year: year });
+        people.push({
+            name: el('bc-name').value.trim(),
+            month: parseInt(el('bc-month').value, 10),
+            day: parseInt(el('bc-day').value, 10),
+            year: year
+        });
         el('bc-name').value = '';
         el('bc-year').value = '';
         persist();
@@ -516,7 +460,9 @@
 
     el('bc-share').addEventListener('click', function () {
         var btn = el('bc-share');
-        var url = window.location.href;
+        // Share the full-screen view, not the editor — what a recipient wants
+        // is the countdown, not the form that made it.
+        var url = displayUrl();
         var done = function () {
             btn.textContent = 'Link copied';
             setTimeout(function () { btn.textContent = 'Copy shareable link'; }, 2000);
@@ -533,25 +479,29 @@
     // --- boot ---------------------------------------------------------------
 
     buildSelects();
-    // A shared link wins over whatever is in storage — the visitor followed it
-    // to see that countdown, not their own.
-    var fromUrl = readFromUrl();
+    // A shared link wins over storage — the visitor followed it to see that
+    // countdown, not their own.
+    var fromUrl = C.readFromUrl();
     people = fromUrl.length ? fromUrl : readFromStorage();
     render();
     if (people.length) { persist(); }
 
     setInterval(function () {
         if (!people.length) { return; }
-        var now = todayMidnight();
-        renderClock(nextOccurrence(people[0].month, people[0].day, now));
+        var now = C.todayMidnight();
+        var soonest = C.bySoonest(people, now)[0];
+        var d = C.describe(soonest, now);
+        if (d.days > 0) {
+            el('bc-clock').textContent = C.clockText(d.target);
+        }
     }, 1000);
 
     // Recompute at local midnight so a tab left open overnight is not stale.
     setInterval(function () {
         if (!people.length) { return; }
+        var d = C.describe(C.bySoonest(people, C.todayMidnight())[0], C.todayMidnight());
         var shown = el('bc-days').textContent;
-        var d = describe(people[0], todayMidnight());
-        if (String(d.days) !== shown && !(d.days === 0 && shown.indexOf('Today') !== -1)) {
+        if (shown !== String(d.days) && !(d.days === 0 && shown.indexOf('Today') !== -1)) {
             render();
         }
     }, 60000);


### PR DESCRIPTION
Follow-up to #23, addressing two pieces of feedback.

## 1. Stacking was invisible

Adding a second birthday already worked — but nothing said so. After the first countdown the form still read **"Start countdown"**, which reads as *replace this one* rather than *add another*, so there was no reason to try. A feature nobody can find is the same as a feature that isn't there.

The form heading, button label and hint now change once there's at least one countdown:

| | Empty | Populated |
|---|---|---|
| Heading | Start a countdown | **Add another birthday** |
| Button | Start countdown | **Add birthday** |
| Hint | (privacy note) | **Add everyone — the whole family stacks up in one countdown you can share.** |

**Countdowns are now ordered soonest-first** in both views, rather than by insertion. "Whose birthday is next" is the question a countdown exists to answer, and insertion order put the emphasis in the wrong place — a birthday ten months out could hold the hero slot while one next week sat in a list underneath. Removal maps back through object identity, so the sorted view stays consistent with the insertion-ordered array that gets persisted.

## 2. Shared links open full screen

A shared countdown now opens `/birthday-countdown/display/` — no nav, no footer, no article, just the numbers on the warm background. That's what a recipient actually wants, and it doubles as something you can leave open on a spare tablet or TV, which is the product pitch made literal rather than argued.

- **Copy shareable link** produces that URL
- A new **Open full screen** button opens it for yourself
- The document title becomes `12 days until Bob's birthday`, so the tab — and some link unfurls — carry the count

The display page is standalone rather than an extension of `base.html`, so it ships none of the site chrome. It sorts soonest-first, shows the rest as a compact strip, supports dark mode, sizes everything in viewport units so it fills a phone or a wall-mounted screen without breakpoints, and falls back to a link back to the tool when the URL carries no birthdays.

It keeps exactly one piece of text: a quiet **"Made with DinkyDash"** mark. A shared countdown is the only place a recipient learns where it came from, so removing it entirely would remove the reason sharing is worth building. Happy to drop it if you'd rather it were completely bare.

## Supporting changes

**`build.py` gains `noindex: true` front matter** — adds a robots meta tag and keeps the page out of `sitemap.xml`. The display page has nothing on it until query parameters are supplied, so indexing the bare URL would just add a thin page. The build line now reports both counts (`15 pages, 14 in sitemap`) since the two can now differ.

**Date logic moved to `templates/_countdown-lib.html`,** included by both templates. It was about to be duplicated across two files that must never disagree about how many days are left; it's now defined once, and still mirrors `anniversary()` in `generate.py` for leap-day handling.

## Testing

Driven in a browser: the add-another affordance, soonest-first reordering when a nearer birthday is added (Bob at 12 days correctly displaced Alice at 207), the full-screen view at desktop and 390px, the empty-link fallback, and that the display page carries `noindex` and is absent from the sitemap. Confirmed every internal link on both pages resolves.

21 tests still pass. The only console error is the site-wide missing `favicon.ico`, which predates this work.

Rebased onto `main` after #23 merged; git dropped the already-applied commit, and `build.py` was re-run to confirm the generated `docs/` output matches the rebased tree exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)