### PR TITLE
Add design mockups for the settings UI and the board

### DIFF
--- a/design/README.md
+++ b/design/README.md
@@ -1,0 +1,55 @@
+# Design mockups
+
+Visual mockups for the hosted MVP — the Phase 1 settings UI and the Phase 3 board.
+These are **design artefacts, not application code**. Nothing here is imported or
+served by `app.py`; they exist so the layout and copy decisions can be reviewed
+before the templates get written.
+
+| Directory | What it covers | PLAN.md phase |
+|---|---|---|
+| [`settings-ui/`](settings-ui/) | The logged-in family settings UI, mobile (390×844) | Phase 1 |
+| [`board-ui/`](board-ui/) | The board itself, across TV / iPad / Pi, light and dark | Phase 3 |
+
+## Format
+
+Each `*.dc.html` file is one artboard — a self-contained HTML page laid out at a
+fixed pixel size, styled with inline styles lifted from `website/templates/`
+(Nunito, `#fffaf5` ground, `#e85d24` accent, `#f0e6da` borders). `canvas.json`
+positions them on a shared canvas and carries the annotations explaining each
+design decision.
+
+The `<script src="./support.js">` line and the `<x-dc>` / `<helmet>` wrappers are
+required by the canvas editor these were authored in. Opening a `.dc.html`
+directly in a browser renders it close enough to read, with two caveats: the
+`{{qr}}` placeholder in `settings-ui/Screen.dc.html` stays empty, and headless
+screenshots of a fixed-height artboard tend to drop the bottom ~70px — measure
+`scrollHeight` against the frame rather than trusting a screenshot.
+
+## Decisions recorded here
+
+**Settings** — a hub whose rows carry live state, so a broken calendar feed
+surfaces before you tap in. Chore rotation is an explicit ordered list plus a
+next-week preview, making the day-of-year modulo visible. Adding a calendar
+validates on paste and answers with a real event count.
+
+**Board** — no person cards; the agenda is the board, at a size that reads across
+a room. One prose box carries whatever the generator wrote that day rather than
+three fixed slots. Wide-and-short screens (TV, Pi) get two columns, tall ones
+(iPad) one — a real breakpoint, not the `vmin` scaling the current template uses.
+
+**Stale state** — the payload has two halves. Ages, countdowns, chore rotation and
+the agenda are computed and stay correct when generation fails; only the prose is
+stale, so only the prose is marked and the AI headline gives way to a computed one.
+
+**Colour scheme** — Light and Dark, chosen on the Screen link screen because the
+colour belongs to the screen on the wall, not to the person editing. Dark is a
+full palette swap: `#17120f` ground, accent lifted to `#ff7a45`, chore-pill tints
+raised to stay visible.
+
+## Known gaps
+
+- Drag-to-reorder is not drawn; the "Reorder" affordance is a placeholder.
+- Post-trial lapse behaviour is unresolved — an open question in [PLAN.md](../PLAN.md).
+- The QR code is an illustrative pattern, not a scannable code.
+- An Auto colour mode (dark after sunset, using the family timezone) is proposed
+  in the annotations but not designed.

--- a/design/board-ui/FirstRun.dc.html
+++ b/design/board-ui/FirstRun.dc.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800&display=swap">
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: 'Nunito', system-ui, -apple-system, sans-serif; background: #fffaf5; color: #2d2319; -webkit-font-smoothing: antialiased; }
+    a { color: #e85d24; text-decoration: none; }
+    a:hover { color: #c44d1a; }
+  </style>
+</helmet>
+
+<div style="width: 1280px; height: 720px; background: #fffaf5; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 28px; overflow: hidden; position: relative;">
+
+  <div style="font-size: 20px; font-weight: 800; text-transform: uppercase; letter-spacing: 0.11em; color: #e85d24;">DinkyDash</div>
+
+  <div style="font-size: 44px; font-weight: 800; letter-spacing: -0.02em; text-align: center; max-width: 800px; line-height: 1.2;">Writing the Wilsons&rsquo; first board&hellip;</div>
+
+  <div style="width: 400px; height: 8px; border-radius: 999px; background: #f0e6da; overflow: hidden;">
+    <div style="width: 176px; height: 8px; border-radius: 999px; background: #e85d24;"></div>
+  </div>
+
+  <div style="font-size: 20px; color: #5c4a3a; text-align: center; line-height: 1.6; max-width: 580px;">Under a minute. Leave this page up &mdash; it fills itself in, then rewrites every morning at 4:30.</div>
+
+  <div style="display: flex; align-items: center; gap: 11px; margin-top: 12px; background: #ffffff; border: 1px solid #f0e6da; border-radius: 999px; padding: 12px 24px;">
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#16a34a" stroke-width="2.3" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"></circle><polyline points="8 12.4 11 15.4 16 9.4"></polyline></svg>
+    <div style="font-size: 16px; font-weight: 700; color: #5c4a3a;">2 calendars connected &middot; 2 jobs rotating &middot; 3 countdowns</div>
+  </div>
+
+</div>
+</x-dc>
+</body>
+</html>

--- a/design/board-ui/Main.dc.html
+++ b/design/board-ui/Main.dc.html
@@ -1,0 +1,77 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800&display=swap">
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: 'Nunito', system-ui, -apple-system, sans-serif; background: #ffffff; color: #2d2319; -webkit-font-smoothing: antialiased; }
+    a { color: #e85d24; text-decoration: none; }
+    a:hover { color: #c44d1a; }
+  </style>
+</helmet>
+
+<div style="width: 1280px; height: 720px; background: #ffffff; padding: 40px 52px; display: flex; flex-direction: column; gap: 26px; overflow: hidden;">
+
+  <div style="display: flex; align-items: baseline; justify-content: space-between; flex-shrink: 0;">
+    <div style="font-size: 17px; font-weight: 800; text-transform: uppercase; letter-spacing: 0.09em; color: #e85d24;">The Wilsons</div>
+    <div style="font-size: 20px; font-weight: 700; color: #9a8677;">Thursday, 3 September</div>
+  </div>
+
+  <div style="font-size: 48px; font-weight: 800; line-height: 1.18; letter-spacing: -0.02em; flex-shrink: 0;">Ines starts nursery today &mdash; and Mia has her swimming badge.</div>
+
+  <div style="display: flex; gap: 52px; align-items: flex-start; flex-shrink: 0; flex-grow: 1;">
+
+    <div style="flex-grow: 1; flex-basis: 0;">
+      <div style="font-size: 14px; font-weight: 800; text-transform: uppercase; letter-spacing: 0.1em; color: #9a8677; margin-bottom: 16px;">Today</div>
+      <div style="display: flex; flex-direction: column; gap: 14px;">
+        <div style="display: flex; gap: 20px; align-items: baseline;">
+          <div style="font-size: 26px; font-weight: 800; color: #e85d24; width: 92px; flex-shrink: 0;">08:20</div>
+          <div style="font-size: 26px; font-weight: 700;">School run <span style="color: #9a8677; font-weight: 600;">&mdash; Mia &amp; Theo</span></div>
+        </div>
+        <div style="display: flex; gap: 20px; align-items: baseline;">
+          <div style="font-size: 26px; font-weight: 800; color: #e85d24; width: 92px; flex-shrink: 0;">09:00</div>
+          <div style="font-size: 26px; font-weight: 700;">Ines&rsquo; first morning at nursery</div>
+        </div>
+        <div style="display: flex; gap: 20px; align-items: baseline;">
+          <div style="font-size: 26px; font-weight: 800; color: #e85d24; width: 92px; flex-shrink: 0;">15:45</div>
+          <div style="font-size: 26px; font-weight: 700;">Mia&rsquo;s swimming badge test</div>
+        </div>
+        <div style="display: flex; gap: 20px; align-items: baseline;">
+          <div style="font-size: 26px; font-weight: 800; color: #e85d24; width: 92px; flex-shrink: 0;">18:30</div>
+          <div style="font-size: 26px; font-weight: 700;">Sam: parents&rsquo; evening <span style="color: #9a8677; font-weight: 600;">&mdash; online</span></div>
+        </div>
+      </div>
+    </div>
+
+    <div style="width: 430px; flex-shrink: 0; display: flex; flex-direction: column; gap: 24px;">
+      <div>
+        <div style="font-size: 14px; font-weight: 800; text-transform: uppercase; letter-spacing: 0.1em; color: #9a8677; margin-bottom: 13px;">Whose turn</div>
+        <div style="display: flex; flex-direction: column; align-items: flex-start; gap: 10px;">
+          <div style="display: inline-flex; align-items: center; gap: 10px; padding: 8px 20px 8px 10px; border-radius: 999px; background: rgba(232, 93, 36, 0.1); font-size: 20px; font-weight: 800; color: #c44d1a;"><span style="font-size: 23px;">🍽</span> Set the table &mdash; Theo</div>
+          <div style="display: inline-flex; align-items: center; gap: 10px; padding: 8px 20px 8px 10px; border-radius: 999px; background: rgba(124, 92, 191, 0.1); font-size: 20px; font-weight: 800; color: #6b4fa8;"><span style="font-size: 23px;">🦴</span> Feed Biscuit &mdash; Mia</div>
+        </div>
+      </div>
+      <div>
+        <div style="font-size: 14px; font-weight: 800; text-transform: uppercase; letter-spacing: 0.1em; color: #9a8677; margin-bottom: 13px;">Coming up</div>
+        <div style="display: flex; flex-direction: column; gap: 10px;">
+          <div style="display: flex; align-items: center; gap: 12px; font-size: 19px; color: #5c4a3a;"><span style="font-size: 21px;">🎂</span> <span><strong style="color: #2d2319; font-weight: 800;">12 days</strong> until Mia&rsquo;s birthday</span></div>
+          <div style="display: flex; align-items: center; gap: 12px; font-size: 19px; color: #5c4a3a;"><span style="font-size: 21px;">🚂</span> <span><strong style="color: #2d2319; font-weight: 800;">45 days</strong> until Grandma &amp; Grandad visit</span></div>
+          <div style="display: flex; align-items: center; gap: 12px; font-size: 19px; color: #5c4a3a;"><span style="font-size: 21px;">🎄</span> <span><strong style="color: #2d2319; font-weight: 800;">113 days</strong> until Christmas</span></div>
+        </div>
+      </div>
+    </div>
+
+  </div>
+
+  <div style="background: #fff5ec; border-radius: 16px; padding: 18px 24px; font-size: 19px; line-height: 1.5; color: #5c4a3a; flex-shrink: 0;">Micropachycephalosaurus is the longest dinosaur name there is &mdash; 23 letters for an animal about the size of a turkey.</div>
+
+</div>
+</x-dc>
+</body>
+</html>

--- a/design/board-ui/MainDark.dc.html
+++ b/design/board-ui/MainDark.dc.html
@@ -1,0 +1,77 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800&display=swap">
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: 'Nunito', system-ui, -apple-system, sans-serif; background: #17120f; color: #f6efe7; -webkit-font-smoothing: antialiased; }
+    a { color: #ff7a45; text-decoration: none; }
+    a:hover { color: #ffa477; }
+  </style>
+</helmet>
+
+<div style="width: 1280px; height: 720px; background: #17120f; padding: 40px 52px; display: flex; flex-direction: column; gap: 26px; overflow: hidden;">
+
+  <div style="display: flex; align-items: baseline; justify-content: space-between; flex-shrink: 0;">
+    <div style="font-size: 17px; font-weight: 800; text-transform: uppercase; letter-spacing: 0.09em; color: #ff7a45;">The Wilsons</div>
+    <div style="font-size: 20px; font-weight: 700; color: #93816f;">Thursday, 3 September</div>
+  </div>
+
+  <div style="font-size: 48px; font-weight: 800; line-height: 1.18; letter-spacing: -0.02em; flex-shrink: 0;">Ines starts nursery today &mdash; and Mia has her swimming badge.</div>
+
+  <div style="display: flex; gap: 52px; align-items: flex-start; flex-shrink: 0; flex-grow: 1;">
+
+    <div style="flex-grow: 1; flex-basis: 0;">
+      <div style="font-size: 14px; font-weight: 800; text-transform: uppercase; letter-spacing: 0.1em; color: #93816f; margin-bottom: 16px;">Today</div>
+      <div style="display: flex; flex-direction: column; gap: 14px;">
+        <div style="display: flex; gap: 20px; align-items: baseline;">
+          <div style="font-size: 26px; font-weight: 800; color: #ff7a45; width: 92px; flex-shrink: 0;">08:20</div>
+          <div style="font-size: 26px; font-weight: 700;">School run <span style="color: #93816f; font-weight: 600;">&mdash; Mia &amp; Theo</span></div>
+        </div>
+        <div style="display: flex; gap: 20px; align-items: baseline;">
+          <div style="font-size: 26px; font-weight: 800; color: #ff7a45; width: 92px; flex-shrink: 0;">09:00</div>
+          <div style="font-size: 26px; font-weight: 700;">Ines&rsquo; first morning at nursery</div>
+        </div>
+        <div style="display: flex; gap: 20px; align-items: baseline;">
+          <div style="font-size: 26px; font-weight: 800; color: #ff7a45; width: 92px; flex-shrink: 0;">15:45</div>
+          <div style="font-size: 26px; font-weight: 700;">Mia&rsquo;s swimming badge test</div>
+        </div>
+        <div style="display: flex; gap: 20px; align-items: baseline;">
+          <div style="font-size: 26px; font-weight: 800; color: #ff7a45; width: 92px; flex-shrink: 0;">18:30</div>
+          <div style="font-size: 26px; font-weight: 700;">Sam: parents&rsquo; evening <span style="color: #93816f; font-weight: 600;">&mdash; online</span></div>
+        </div>
+      </div>
+    </div>
+
+    <div style="width: 430px; flex-shrink: 0; display: flex; flex-direction: column; gap: 24px;">
+      <div>
+        <div style="font-size: 14px; font-weight: 800; text-transform: uppercase; letter-spacing: 0.1em; color: #93816f; margin-bottom: 13px;">Whose turn</div>
+        <div style="display: flex; flex-direction: column; align-items: flex-start; gap: 10px;">
+          <div style="display: inline-flex; align-items: center; gap: 10px; padding: 8px 20px 8px 10px; border-radius: 999px; background: rgba(255, 122, 69, 0.16); font-size: 20px; font-weight: 800; color: #ffa477;"><span style="font-size: 23px;">🍽</span> Set the table &mdash; Theo</div>
+          <div style="display: inline-flex; align-items: center; gap: 10px; padding: 8px 20px 8px 10px; border-radius: 999px; background: rgba(157, 125, 222, 0.2); font-size: 20px; font-weight: 800; color: #bda3ee;"><span style="font-size: 23px;">🦴</span> Feed Biscuit &mdash; Mia</div>
+        </div>
+      </div>
+      <div>
+        <div style="font-size: 14px; font-weight: 800; text-transform: uppercase; letter-spacing: 0.1em; color: #93816f; margin-bottom: 13px;">Coming up</div>
+        <div style="display: flex; flex-direction: column; gap: 10px;">
+          <div style="display: flex; align-items: center; gap: 12px; font-size: 19px; color: #cbb9a7;"><span style="font-size: 21px;">🎂</span> <span><strong style="color: #f6efe7; font-weight: 800;">12 days</strong> until Mia&rsquo;s birthday</span></div>
+          <div style="display: flex; align-items: center; gap: 12px; font-size: 19px; color: #cbb9a7;"><span style="font-size: 21px;">🚂</span> <span><strong style="color: #f6efe7; font-weight: 800;">45 days</strong> until Grandma &amp; Grandad visit</span></div>
+          <div style="display: flex; align-items: center; gap: 12px; font-size: 19px; color: #cbb9a7;"><span style="font-size: 21px;">🎄</span> <span><strong style="color: #f6efe7; font-weight: 800;">113 days</strong> until Christmas</span></div>
+        </div>
+      </div>
+    </div>
+
+  </div>
+
+  <div style="background: #241c17; border-radius: 16px; padding: 18px 24px; font-size: 19px; line-height: 1.5; color: #cbb9a7; flex-shrink: 0;">Micropachycephalosaurus is the longest dinosaur name there is &mdash; 23 letters for an animal about the size of a turkey.</div>
+
+</div>
+</x-dc>
+</body>
+</html>

--- a/design/board-ui/Pi.dc.html
+++ b/design/board-ui/Pi.dc.html
@@ -1,0 +1,77 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800&display=swap">
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: 'Nunito', system-ui, -apple-system, sans-serif; background: #ffffff; color: #2d2319; -webkit-font-smoothing: antialiased; }
+    a { color: #e85d24; text-decoration: none; }
+    a:hover { color: #c44d1a; }
+  </style>
+</helmet>
+
+<div style="width: 800px; height: 480px; background: #ffffff; padding: 22px 28px; display: flex; flex-direction: column; gap: 16px; overflow: hidden;">
+
+  <div style="display: flex; align-items: baseline; justify-content: space-between; flex-shrink: 0;">
+    <div style="font-size: 12px; font-weight: 800; text-transform: uppercase; letter-spacing: 0.09em; color: #e85d24;">The Wilsons</div>
+    <div style="font-size: 14px; font-weight: 700; color: #9a8677;">Thursday, 3 September</div>
+  </div>
+
+  <div style="font-size: 30px; font-weight: 800; line-height: 1.18; letter-spacing: -0.02em; flex-shrink: 0;">Ines starts nursery today &mdash; and Mia has her swimming badge.</div>
+
+  <div style="display: flex; gap: 32px; align-items: flex-start; flex-shrink: 0; flex-grow: 1;">
+
+    <div style="flex-grow: 1; flex-basis: 0;">
+      <div style="font-size: 10px; font-weight: 800; text-transform: uppercase; letter-spacing: 0.1em; color: #9a8677; margin-bottom: 9px;">Today</div>
+      <div style="display: flex; flex-direction: column; gap: 8px;">
+        <div style="display: flex; gap: 13px; align-items: baseline;">
+          <div style="font-size: 17px; font-weight: 800; color: #e85d24; width: 58px; flex-shrink: 0;">08:20</div>
+          <div style="font-size: 17px; font-weight: 700;">School run <span style="color: #9a8677; font-weight: 600;">&mdash; Mia &amp; Theo</span></div>
+        </div>
+        <div style="display: flex; gap: 13px; align-items: baseline;">
+          <div style="font-size: 17px; font-weight: 800; color: #e85d24; width: 58px; flex-shrink: 0;">09:00</div>
+          <div style="font-size: 17px; font-weight: 700;">Ines&rsquo; first morning at nursery</div>
+        </div>
+        <div style="display: flex; gap: 13px; align-items: baseline;">
+          <div style="font-size: 17px; font-weight: 800; color: #e85d24; width: 58px; flex-shrink: 0;">15:45</div>
+          <div style="font-size: 17px; font-weight: 700;">Mia&rsquo;s swimming badge test</div>
+        </div>
+        <div style="display: flex; gap: 13px; align-items: baseline;">
+          <div style="font-size: 17px; font-weight: 800; color: #e85d24; width: 58px; flex-shrink: 0;">18:30</div>
+          <div style="font-size: 17px; font-weight: 700;">Sam: parents&rsquo; evening</div>
+        </div>
+      </div>
+    </div>
+
+    <div style="width: 268px; flex-shrink: 0; display: flex; flex-direction: column; gap: 15px;">
+      <div>
+        <div style="font-size: 10px; font-weight: 800; text-transform: uppercase; letter-spacing: 0.1em; color: #9a8677; margin-bottom: 8px;">Whose turn</div>
+        <div style="display: flex; flex-direction: column; align-items: flex-start; gap: 7px;">
+          <div style="display: inline-flex; align-items: center; gap: 7px; padding: 5px 13px 5px 7px; border-radius: 999px; background: rgba(232, 93, 36, 0.1); font-size: 13px; font-weight: 800; color: #c44d1a;"><span style="font-size: 15px;">🍽</span> Set the table &mdash; Theo</div>
+          <div style="display: inline-flex; align-items: center; gap: 7px; padding: 5px 13px 5px 7px; border-radius: 999px; background: rgba(124, 92, 191, 0.1); font-size: 13px; font-weight: 800; color: #6b4fa8;"><span style="font-size: 15px;">🦴</span> Feed Biscuit &mdash; Mia</div>
+        </div>
+      </div>
+      <div>
+        <div style="font-size: 10px; font-weight: 800; text-transform: uppercase; letter-spacing: 0.1em; color: #9a8677; margin-bottom: 8px;">Coming up</div>
+        <div style="display: flex; flex-direction: column; gap: 6px;">
+          <div style="display: flex; align-items: center; gap: 8px; font-size: 13px; color: #5c4a3a;"><span style="font-size: 14px;">🎂</span> <span><strong style="color: #2d2319; font-weight: 800;">12 days</strong> until Mia&rsquo;s birthday</span></div>
+          <div style="display: flex; align-items: center; gap: 8px; font-size: 13px; color: #5c4a3a;"><span style="font-size: 14px;">🚂</span> <span><strong style="color: #2d2319; font-weight: 800;">45 days</strong> until Grandma visits</span></div>
+          <div style="display: flex; align-items: center; gap: 8px; font-size: 13px; color: #5c4a3a;"><span style="font-size: 14px;">🎄</span> <span><strong style="color: #2d2319; font-weight: 800;">113 days</strong> until Christmas</span></div>
+        </div>
+      </div>
+    </div>
+
+  </div>
+
+  <div style="background: #fff5ec; border-radius: 12px; padding: 12px 16px; font-size: 13px; line-height: 1.5; color: #5c4a3a; flex-shrink: 0;">Micropachycephalosaurus is the longest dinosaur name there is &mdash; 23 letters for an animal about the size of a turkey.</div>
+
+</div>
+</x-dc>
+</body>
+</html>

--- a/design/board-ui/PiDark.dc.html
+++ b/design/board-ui/PiDark.dc.html
@@ -1,0 +1,77 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800&display=swap">
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: 'Nunito', system-ui, -apple-system, sans-serif; background: #17120f; color: #f6efe7; -webkit-font-smoothing: antialiased; }
+    a { color: #ff7a45; text-decoration: none; }
+    a:hover { color: #ffa477; }
+  </style>
+</helmet>
+
+<div style="width: 800px; height: 480px; background: #17120f; padding: 22px 28px; display: flex; flex-direction: column; gap: 16px; overflow: hidden;">
+
+  <div style="display: flex; align-items: baseline; justify-content: space-between; flex-shrink: 0;">
+    <div style="font-size: 12px; font-weight: 800; text-transform: uppercase; letter-spacing: 0.09em; color: #ff7a45;">The Wilsons</div>
+    <div style="font-size: 14px; font-weight: 700; color: #93816f;">Thursday, 3 September</div>
+  </div>
+
+  <div style="font-size: 30px; font-weight: 800; line-height: 1.18; letter-spacing: -0.02em; flex-shrink: 0;">Ines starts nursery today &mdash; and Mia has her swimming badge.</div>
+
+  <div style="display: flex; gap: 32px; align-items: flex-start; flex-shrink: 0; flex-grow: 1;">
+
+    <div style="flex-grow: 1; flex-basis: 0;">
+      <div style="font-size: 10px; font-weight: 800; text-transform: uppercase; letter-spacing: 0.1em; color: #93816f; margin-bottom: 9px;">Today</div>
+      <div style="display: flex; flex-direction: column; gap: 8px;">
+        <div style="display: flex; gap: 13px; align-items: baseline;">
+          <div style="font-size: 17px; font-weight: 800; color: #ff7a45; width: 58px; flex-shrink: 0;">08:20</div>
+          <div style="font-size: 17px; font-weight: 700;">School run <span style="color: #93816f; font-weight: 600;">&mdash; Mia &amp; Theo</span></div>
+        </div>
+        <div style="display: flex; gap: 13px; align-items: baseline;">
+          <div style="font-size: 17px; font-weight: 800; color: #ff7a45; width: 58px; flex-shrink: 0;">09:00</div>
+          <div style="font-size: 17px; font-weight: 700;">Ines&rsquo; first morning at nursery</div>
+        </div>
+        <div style="display: flex; gap: 13px; align-items: baseline;">
+          <div style="font-size: 17px; font-weight: 800; color: #ff7a45; width: 58px; flex-shrink: 0;">15:45</div>
+          <div style="font-size: 17px; font-weight: 700;">Mia&rsquo;s swimming badge test</div>
+        </div>
+        <div style="display: flex; gap: 13px; align-items: baseline;">
+          <div style="font-size: 17px; font-weight: 800; color: #ff7a45; width: 58px; flex-shrink: 0;">18:30</div>
+          <div style="font-size: 17px; font-weight: 700;">Sam: parents&rsquo; evening</div>
+        </div>
+      </div>
+    </div>
+
+    <div style="width: 268px; flex-shrink: 0; display: flex; flex-direction: column; gap: 15px;">
+      <div>
+        <div style="font-size: 10px; font-weight: 800; text-transform: uppercase; letter-spacing: 0.1em; color: #93816f; margin-bottom: 8px;">Whose turn</div>
+        <div style="display: flex; flex-direction: column; align-items: flex-start; gap: 7px;">
+          <div style="display: inline-flex; align-items: center; gap: 7px; padding: 5px 13px 5px 7px; border-radius: 999px; background: rgba(255, 122, 69, 0.16); font-size: 13px; font-weight: 800; color: #ffa477;"><span style="font-size: 15px;">🍽</span> Set the table &mdash; Theo</div>
+          <div style="display: inline-flex; align-items: center; gap: 7px; padding: 5px 13px 5px 7px; border-radius: 999px; background: rgba(157, 125, 222, 0.2); font-size: 13px; font-weight: 800; color: #bda3ee;"><span style="font-size: 15px;">🦴</span> Feed Biscuit &mdash; Mia</div>
+        </div>
+      </div>
+      <div>
+        <div style="font-size: 10px; font-weight: 800; text-transform: uppercase; letter-spacing: 0.1em; color: #93816f; margin-bottom: 8px;">Coming up</div>
+        <div style="display: flex; flex-direction: column; gap: 6px;">
+          <div style="display: flex; align-items: center; gap: 8px; font-size: 13px; color: #cbb9a7;"><span style="font-size: 14px;">🎂</span> <span><strong style="color: #f6efe7; font-weight: 800;">12 days</strong> until Mia&rsquo;s birthday</span></div>
+          <div style="display: flex; align-items: center; gap: 8px; font-size: 13px; color: #cbb9a7;"><span style="font-size: 14px;">🚂</span> <span><strong style="color: #f6efe7; font-weight: 800;">45 days</strong> until Grandma visits</span></div>
+          <div style="display: flex; align-items: center; gap: 8px; font-size: 13px; color: #cbb9a7;"><span style="font-size: 14px;">🎄</span> <span><strong style="color: #f6efe7; font-weight: 800;">113 days</strong> until Christmas</span></div>
+        </div>
+      </div>
+    </div>
+
+  </div>
+
+  <div style="background: #241c17; border-radius: 12px; padding: 12px 16px; font-size: 13px; line-height: 1.5; color: #cbb9a7; flex-shrink: 0;">Micropachycephalosaurus is the longest dinosaur name there is &mdash; 23 letters for an animal about the size of a turkey.</div>
+
+</div>
+</x-dc>
+</body>
+</html>

--- a/design/board-ui/QuietDay.dc.html
+++ b/design/board-ui/QuietDay.dc.html
@@ -1,0 +1,61 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800&display=swap">
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: 'Nunito', system-ui, -apple-system, sans-serif; background: #ffffff; color: #2d2319; -webkit-font-smoothing: antialiased; }
+    a { color: #e85d24; text-decoration: none; }
+    a:hover { color: #c44d1a; }
+  </style>
+</helmet>
+
+<div style="width: 1280px; height: 720px; background: #ffffff; padding: 40px 52px; display: flex; flex-direction: column; gap: 26px; overflow: hidden;">
+
+  <div style="display: flex; align-items: baseline; justify-content: space-between; flex-shrink: 0;">
+    <div style="font-size: 17px; font-weight: 800; text-transform: uppercase; letter-spacing: 0.09em; color: #e85d24;">The Wilsons</div>
+    <div style="font-size: 20px; font-weight: 700; color: #9a8677;">Saturday, 12 September</div>
+  </div>
+
+  <div style="font-size: 48px; font-weight: 800; line-height: 1.18; letter-spacing: -0.02em; flex-shrink: 0;">Nothing booked in all day.</div>
+
+  <div style="display: flex; gap: 52px; align-items: stretch; flex-shrink: 0; flex-grow: 1;">
+
+    <div style="flex-grow: 1; flex-basis: 0; background: #fff5ec; border-radius: 18px; padding: 30px 34px; display: flex; flex-direction: column; justify-content: center; gap: 9px;">
+      <div style="font-size: 14px; font-weight: 800; text-transform: uppercase; letter-spacing: 0.1em; color: #c4b3a3;">Today</div>
+      <div style="font-size: 32px; font-weight: 800; color: #5c4a3a; line-height: 1.25;">The calendar is empty.</div>
+      <div style="font-size: 19px; color: #9a8677; line-height: 1.45;">Nothing from either calendar between now and bedtime.</div>
+    </div>
+
+    <div style="width: 430px; flex-shrink: 0; display: flex; flex-direction: column; gap: 24px;">
+      <div>
+        <div style="font-size: 14px; font-weight: 800; text-transform: uppercase; letter-spacing: 0.1em; color: #9a8677; margin-bottom: 13px;">Whose turn</div>
+        <div style="display: flex; flex-direction: column; align-items: flex-start; gap: 10px;">
+          <div style="display: inline-flex; align-items: center; gap: 10px; padding: 8px 20px 8px 10px; border-radius: 999px; background: rgba(232, 93, 36, 0.1); font-size: 20px; font-weight: 800; color: #c44d1a;"><span style="font-size: 23px;">🍽</span> Set the table &mdash; Ines</div>
+          <div style="display: inline-flex; align-items: center; gap: 10px; padding: 8px 20px 8px 10px; border-radius: 999px; background: rgba(124, 92, 191, 0.1); font-size: 20px; font-weight: 800; color: #6b4fa8;"><span style="font-size: 23px;">🦴</span> Feed Biscuit &mdash; Theo</div>
+        </div>
+      </div>
+      <div>
+        <div style="font-size: 14px; font-weight: 800; text-transform: uppercase; letter-spacing: 0.1em; color: #9a8677; margin-bottom: 13px;">Coming up</div>
+        <div style="display: flex; flex-direction: column; gap: 10px;">
+          <div style="display: flex; align-items: center; gap: 12px; font-size: 19px; color: #5c4a3a;"><span style="font-size: 21px;">🎂</span> <span><strong style="color: #e85d24; font-weight: 800;">3 days</strong> until Mia&rsquo;s birthday</span></div>
+          <div style="display: flex; align-items: center; gap: 12px; font-size: 19px; color: #5c4a3a;"><span style="font-size: 21px;">🚂</span> <span><strong style="color: #2d2319; font-weight: 800;">36 days</strong> until Grandma &amp; Grandad visit</span></div>
+          <div style="display: flex; align-items: center; gap: 12px; font-size: 19px; color: #5c4a3a;"><span style="font-size: 21px;">🎄</span> <span><strong style="color: #2d2319; font-weight: 800;">104 days</strong> until Christmas</span></div>
+        </div>
+      </div>
+    </div>
+
+  </div>
+
+  <div style="background: #fff5ec; border-radius: 16px; padding: 18px 24px; font-size: 19px; line-height: 1.5; color: #5c4a3a; flex-shrink: 0;">Build the tallest cushion tower that stays up for ten seconds. Biscuit judges.</div>
+
+</div>
+</x-dc>
+</body>
+</html>

--- a/design/board-ui/Stale.dc.html
+++ b/design/board-ui/Stale.dc.html
@@ -1,0 +1,88 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800&display=swap">
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: 'Nunito', system-ui, -apple-system, sans-serif; background: #ffffff; color: #2d2319; -webkit-font-smoothing: antialiased; }
+    a { color: #e85d24; text-decoration: none; }
+    a:hover { color: #c44d1a; }
+  </style>
+</helmet>
+
+<div style="width: 1280px; height: 720px; background: #ffffff; display: flex; flex-direction: column; overflow: hidden;">
+
+  <div style="display: flex; align-items: center; gap: 12px; background: #fdf6e7; padding: 13px 52px; flex-shrink: 0;">
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#b45309" stroke-width="2.1" stroke-linecap="round" style="flex-shrink: 0;"><circle cx="12" cy="12" r="9"></circle><path d="M12 7.6v5"></path><path d="M12 16.2h.01"></path></svg>
+    <div style="font-size: 16px; font-weight: 700; color: #b45309;">This morning's brief didn't arrive. Times, chores and countdowns are today's &mdash; only the written line is yesterday's.</div>
+  </div>
+
+  <div style="flex-grow: 1; padding: 30px 52px 40px; display: flex; flex-direction: column; gap: 26px; overflow: hidden;">
+
+  <div style="display: flex; align-items: baseline; justify-content: space-between; flex-shrink: 0;">
+    <div style="font-size: 17px; font-weight: 800; text-transform: uppercase; letter-spacing: 0.09em; color: #e85d24;">The Wilsons</div>
+    <div style="font-size: 20px; font-weight: 700; color: #9a8677;">Thursday, 3 September</div>
+  </div>
+
+  <div style="font-size: 48px; font-weight: 800; line-height: 1.18; letter-spacing: -0.02em; flex-shrink: 0;">Four things on today, starting at 08:20.</div>
+
+  <div style="display: flex; gap: 52px; align-items: flex-start; flex-shrink: 0; flex-grow: 1;">
+
+    <div style="flex-grow: 1; flex-basis: 0;">
+      <div style="font-size: 14px; font-weight: 800; text-transform: uppercase; letter-spacing: 0.1em; color: #9a8677; margin-bottom: 16px;">Today</div>
+      <div style="display: flex; flex-direction: column; gap: 14px;">
+        <div style="display: flex; gap: 20px; align-items: baseline;">
+          <div style="font-size: 26px; font-weight: 800; color: #e85d24; width: 92px; flex-shrink: 0;">08:20</div>
+          <div style="font-size: 26px; font-weight: 700;">School run <span style="color: #9a8677; font-weight: 600;">&mdash; Mia &amp; Theo</span></div>
+        </div>
+        <div style="display: flex; gap: 20px; align-items: baseline;">
+          <div style="font-size: 26px; font-weight: 800; color: #e85d24; width: 92px; flex-shrink: 0;">09:00</div>
+          <div style="font-size: 26px; font-weight: 700;">Ines&rsquo; first morning at nursery</div>
+        </div>
+        <div style="display: flex; gap: 20px; align-items: baseline;">
+          <div style="font-size: 26px; font-weight: 800; color: #e85d24; width: 92px; flex-shrink: 0;">15:45</div>
+          <div style="font-size: 26px; font-weight: 700;">Mia&rsquo;s swimming badge test</div>
+        </div>
+        <div style="display: flex; gap: 20px; align-items: baseline;">
+          <div style="font-size: 26px; font-weight: 800; color: #e85d24; width: 92px; flex-shrink: 0;">18:30</div>
+          <div style="font-size: 26px; font-weight: 700;">Sam: parents&rsquo; evening <span style="color: #9a8677; font-weight: 600;">&mdash; online</span></div>
+        </div>
+      </div>
+    </div>
+
+    <div style="width: 430px; flex-shrink: 0; display: flex; flex-direction: column; gap: 24px;">
+      <div>
+        <div style="font-size: 14px; font-weight: 800; text-transform: uppercase; letter-spacing: 0.1em; color: #9a8677; margin-bottom: 13px;">Whose turn</div>
+        <div style="display: flex; flex-direction: column; align-items: flex-start; gap: 10px;">
+          <div style="display: inline-flex; align-items: center; gap: 10px; padding: 8px 20px 8px 10px; border-radius: 999px; background: rgba(232, 93, 36, 0.1); font-size: 20px; font-weight: 800; color: #c44d1a;"><span style="font-size: 23px;">🍽</span> Set the table &mdash; Theo</div>
+          <div style="display: inline-flex; align-items: center; gap: 10px; padding: 8px 20px 8px 10px; border-radius: 999px; background: rgba(124, 92, 191, 0.1); font-size: 20px; font-weight: 800; color: #6b4fa8;"><span style="font-size: 23px;">🦴</span> Feed Biscuit &mdash; Mia</div>
+        </div>
+      </div>
+      <div>
+        <div style="font-size: 14px; font-weight: 800; text-transform: uppercase; letter-spacing: 0.1em; color: #9a8677; margin-bottom: 13px;">Coming up</div>
+        <div style="display: flex; flex-direction: column; gap: 10px;">
+          <div style="display: flex; align-items: center; gap: 12px; font-size: 19px; color: #5c4a3a;"><span style="font-size: 21px;">🎂</span> <span><strong style="color: #2d2319; font-weight: 800;">12 days</strong> until Mia&rsquo;s birthday</span></div>
+          <div style="display: flex; align-items: center; gap: 12px; font-size: 19px; color: #5c4a3a;"><span style="font-size: 21px;">🚂</span> <span><strong style="color: #2d2319; font-weight: 800;">45 days</strong> until Grandma &amp; Grandad visit</span></div>
+          <div style="display: flex; align-items: center; gap: 12px; font-size: 19px; color: #5c4a3a;"><span style="font-size: 21px;">🎄</span> <span><strong style="color: #2d2319; font-weight: 800;">113 days</strong> until Christmas</span></div>
+        </div>
+      </div>
+    </div>
+
+  </div>
+
+  <div style="flex-shrink: 0;">
+    <div style="font-size: 12px; font-weight: 800; text-transform: uppercase; letter-spacing: 0.1em; color: #c4b3a3; margin-bottom: 9px;">Yesterday's line</div>
+    <div style="background: #faf6f1; border-radius: 16px; padding: 18px 24px; font-size: 19px; line-height: 1.5; color: #9a8677;">Octopuses have three hearts, and two of them stop beating whenever they swim.</div>
+  </div>
+
+  </div>
+</div>
+</x-dc>
+</body>
+</html>

--- a/design/board-ui/Tablet.dc.html
+++ b/design/board-ui/Tablet.dc.html
@@ -1,0 +1,72 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800&display=swap">
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: 'Nunito', system-ui, -apple-system, sans-serif; background: #ffffff; color: #2d2319; -webkit-font-smoothing: antialiased; }
+    a { color: #e85d24; text-decoration: none; }
+    a:hover { color: #c44d1a; }
+  </style>
+</helmet>
+
+<div style="width: 1024px; height: 768px; background: #ffffff; padding: 36px 42px; display: flex; flex-direction: column; gap: 24px; overflow: hidden;">
+
+  <div style="display: flex; align-items: baseline; justify-content: space-between; flex-shrink: 0;">
+    <div style="font-size: 15px; font-weight: 800; text-transform: uppercase; letter-spacing: 0.09em; color: #e85d24;">The Wilsons</div>
+    <div style="font-size: 18px; font-weight: 700; color: #9a8677;">Thursday, 3 September</div>
+  </div>
+
+  <div style="font-size: 42px; font-weight: 800; line-height: 1.18; letter-spacing: -0.02em; flex-shrink: 0;">Ines starts nursery today &mdash; and Mia has her swimming badge.</div>
+
+  <div style="flex-grow: 1;">
+    <div style="font-size: 13px; font-weight: 800; text-transform: uppercase; letter-spacing: 0.1em; color: #9a8677; margin-bottom: 15px;">Today</div>
+    <div style="display: flex; flex-direction: column; gap: 13px;">
+      <div style="display: flex; gap: 18px; align-items: baseline;">
+        <div style="font-size: 24px; font-weight: 800; color: #e85d24; width: 84px; flex-shrink: 0;">08:20</div>
+        <div style="font-size: 24px; font-weight: 700;">School run <span style="color: #9a8677; font-weight: 600;">&mdash; Mia &amp; Theo</span></div>
+      </div>
+      <div style="display: flex; gap: 18px; align-items: baseline;">
+        <div style="font-size: 24px; font-weight: 800; color: #e85d24; width: 84px; flex-shrink: 0;">09:00</div>
+        <div style="font-size: 24px; font-weight: 700;">Ines&rsquo; first morning at nursery</div>
+      </div>
+      <div style="display: flex; gap: 18px; align-items: baseline;">
+        <div style="font-size: 24px; font-weight: 800; color: #e85d24; width: 84px; flex-shrink: 0;">15:45</div>
+        <div style="font-size: 24px; font-weight: 700;">Mia&rsquo;s swimming badge test</div>
+      </div>
+      <div style="display: flex; gap: 18px; align-items: baseline;">
+        <div style="font-size: 24px; font-weight: 800; color: #e85d24; width: 84px; flex-shrink: 0;">18:30</div>
+        <div style="font-size: 24px; font-weight: 700;">Sam: parents&rsquo; evening <span style="color: #9a8677; font-weight: 600;">&mdash; online</span></div>
+      </div>
+    </div>
+  </div>
+
+  <div style="flex-shrink: 0;">
+    <div style="font-size: 13px; font-weight: 800; text-transform: uppercase; letter-spacing: 0.1em; color: #9a8677; margin-bottom: 12px;">Whose turn</div>
+    <div style="display: flex; flex-wrap: wrap; gap: 10px;">
+      <div style="display: inline-flex; align-items: center; gap: 9px; padding: 7px 18px 7px 9px; border-radius: 999px; background: rgba(232, 93, 36, 0.1); font-size: 18px; font-weight: 800; color: #c44d1a;"><span style="font-size: 21px;">🍽</span> Set the table &mdash; Theo</div>
+      <div style="display: inline-flex; align-items: center; gap: 9px; padding: 7px 18px 7px 9px; border-radius: 999px; background: rgba(124, 92, 191, 0.1); font-size: 18px; font-weight: 800; color: #6b4fa8;"><span style="font-size: 21px;">🦴</span> Feed Biscuit &mdash; Mia</div>
+    </div>
+  </div>
+
+  <div style="flex-shrink: 0;">
+    <div style="font-size: 13px; font-weight: 800; text-transform: uppercase; letter-spacing: 0.1em; color: #9a8677; margin-bottom: 12px;">Coming up</div>
+    <div style="display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 9px 32px;">
+      <div style="display: flex; align-items: center; gap: 10px; font-size: 18px; color: #5c4a3a;"><span style="font-size: 20px;">🎂</span> <span><strong style="color: #2d2319; font-weight: 800;">12 days</strong> until Mia&rsquo;s birthday</span></div>
+      <div style="display: flex; align-items: center; gap: 10px; font-size: 18px; color: #5c4a3a;"><span style="font-size: 20px;">🚂</span> <span><strong style="color: #2d2319; font-weight: 800;">45 days</strong> until Grandma visits</span></div>
+      <div style="display: flex; align-items: center; gap: 10px; font-size: 18px; color: #5c4a3a;"><span style="font-size: 20px;">🎄</span> <span><strong style="color: #2d2319; font-weight: 800;">113 days</strong> until Christmas</span></div>
+    </div>
+  </div>
+
+  <div style="background: #fff5ec; border-radius: 14px; padding: 16px 20px; font-size: 17px; line-height: 1.5; color: #5c4a3a; flex-shrink: 0;">Micropachycephalosaurus is the longest dinosaur name there is &mdash; 23 letters for an animal about the size of a turkey.</div>
+
+</div>
+</x-dc>
+</body>
+</html>

--- a/design/board-ui/canvas.json
+++ b/design/board-ui/canvas.json
@@ -1,0 +1,19 @@
+{
+  "artboards": [
+    { "file": "Main.dc.html",     "x": 0,    "y": 0,    "w": 1280, "h": 720, "title": "TV — light — 1280×720" },
+    { "file": "MainDark.dc.html", "x": 1360, "y": 0,    "w": 1280, "h": 720, "title": "TV — dark" },
+    { "file": "Tablet.dc.html",   "x": 2720, "y": 0,    "w": 1024, "h": 768, "title": "Old iPad — 1024×768" },
+    { "file": "Pi.dc.html",       "x": 0,    "y": 900,  "w": 800,  "h": 480, "title": "Pi display — light — 800×480" },
+    { "file": "PiDark.dc.html",   "x": 880,  "y": 900,  "w": 800,  "h": 480, "title": "Pi display — dark" },
+    { "file": "Stale.dc.html",    "x": 1760, "y": 900,  "w": 1280, "h": 720, "title": "State — brief didn't arrive" },
+    { "file": "QuietDay.dc.html", "x": 0,    "y": 1740, "w": 1280, "h": 720, "title": "State — nothing on" },
+    { "file": "FirstRun.dc.html", "x": 1360, "y": 1740, "w": 1280, "h": 720, "title": "State — first board" }
+  ],
+  "annotations": [
+    { "id": "intro", "x": 0, "y": -230, "w": 940, "text": "DinkyDash — the board itself\n\nNo person cards, no ages: the agenda is the board now, at 26px so it reads across a kitchen. The three prose boxes are one box carrying whatever the generator wrote that day — a fact here, a challenge on the quiet-day artboard." },
+    { "id": "theme-note", "x": 1360, "y": 760, "w": 620, "text": "Dark is a full palette swap, not a filter: warm near-black #17120f, the accent lifted to #ff7a45 so it still carries on a dark ground, and the chore-pill tints raised to stay visible. Chosen in Settings → Screen link." },
+    { "id": "layout-note", "x": 0, "y": 1420, "w": 800, "text": "Wide and short (TV, Pi) gets two columns — agenda left, chores and countdowns right. Tall (iPad, 4:3) keeps one column. That is a real breakpoint at roughly 1.5:1, not the vmin scaling the template does today." },
+    { "id": "stale-note", "x": 1760, "y": 1660, "w": 620, "text": "Ages, countdowns, chore rotation and the agenda are computed, not written — right even when generation fails. Only the one prose line is stale, so only it is marked, and the AI headline gives way to a computed one." }
+  ],
+  "launch": { "view": "canvas" }
+}

--- a/design/settings-ui/Account.dc.html
+++ b/design/settings-ui/Account.dc.html
@@ -1,0 +1,92 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800&display=swap">
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: 'Nunito', system-ui, -apple-system, sans-serif; background: #fffaf5; color: #2d2319; line-height: 1.5; -webkit-font-smoothing: antialiased; }
+    a { color: #e85d24; text-decoration: none; }
+    a:hover { color: #c44d1a; }
+  </style>
+</helmet>
+
+<div style="width: 390px; height: 844px; background: #fffaf5; display: flex; flex-direction: column; overflow: hidden;">
+
+  <div style="display: flex; align-items: center; gap: 4px; height: 56px; padding: 0 12px; border-bottom: 1px solid #f0e6da; flex-shrink: 0;">
+    <div style="display: flex; align-items: center; justify-content: center; width: 44px; height: 44px; margin-left: -10px;">
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="#5c4a3a" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"></polyline></svg>
+    </div>
+    <div style="font-size: 1.0625rem; font-weight: 800; letter-spacing: -0.01em; flex-grow: 1;">Account</div>
+  </div>
+
+  <div style="flex-grow: 1; padding: 16px; display: flex; flex-direction: column; gap: 16px; overflow: hidden;">
+
+    <div style="background: rgba(124, 92, 191, 0.07); border: 1.5px solid rgba(124, 92, 191, 0.22); border-radius: 16px; padding: 15px; display: flex; flex-direction: column; gap: 12px;">
+      <div style="display: flex; align-items: center; gap: 10px;">
+        <div style="padding: 3px 10px; border-radius: 999px; background: #7c5cbf; font-size: 0.6875rem; font-weight: 800; color: #ffffff; letter-spacing: 0.03em;">TRIAL</div>
+        <div style="font-size: 0.9375rem; font-weight: 800; color: #5b3f96;">9 days left</div>
+      </div>
+      <div style="font-size: 0.8125rem; color: #5c4a3a; line-height: 1.55;">After that it's $5 a month, or $39 a year. Add a card whenever &mdash; nothing is charged until the trial runs out.</div>
+      <div style="display: flex; align-items: center; justify-content: center; height: 46px; background: #7c5cbf; color: #ffffff; border-radius: 12px; font-weight: 700; font-size: 0.9375rem;">Add a payment method</div>
+    </div>
+
+    <div>
+      <div style="font-size: 0.6875rem; font-weight: 800; letter-spacing: 0.08em; text-transform: uppercase; color: #9a8677; padding: 0 4px 8px;">Your family</div>
+      <div style="background: #ffffff; border: 1px solid #f0e6da; border-radius: 16px; overflow: hidden;">
+        <div style="display: flex; align-items: center; gap: 12px; padding: 12px 14px; min-height: 60px;">
+          <div style="flex-grow: 1;">
+            <div style="font-size: 0.75rem; color: #9a8677;">Name on the board</div>
+            <div style="font-size: 0.9375rem; font-weight: 700;">The Wilsons</div>
+          </div>
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#c4b3a3" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"></polyline></svg>
+        </div>
+        <div style="display: flex; align-items: center; gap: 12px; padding: 12px 14px; min-height: 60px; border-top: 1px solid #f0e6da;">
+          <div style="flex-grow: 1;">
+            <div style="font-size: 0.75rem; color: #9a8677;">Time zone &mdash; the board is rewritten at 4:30 am here</div>
+            <div style="font-size: 0.9375rem; font-weight: 700;">Europe/Berlin</div>
+          </div>
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#c4b3a3" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"></polyline></svg>
+        </div>
+        <div style="display: flex; align-items: center; gap: 12px; padding: 12px 14px; min-height: 60px; border-top: 1px solid #f0e6da;">
+          <div style="flex-grow: 1;">
+            <div style="font-size: 0.75rem; color: #9a8677;">Where you live &mdash; used for local touches</div>
+            <div style="font-size: 0.9375rem; font-weight: 700;">Berlin, Germany</div>
+          </div>
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#c4b3a3" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"></polyline></svg>
+        </div>
+      </div>
+    </div>
+
+    <div>
+      <div style="font-size: 0.6875rem; font-weight: 800; letter-spacing: 0.08em; text-transform: uppercase; color: #9a8677; padding: 0 4px 8px;">Signing in</div>
+      <div style="background: #ffffff; border: 1px solid #f0e6da; border-radius: 16px; padding: 12px 14px;">
+        <div style="font-size: 0.9375rem; font-weight: 700;">sam@example.com</div>
+        <div style="font-size: 0.75rem; color: #9a8677; line-height: 1.5; margin-top: 3px;">We email a sign-in link each time &mdash; there's no password to forget.</div>
+      </div>
+    </div>
+
+    <div>
+      <div style="font-size: 0.6875rem; font-weight: 800; letter-spacing: 0.08em; text-transform: uppercase; color: #9a8677; padding: 0 4px 8px;">Your data</div>
+      <div style="background: #ffffff; border: 1px solid #f0e6da; border-radius: 16px; overflow: hidden;">
+        <div style="display: flex; align-items: center; gap: 12px; padding: 14px; min-height: 54px;">
+          <div style="flex-grow: 1; font-size: 0.9375rem; font-weight: 700;">Download everything we hold</div>
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#c4b3a3" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"></polyline></svg>
+        </div>
+        <div style="display: flex; align-items: center; gap: 12px; padding: 14px; min-height: 54px; border-top: 1px solid #f0e6da;">
+          <div style="flex-grow: 1; font-size: 0.9375rem; font-weight: 700; color: #c0392b;">Delete the family and all its data</div>
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#e0a99f" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"></polyline></svg>
+        </div>
+      </div>
+    </div>
+
+  </div>
+</div>
+</x-dc>
+</body>
+</html>

--- a/design/settings-ui/AddCalendar.dc.html
+++ b/design/settings-ui/AddCalendar.dc.html
@@ -1,0 +1,78 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800&display=swap">
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: 'Nunito', system-ui, -apple-system, sans-serif; background: #fffaf5; color: #2d2319; line-height: 1.5; -webkit-font-smoothing: antialiased; }
+    a { color: #e85d24; text-decoration: none; }
+    a:hover { color: #c44d1a; }
+  </style>
+</helmet>
+
+<div style="width: 390px; height: 844px; background: #fffaf5; display: flex; flex-direction: column; overflow: hidden;">
+
+  <div style="display: flex; align-items: center; height: 56px; padding: 0 14px; border-bottom: 1px solid #f0e6da; flex-shrink: 0;">
+    <div style="font-size: 0.9375rem; font-weight: 700; color: #9a8677; width: 62px;">Cancel</div>
+    <div style="font-size: 1.0625rem; font-weight: 800; letter-spacing: -0.01em; flex-grow: 1; text-align: center;">Add a calendar</div>
+    <div style="font-size: 0.9375rem; font-weight: 800; color: #e85d24; width: 62px; text-align: right;">Add</div>
+  </div>
+
+  <div style="flex-grow: 1; padding: 16px; display: flex; flex-direction: column; gap: 15px; overflow: hidden;">
+
+    <div>
+      <div style="font-size: 0.6875rem; font-weight: 800; letter-spacing: 0.08em; text-transform: uppercase; color: #9a8677; padding: 0 4px 8px;">Where does it live?</div>
+      <div style="display: flex; gap: 8px;">
+        <div style="flex-grow: 1; height: 46px; border-radius: 12px; border: 2px solid #e85d24; background: rgba(232, 93, 36, 0.06); display: flex; align-items: center; justify-content: center; font-size: 0.875rem; font-weight: 800; color: #c44d1a;">Google</div>
+        <div style="flex-grow: 1; height: 46px; border-radius: 12px; border: 1.5px solid #f0e6da; background: #ffffff; display: flex; align-items: center; justify-content: center; font-size: 0.875rem; font-weight: 700; color: #5c4a3a;">iCloud</div>
+        <div style="flex-grow: 1; height: 46px; border-radius: 12px; border: 1.5px solid #f0e6da; background: #ffffff; display: flex; align-items: center; justify-content: center; font-size: 0.875rem; font-weight: 700; color: #5c4a3a;">Outlook</div>
+        <div style="flex-grow: 1; height: 46px; border-radius: 12px; border: 1.5px solid #f0e6da; background: #ffffff; display: flex; align-items: center; justify-content: center; font-size: 0.875rem; font-weight: 700; color: #5c4a3a;">Other</div>
+      </div>
+    </div>
+
+    <div style="background: #ffffff; border: 1px solid #f0e6da; border-radius: 16px; padding: 15px; display: flex; flex-direction: column; gap: 10px;">
+      <div style="font-size: 0.8125rem; font-weight: 800; color: #2d2319;">Finding the link in Google Calendar</div>
+      <div style="display: flex; gap: 10px;">
+        <div style="width: 19px; height: 19px; border-radius: 50%; background: #fff5ec; display: flex; align-items: center; justify-content: center; font-size: 0.625rem; font-weight: 800; color: #9a8677; flex-shrink: 0; margin-top: 2px;">1</div>
+        <div style="font-size: 0.8125rem; color: #5c4a3a; line-height: 1.5;">Open Google Calendar on a computer &mdash; this isn't in the phone app.</div>
+      </div>
+      <div style="display: flex; gap: 10px;">
+        <div style="width: 19px; height: 19px; border-radius: 50%; background: #fff5ec; display: flex; align-items: center; justify-content: center; font-size: 0.625rem; font-weight: 800; color: #9a8677; flex-shrink: 0; margin-top: 2px;">2</div>
+        <div style="font-size: 0.8125rem; color: #5c4a3a; line-height: 1.5;">Hover the calendar in the left sidebar &rarr; <strong style="color: #2d2319;">Settings and sharing</strong>.</div>
+      </div>
+      <div style="display: flex; gap: 10px;">
+        <div style="width: 19px; height: 19px; border-radius: 50%; background: #fff5ec; display: flex; align-items: center; justify-content: center; font-size: 0.625rem; font-weight: 800; color: #9a8677; flex-shrink: 0; margin-top: 2px;">3</div>
+        <div style="font-size: 0.8125rem; color: #5c4a3a; line-height: 1.5;">Scroll to <strong style="color: #2d2319;">Secret address in iCal format</strong> and copy it.</div>
+      </div>
+    </div>
+
+    <div>
+      <div style="font-size: 0.6875rem; font-weight: 800; letter-spacing: 0.08em; text-transform: uppercase; color: #9a8677; padding: 0 4px 8px;">Paste it here</div>
+      <div style="min-height: 48px; border: 2px solid #16a34a; border-radius: 12px; background: #ffffff; padding: 12px 14px; font-size: 0.8125rem; color: #5c4a3a; line-height: 1.45; word-break: break-all;">https://calendar.google.com/calendar/ical/sam%40gmail.com/private-8f3c1a/basic.ics</div>
+      <div style="display: flex; gap: 10px; background: rgba(22, 163, 74, 0.07); border-radius: 12px; padding: 12px 14px; margin-top: 8px;">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#15803d" stroke-width="2.3" stroke-linecap="round" stroke-linejoin="round" style="flex-shrink: 0; margin-top: 1px;"><circle cx="12" cy="12" r="9"></circle><polyline points="8 12.4 11 15.4 16 9.4"></polyline></svg>
+        <div style="font-size: 0.8125rem; color: #15803d; line-height: 1.5;"><strong>24 events over the next fortnight.</strong><br><span style="color: #5c4a3a;">First one: School run, tomorrow at 8:20 am.</span></div>
+      </div>
+    </div>
+
+    <div>
+      <div style="font-size: 0.6875rem; font-weight: 800; letter-spacing: 0.08em; text-transform: uppercase; color: #9a8677; padding: 0 4px 8px;">Call it</div>
+      <div style="height: 48px; border: 1.5px solid #f0e6da; border-radius: 12px; background: #ffffff; padding: 0 14px; display: flex; align-items: center; font-size: 0.9375rem; font-weight: 600;">Sam's Google</div>
+    </div>
+
+    <div style="background: #fff5ec; border-radius: 14px; padding: 13px 15px; display: flex; gap: 11px;">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#9a8677" stroke-width="1.9" stroke-linecap="round" style="flex-shrink: 0; margin-top: 2px;"><rect x="4.5" y="10.5" width="15" height="9.5" rx="2.2"></rect><path d="M8 10.5V7.6a4 4 0 0 1 8 0v2.9"></path></svg>
+      <div style="font-size: 0.8125rem; color: #5c4a3a; line-height: 1.55;">That secret address lets anyone read the calendar, so don't share it around. You can revoke it from Google at any time.</div>
+    </div>
+
+  </div>
+</div>
+</x-dc>
+</body>
+</html>

--- a/design/settings-ui/Calendars.dc.html
+++ b/design/settings-ui/Calendars.dc.html
@@ -1,0 +1,90 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800&display=swap">
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: 'Nunito', system-ui, -apple-system, sans-serif; background: #fffaf5; color: #2d2319; line-height: 1.5; -webkit-font-smoothing: antialiased; }
+    a { color: #e85d24; text-decoration: none; }
+    a:hover { color: #c44d1a; }
+  </style>
+</helmet>
+
+<div style="width: 390px; height: 844px; background: #fffaf5; display: flex; flex-direction: column; overflow: hidden;">
+
+  <div style="display: flex; align-items: center; gap: 4px; height: 56px; padding: 0 12px; border-bottom: 1px solid #f0e6da; flex-shrink: 0;">
+    <div style="display: flex; align-items: center; justify-content: center; width: 44px; height: 44px; margin-left: -10px;">
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="#5c4a3a" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"></polyline></svg>
+    </div>
+    <div style="font-size: 1.0625rem; font-weight: 800; letter-spacing: -0.01em; flex-grow: 1;">Calendars</div>
+  </div>
+
+  <div style="flex-grow: 1; padding: 16px; display: flex; flex-direction: column; gap: 12px; overflow: hidden;">
+
+    <div style="background: #ffffff; border: 1px solid #f0e6da; border-radius: 16px; padding: 14px; display: flex; align-items: flex-start; gap: 12px;">
+      <div style="flex-grow: 1;">
+        <div style="font-size: 0.9375rem; font-weight: 800;">Sam's Google</div>
+        <div style="font-size: 0.75rem; color: #c4b3a3; margin-top: 1px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 245px;">calendar.google.com/&hellip;/basic.ics</div>
+        <div style="display: flex; align-items: center; gap: 7px; margin-top: 7px;">
+          <div style="width: 7px; height: 7px; border-radius: 50%; background: #16a34a; flex-shrink: 0;"></div>
+          <div style="font-size: 0.8125rem; color: #5c4a3a;">24 events &middot; checked 4:31 am</div>
+        </div>
+      </div>
+      <div style="width: 48px; height: 28px; border-radius: 999px; background: #e85d24; padding: 3px; display: flex; justify-content: flex-end; flex-shrink: 0;">
+        <div style="width: 22px; height: 22px; border-radius: 50%; background: #ffffff; box-shadow: 0 1px 3px rgba(45, 35, 25, 0.3);"></div>
+      </div>
+    </div>
+
+    <div style="background: #ffffff; border: 1.5px solid #f4d9a8; border-radius: 16px; padding: 14px; display: flex; flex-direction: column; gap: 12px;">
+      <div style="display: flex; align-items: flex-start; gap: 12px;">
+        <div style="flex-grow: 1;">
+          <div style="font-size: 0.9375rem; font-weight: 800;">Alex's iCloud</div>
+          <div style="font-size: 0.75rem; color: #c4b3a3; margin-top: 1px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 245px;">p42-caldav.icloud.com/&hellip;/calendar.ics</div>
+          <div style="display: flex; align-items: center; gap: 7px; margin-top: 7px;">
+            <div style="width: 7px; height: 7px; border-radius: 50%; background: #d97706; flex-shrink: 0;"></div>
+            <div style="font-size: 0.8125rem; color: #b45309; font-weight: 700;">Nothing came back for 3 days</div>
+          </div>
+        </div>
+        <div style="width: 48px; height: 28px; border-radius: 999px; background: #e85d24; padding: 3px; display: flex; justify-content: flex-end; flex-shrink: 0;">
+          <div style="width: 22px; height: 22px; border-radius: 50%; background: #ffffff; box-shadow: 0 1px 3px rgba(45, 35, 25, 0.3);"></div>
+        </div>
+      </div>
+      <div style="background: #fdf6e7; border-radius: 11px; padding: 11px 13px; font-size: 0.8125rem; color: #5c4a3a; line-height: 1.55;">Apple regenerates this link when a calendar stops being shared. Paste a fresh one to fix it.</div>
+      <div style="display: flex; align-items: center; justify-content: center; height: 44px; border: 2px solid #f0e6da; border-radius: 12px; font-weight: 700; font-size: 0.875rem; color: #2d2319;">Replace the link</div>
+    </div>
+
+    <div style="background: #ffffff; border: 1px solid #f0e6da; border-radius: 16px; padding: 14px; display: flex; align-items: flex-start; gap: 12px; opacity: 0.62;">
+      <div style="flex-grow: 1;">
+        <div style="font-size: 0.9375rem; font-weight: 800;">School term dates</div>
+        <div style="font-size: 0.75rem; color: #c4b3a3; margin-top: 1px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 245px;">stmarys.sch.uk/calendar/term.ics</div>
+        <div style="display: flex; align-items: center; gap: 7px; margin-top: 7px;">
+          <div style="width: 7px; height: 7px; border-radius: 50%; background: #c4b3a3; flex-shrink: 0;"></div>
+          <div style="font-size: 0.8125rem; color: #9a8677;">Paused &mdash; not on the board</div>
+        </div>
+      </div>
+      <div style="width: 48px; height: 28px; border-radius: 999px; background: #e2d7c9; padding: 3px; display: flex; justify-content: flex-start; flex-shrink: 0;">
+        <div style="width: 22px; height: 22px; border-radius: 50%; background: #ffffff; box-shadow: 0 1px 3px rgba(45, 35, 25, 0.2);"></div>
+      </div>
+    </div>
+
+    <div style="display: flex; align-items: center; justify-content: center; gap: 9px; height: 52px; border: 2px dashed #e2d7c9; border-radius: 14px; font-size: 0.9375rem; font-weight: 700; color: #5c4a3a;">
+      <svg width="19" height="19" viewBox="0 0 24 24" fill="none" stroke="#5c4a3a" stroke-width="2.2" stroke-linecap="round"><path d="M12 5v14"></path><path d="M5 12h14"></path></svg>
+      Add a calendar
+    </div>
+
+    <div style="background: #fff5ec; border-radius: 14px; padding: 13px 15px; display: flex; gap: 11px;">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#9a8677" stroke-width="1.9" stroke-linecap="round" style="flex-shrink: 0; margin-top: 2px;"><rect x="4.5" y="10.5" width="15" height="9.5" rx="2.2"></rect><path d="M8 10.5V7.6a4 4 0 0 1 8 0v2.9"></path></svg>
+      <div style="font-size: 0.8125rem; color: #5c4a3a; line-height: 1.55;">Every calendar you switch on is merged into one agenda. Event titles and times are sent to Claude each morning to write the board. <span style="color: #e85d24; font-weight: 700;">What we send</span></div>
+    </div>
+
+  </div>
+</div>
+</x-dc>
+</body>
+</html>

--- a/design/settings-ui/ChoreEdit.dc.html
+++ b/design/settings-ui/ChoreEdit.dc.html
@@ -1,0 +1,115 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800&display=swap">
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: 'Nunito', system-ui, -apple-system, sans-serif; background: #fffaf5; color: #2d2319; line-height: 1.5; -webkit-font-smoothing: antialiased; }
+    a { color: #e85d24; text-decoration: none; }
+    a:hover { color: #c44d1a; }
+  </style>
+</helmet>
+
+<div style="width: 390px; height: 844px; background: #fffaf5; display: flex; flex-direction: column; overflow: hidden;">
+
+  <div style="display: flex; align-items: center; height: 56px; padding: 0 14px; border-bottom: 1px solid #f0e6da; flex-shrink: 0;">
+    <div style="font-size: 0.9375rem; font-weight: 700; color: #9a8677; width: 62px;">Cancel</div>
+    <div style="font-size: 1.0625rem; font-weight: 800; letter-spacing: -0.01em; flex-grow: 1; text-align: center;">Set the table</div>
+    <div style="font-size: 0.9375rem; font-weight: 800; color: #e85d24; width: 62px; text-align: right;">Save</div>
+  </div>
+
+  <div style="flex-grow: 1; padding: 16px; display: flex; flex-direction: column; gap: 14px; overflow: hidden;">
+
+    <div style="display: flex; gap: 10px;">
+      <div style="width: 62px; height: 62px; border-radius: 14px; border: 1.5px solid #f0e6da; background: #ffffff; display: flex; align-items: center; justify-content: center; font-size: 1.75rem; flex-shrink: 0;">🍽</div>
+      <div style="flex-grow: 1;">
+        <div style="font-size: 0.6875rem; font-weight: 800; letter-spacing: 0.07em; text-transform: uppercase; color: #9a8677; margin-bottom: 6px;">Job</div>
+        <div style="height: 48px; border: 1.5px solid #f0e6da; border-radius: 12px; background: #ffffff; padding: 0 14px; display: flex; align-items: center; font-size: 0.9375rem; font-weight: 600;">Set the table</div>
+      </div>
+    </div>
+
+    <div>
+      <div style="display: flex; align-items: baseline; justify-content: space-between; padding: 0 4px 8px;">
+        <div style="font-size: 0.6875rem; font-weight: 800; letter-spacing: 0.08em; text-transform: uppercase; color: #9a8677;">Whose turn, in order</div>
+      </div>
+      <div style="background: #ffffff; border: 1px solid #f0e6da; border-radius: 16px; overflow: hidden;">
+
+        <div style="display: flex; align-items: center; gap: 12px; padding: 10px 14px; min-height: 58px;">
+          <div style="width: 21px; height: 21px; border-radius: 50%; background: #fff5ec; display: flex; align-items: center; justify-content: center; font-size: 0.6875rem; font-weight: 800; color: #9a8677; flex-shrink: 0;">1</div>
+          <div style="width: 34px; height: 34px; border-radius: 50%; background: rgba(124, 92, 191, 0.14); display: flex; align-items: center; justify-content: center; font-size: 1.05rem; flex-shrink: 0;">🦖</div>
+          <div style="flex-grow: 1; font-size: 0.9375rem; font-weight: 700;">Mia</div>
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#c4b3a3" stroke-width="2.4" stroke-linecap="round"><path d="M8 8h.01"></path><path d="M16 8h.01"></path><path d="M8 12h.01"></path><path d="M16 12h.01"></path><path d="M8 16h.01"></path><path d="M16 16h.01"></path></svg>
+        </div>
+
+        <div style="display: flex; align-items: center; gap: 12px; padding: 10px 14px; min-height: 58px; border-top: 1px solid #f0e6da;">
+          <div style="width: 21px; height: 21px; border-radius: 50%; background: #fff5ec; display: flex; align-items: center; justify-content: center; font-size: 0.6875rem; font-weight: 800; color: #9a8677; flex-shrink: 0;">2</div>
+          <div style="width: 34px; height: 34px; border-radius: 50%; background: rgba(59, 130, 246, 0.14); display: flex; align-items: center; justify-content: center; font-size: 1.05rem; flex-shrink: 0;">⚽</div>
+          <div style="flex-grow: 1; font-size: 0.9375rem; font-weight: 700;">Theo</div>
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#c4b3a3" stroke-width="2.4" stroke-linecap="round"><path d="M8 8h.01"></path><path d="M16 8h.01"></path><path d="M8 12h.01"></path><path d="M16 12h.01"></path><path d="M8 16h.01"></path><path d="M16 16h.01"></path></svg>
+        </div>
+
+        <div style="display: flex; align-items: center; gap: 12px; padding: 10px 14px; min-height: 58px; border-top: 1px solid #f0e6da;">
+          <div style="width: 21px; height: 21px; border-radius: 50%; background: #fff5ec; display: flex; align-items: center; justify-content: center; font-size: 0.6875rem; font-weight: 800; color: #9a8677; flex-shrink: 0;">3</div>
+          <div style="width: 34px; height: 34px; border-radius: 50%; background: rgba(219, 39, 119, 0.11); display: flex; align-items: center; justify-content: center; font-size: 1.05rem; flex-shrink: 0;">🎨</div>
+          <div style="flex-grow: 1; font-size: 0.9375rem; font-weight: 700;">Ines</div>
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#c4b3a3" stroke-width="2.4" stroke-linecap="round"><path d="M8 8h.01"></path><path d="M16 8h.01"></path><path d="M8 12h.01"></path><path d="M16 12h.01"></path><path d="M8 16h.01"></path><path d="M16 16h.01"></path></svg>
+        </div>
+
+        <div style="display: flex; align-items: center; gap: 12px; padding: 10px 14px; min-height: 56px; border-top: 1px solid #f0e6da;">
+          <div style="width: 34px; height: 34px; border-radius: 50%; border: 1.5px dashed #e2d7c9; display: flex; align-items: center; justify-content: center; flex-shrink: 0; margin-left: 33px;">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#9a8677" stroke-width="2.4" stroke-linecap="round"><path d="M12 5v14"></path><path d="M5 12h14"></path></svg>
+          </div>
+          <div style="flex-grow: 1; font-size: 0.9375rem; font-weight: 700; color: #9a8677;">Add Sam</div>
+        </div>
+
+      </div>
+    </div>
+
+    <div style="background: #ffffff; border: 1px solid #f0e6da; border-radius: 16px; padding: 14px;">
+      <div style="font-size: 0.6875rem; font-weight: 800; letter-spacing: 0.08em; text-transform: uppercase; color: #9a8677; margin-bottom: 11px;">The next week</div>
+      <div style="display: flex; gap: 5px;">
+        <div style="flex-grow: 1; display: flex; flex-direction: column; align-items: center; gap: 5px; padding: 7px 0 8px; border-radius: 10px; background: #fff5ec;">
+          <div style="font-size: 0.625rem; font-weight: 800; color: #c44d1a;">TODAY</div>
+          <div style="width: 30px; height: 30px; border-radius: 50%; background: rgba(59, 130, 246, 0.14); display: flex; align-items: center; justify-content: center; font-size: 0.95rem;">⚽</div>
+        </div>
+        <div style="flex-grow: 1; display: flex; flex-direction: column; align-items: center; gap: 5px; padding: 7px 0 8px;">
+          <div style="font-size: 0.625rem; font-weight: 800; color: #9a8677;">THU</div>
+          <div style="width: 30px; height: 30px; border-radius: 50%; background: rgba(219, 39, 119, 0.11); display: flex; align-items: center; justify-content: center; font-size: 0.95rem;">🎨</div>
+        </div>
+        <div style="flex-grow: 1; display: flex; flex-direction: column; align-items: center; gap: 5px; padding: 7px 0 8px;">
+          <div style="font-size: 0.625rem; font-weight: 800; color: #9a8677;">FRI</div>
+          <div style="width: 30px; height: 30px; border-radius: 50%; background: rgba(124, 92, 191, 0.14); display: flex; align-items: center; justify-content: center; font-size: 0.95rem;">🦖</div>
+        </div>
+        <div style="flex-grow: 1; display: flex; flex-direction: column; align-items: center; gap: 5px; padding: 7px 0 8px;">
+          <div style="font-size: 0.625rem; font-weight: 800; color: #9a8677;">SAT</div>
+          <div style="width: 30px; height: 30px; border-radius: 50%; background: rgba(59, 130, 246, 0.14); display: flex; align-items: center; justify-content: center; font-size: 0.95rem;">⚽</div>
+        </div>
+        <div style="flex-grow: 1; display: flex; flex-direction: column; align-items: center; gap: 5px; padding: 7px 0 8px;">
+          <div style="font-size: 0.625rem; font-weight: 800; color: #9a8677;">SUN</div>
+          <div style="width: 30px; height: 30px; border-radius: 50%; background: rgba(219, 39, 119, 0.11); display: flex; align-items: center; justify-content: center; font-size: 0.95rem;">🎨</div>
+        </div>
+        <div style="flex-grow: 1; display: flex; flex-direction: column; align-items: center; gap: 5px; padding: 7px 0 8px;">
+          <div style="font-size: 0.625rem; font-weight: 800; color: #9a8677;">MON</div>
+          <div style="width: 30px; height: 30px; border-radius: 50%; background: rgba(124, 92, 191, 0.14); display: flex; align-items: center; justify-content: center; font-size: 0.95rem;">🦖</div>
+        </div>
+        <div style="flex-grow: 1; display: flex; flex-direction: column; align-items: center; gap: 5px; padding: 7px 0 8px;">
+          <div style="font-size: 0.625rem; font-weight: 800; color: #9a8677;">TUE</div>
+          <div style="width: 30px; height: 30px; border-radius: 50%; background: rgba(59, 130, 246, 0.14); display: flex; align-items: center; justify-content: center; font-size: 0.95rem;">⚽</div>
+        </div>
+      </div>
+      <div style="font-size: 0.75rem; color: #9a8677; line-height: 1.55; margin-top: 11px;">Reordering the list above changes who is up tomorrow, not today &mdash; today's board is already written.</div>
+    </div>
+
+    <div style="text-align: center; font-size: 0.875rem; font-weight: 700; color: #c0392b; padding-top: 2px;">Delete this job</div>
+
+  </div>
+</div>
+</x-dc>
+</body>
+</html>

--- a/design/settings-ui/Chores.dc.html
+++ b/design/settings-ui/Chores.dc.html
@@ -1,0 +1,81 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800&display=swap">
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: 'Nunito', system-ui, -apple-system, sans-serif; background: #fffaf5; color: #2d2319; line-height: 1.5; -webkit-font-smoothing: antialiased; }
+    a { color: #e85d24; text-decoration: none; }
+    a:hover { color: #c44d1a; }
+  </style>
+</helmet>
+
+<div style="width: 390px; height: 844px; background: #fffaf5; display: flex; flex-direction: column; overflow: hidden;">
+
+  <div style="display: flex; align-items: center; gap: 4px; height: 56px; padding: 0 12px; border-bottom: 1px solid #f0e6da; flex-shrink: 0;">
+    <div style="display: flex; align-items: center; justify-content: center; width: 44px; height: 44px; margin-left: -10px;">
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="#5c4a3a" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"></polyline></svg>
+    </div>
+    <div style="font-size: 1.0625rem; font-weight: 800; letter-spacing: -0.01em; flex-grow: 1;">Chores</div>
+    <div style="display: flex; align-items: center; justify-content: center; height: 44px; padding: 0 6px; font-size: 0.9375rem; font-weight: 700; color: #e85d24;">Reorder</div>
+  </div>
+
+  <div style="flex-grow: 1; padding: 16px; display: flex; flex-direction: column; gap: 14px; overflow: hidden;">
+
+    <div style="background: #ffffff; border: 1px solid #f0e6da; border-radius: 16px; padding: 14px; display: flex; flex-direction: column; gap: 12px;">
+      <div style="display: flex; align-items: center; gap: 13px;">
+        <div style="width: 46px; height: 46px; border-radius: 13px; background: #fff5ec; display: flex; align-items: center; justify-content: center; font-size: 1.5rem; flex-shrink: 0;">🍽</div>
+        <div style="flex-grow: 1;">
+          <div style="font-size: 1rem; font-weight: 800;">Set the table</div>
+          <div style="font-size: 0.8125rem; color: #9a8677;">Mia &rarr; Theo &rarr; Ines, one a day</div>
+        </div>
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#c4b3a3" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"></polyline></svg>
+      </div>
+      <div style="display: flex; align-items: center; gap: 8px; background: #fff5ec; border-radius: 11px; padding: 8px 12px;">
+        <div style="font-size: 0.6875rem; font-weight: 800; letter-spacing: 0.07em; text-transform: uppercase; color: #9a8677;">Today</div>
+        <div style="width: 24px; height: 24px; border-radius: 50%; background: rgba(59, 130, 246, 0.14); display: flex; align-items: center; justify-content: center; font-size: 0.8125rem;">⚽</div>
+        <div style="font-size: 0.875rem; font-weight: 800;">Theo</div>
+        <div style="flex-grow: 1;"></div>
+        <div style="font-size: 0.75rem; color: #9a8677;">Tomorrow: Ines</div>
+      </div>
+    </div>
+
+    <div style="background: #ffffff; border: 1px solid #f0e6da; border-radius: 16px; padding: 14px; display: flex; flex-direction: column; gap: 12px;">
+      <div style="display: flex; align-items: center; gap: 13px;">
+        <div style="width: 46px; height: 46px; border-radius: 13px; background: #fff5ec; display: flex; align-items: center; justify-content: center; font-size: 1.5rem; flex-shrink: 0;">🦴</div>
+        <div style="flex-grow: 1;">
+          <div style="font-size: 1rem; font-weight: 800;">Feed Biscuit</div>
+          <div style="font-size: 0.8125rem; color: #9a8677;">Theo &rarr; Mia, one a day</div>
+        </div>
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#c4b3a3" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"></polyline></svg>
+      </div>
+      <div style="display: flex; align-items: center; gap: 8px; background: #fff5ec; border-radius: 11px; padding: 8px 12px;">
+        <div style="font-size: 0.6875rem; font-weight: 800; letter-spacing: 0.07em; text-transform: uppercase; color: #9a8677;">Today</div>
+        <div style="width: 24px; height: 24px; border-radius: 50%; background: rgba(124, 92, 191, 0.14); display: flex; align-items: center; justify-content: center; font-size: 0.8125rem;">🦖</div>
+        <div style="font-size: 0.875rem; font-weight: 800;">Mia</div>
+        <div style="flex-grow: 1;"></div>
+        <div style="font-size: 0.75rem; color: #9a8677;">Tomorrow: Theo</div>
+      </div>
+    </div>
+
+    <div style="display: flex; align-items: center; justify-content: center; gap: 9px; height: 52px; border: 2px dashed #e2d7c9; border-radius: 14px; font-size: 0.9375rem; font-weight: 700; color: #5c4a3a;">
+      <svg width="19" height="19" viewBox="0 0 24 24" fill="none" stroke="#5c4a3a" stroke-width="2.2" stroke-linecap="round"><path d="M12 5v14"></path><path d="M5 12h14"></path></svg>
+      Add a job
+    </div>
+
+    <div style="background: #fff5ec; border-radius: 14px; padding: 13px 15px; display: flex; gap: 11px;">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#9a8677" stroke-width="1.9" stroke-linecap="round" style="flex-shrink: 0; margin-top: 2px;"><circle cx="12" cy="12" r="8.8"></circle><path d="M12 11.2v5"></path><path d="M12 7.9h.01"></path></svg>
+      <div style="font-size: 0.8125rem; color: #5c4a3a; line-height: 1.55;">Jobs hand over at midnight and keep to the order you set. Nobody has to tick anything off &mdash; the board just says whose turn it is.</div>
+    </div>
+
+  </div>
+</div>
+</x-dc>
+</body>
+</html>

--- a/design/settings-ui/Main.dc.html
+++ b/design/settings-ui/Main.dc.html
@@ -1,0 +1,145 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800&display=swap">
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: 'Nunito', system-ui, -apple-system, sans-serif; background: #fffaf5; color: #2d2319; line-height: 1.5; -webkit-font-smoothing: antialiased; }
+    a { color: #e85d24; text-decoration: none; }
+    a:hover { color: #c44d1a; }
+  </style>
+</helmet>
+
+<div style="width: 390px; height: 844px; background: #fffaf5; display: flex; flex-direction: column; overflow: hidden;">
+
+  <div style="display: flex; align-items: center; gap: 10px; height: 56px; padding: 0 16px; border-bottom: 1px solid #f0e6da; flex-shrink: 0;">
+    <div style="font-size: 1.15rem; font-weight: 800; letter-spacing: -0.02em; color: #e85d24; flex-grow: 1;">DinkyDash</div>
+    <div style="display: flex; align-items: center; justify-content: center; width: 44px; height: 44px; margin-right: -10px;">
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="#5c4a3a" stroke-width="1.9" stroke-linecap="round"><circle cx="12" cy="8" r="3.4"></circle><path d="M5.5 20c0-3.6 2.9-6.1 6.5-6.1s6.5 2.5 6.5 6.1"></path></svg>
+    </div>
+  </div>
+
+  <div style="flex-grow: 1; padding: 16px; display: flex; flex-direction: column; gap: 18px; overflow: hidden;">
+
+    <div style="background: #ffffff; border: 1px solid #f0e6da; border-radius: 16px; padding: 16px; display: flex; flex-direction: column; gap: 14px;">
+      <div style="display: flex; align-items: flex-start; gap: 12px;">
+        <div style="flex-grow: 1;">
+          <div style="font-size: 1.125rem; font-weight: 800; letter-spacing: -0.01em;">The Wilsons</div>
+          <div style="display: flex; align-items: center; gap: 7px; margin-top: 3px;">
+            <div style="width: 8px; height: 8px; border-radius: 50%; background: #16a34a; flex-shrink: 0;"></div>
+            <div style="font-size: 0.8125rem; color: #5c4a3a;">Today's board is up &mdash; written 4:32 am</div>
+          </div>
+        </div>
+      </div>
+      <div style="display: flex; gap: 10px;">
+        <div style="flex-grow: 1; display: flex; align-items: center; justify-content: center; gap: 8px; height: 46px; background: #e85d24; color: #ffffff; border-radius: 12px; font-weight: 700; font-size: 0.9375rem; box-shadow: 0 2px 8px rgba(232, 93, 36, 0.25);">
+          <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="#ffffff" stroke-width="2.1" stroke-linecap="round" stroke-linejoin="round"><rect x="2.5" y="4" width="19" height="13" rx="2"></rect><path d="M8 20.5h8"></path></svg>
+          View board
+        </div>
+        <div style="flex-grow: 1; display: flex; align-items: center; justify-content: center; gap: 8px; height: 46px; border: 2px solid #f0e6da; border-radius: 12px; font-weight: 700; font-size: 0.9375rem; color: #2d2319;">
+          <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="#5c4a3a" stroke-width="2.1" stroke-linecap="round" stroke-linejoin="round"><path d="M20.5 12a8.5 8.5 0 1 1-2.7-6.2"></path><polyline points="20.8 4.2 20.8 9.4 15.6 9.4"></polyline></svg>
+          Rewrite now
+        </div>
+      </div>
+    </div>
+
+    <div>
+      <div style="font-size: 0.6875rem; font-weight: 800; letter-spacing: 0.08em; text-transform: uppercase; color: #9a8677; padding: 0 4px 8px;">What's on the board</div>
+      <div style="background: #ffffff; border: 1px solid #f0e6da; border-radius: 16px; overflow: hidden;">
+
+        <div style="display: flex; align-items: center; gap: 13px; padding: 13px 14px; min-height: 66px;">
+          <div style="width: 38px; height: 38px; border-radius: 11px; background: rgba(124, 92, 191, 0.1); display: flex; align-items: center; justify-content: center; flex-shrink: 0;">
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#7c5cbf" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><circle cx="9" cy="8" r="3.2"></circle><path d="M3 19.5c0-3.3 2.7-5.6 6-5.6s6 2.3 6 5.6"></path><path d="M16.4 5.2a3.2 3.2 0 0 1 0 5.9"></path><path d="M18.2 14.4c1.8.8 3 2.6 3 5.1"></path></svg>
+          </div>
+          <div style="flex-grow: 1;">
+            <div style="font-size: 0.9375rem; font-weight: 700;">People</div>
+            <div style="font-size: 0.8125rem; color: #9a8677;">Mia, Theo, Ines, Sam</div>
+          </div>
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#c4b3a3" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"></polyline></svg>
+        </div>
+
+        <div style="display: flex; align-items: center; gap: 13px; padding: 13px 14px; min-height: 66px; border-top: 1px solid #f0e6da;">
+          <div style="width: 38px; height: 38px; border-radius: 11px; background: rgba(219, 39, 119, 0.09); display: flex; align-items: center; justify-content: center; flex-shrink: 0;">
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#be185d" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="7" cy="8.2" rx="1.9" ry="2.5"></ellipse><ellipse cx="12" cy="6.6" rx="1.9" ry="2.6"></ellipse><ellipse cx="17" cy="8.2" rx="1.9" ry="2.5"></ellipse><path d="M12 12.2c2.7 0 4.8 2 4.8 4.3 0 1.7-1.3 2.8-3 2.8-1 0-1.3-.4-1.8-.4s-.8.4-1.8.4c-1.7 0-3-1.1-3-2.8 0-2.3 2.1-4.3 4.8-4.3z"></path></svg>
+          </div>
+          <div style="flex-grow: 1;">
+            <div style="font-size: 0.9375rem; font-weight: 700;">Pets</div>
+            <div style="font-size: 0.8125rem; color: #9a8677;">Biscuit</div>
+          </div>
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#c4b3a3" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"></polyline></svg>
+        </div>
+
+        <div style="display: flex; align-items: center; gap: 13px; padding: 13px 14px; min-height: 66px; border-top: 1px solid #f0e6da;">
+          <div style="width: 38px; height: 38px; border-radius: 11px; background: rgba(22, 163, 74, 0.09); display: flex; align-items: center; justify-content: center; flex-shrink: 0;">
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#15803d" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M4 6.8h6"></path><path d="M4 12h6"></path><path d="M4 17.2h6"></path><polyline points="13.6 6.4 15.4 8.2 19.6 4"></polyline><polyline points="13.6 16.8 15.4 18.6 19.6 14.4"></polyline></svg>
+          </div>
+          <div style="flex-grow: 1;">
+            <div style="font-size: 0.9375rem; font-weight: 700;">Chores</div>
+            <div style="font-size: 0.8125rem; color: #9a8677;">2 jobs, rotating daily</div>
+          </div>
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#c4b3a3" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"></polyline></svg>
+        </div>
+
+        <div style="display: flex; align-items: center; gap: 13px; padding: 13px 14px; min-height: 66px; border-top: 1px solid #f0e6da;">
+          <div style="width: 38px; height: 38px; border-radius: 11px; background: rgba(232, 93, 36, 0.09); display: flex; align-items: center; justify-content: center; flex-shrink: 0;">
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#c44d1a" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="7.5" width="18" height="12.5" rx="2"></rect><path d="M3 12h18"></path><path d="M12 7.5V20"></path><path d="M12 7.5c-2.6 0-4.2-.7-4.2-2.2C7.8 4.1 8.8 3.4 10 3.4c1.4 0 2 1.6 2 4.1z"></path><path d="M12 7.5c2.6 0 4.2-.7 4.2-2.2 0-1.2-1-1.9-2.2-1.9-1.4 0-2 1.6-2 4.1z"></path></svg>
+          </div>
+          <div style="flex-grow: 1;">
+            <div style="font-size: 0.9375rem; font-weight: 700;">Special dates</div>
+            <div style="font-size: 0.8125rem; color: #9a8677;">3 countdowns</div>
+          </div>
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#c4b3a3" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"></polyline></svg>
+        </div>
+
+        <div style="display: flex; align-items: center; gap: 13px; padding: 13px 14px; min-height: 66px; border-top: 1px solid #f0e6da;">
+          <div style="width: 38px; height: 38px; border-radius: 11px; background: rgba(59, 130, 246, 0.09); display: flex; align-items: center; justify-content: center; flex-shrink: 0;">
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#2563eb" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="5" width="18" height="16" rx="2.4"></rect><path d="M3 10h18"></path><path d="M8 3v4"></path><path d="M16 3v4"></path></svg>
+          </div>
+          <div style="flex-grow: 1;">
+            <div style="font-size: 0.9375rem; font-weight: 700;">Calendars</div>
+            <div style="display: flex; align-items: center; gap: 6px; margin-top: 1px;">
+              <div style="width: 7px; height: 7px; border-radius: 50%; background: #d97706; flex-shrink: 0;"></div>
+              <div style="font-size: 0.8125rem; color: #b45309; font-weight: 600;">1 of 2 needs attention</div>
+            </div>
+          </div>
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#c4b3a3" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"></polyline></svg>
+        </div>
+
+        <div style="display: flex; align-items: center; gap: 13px; padding: 13px 14px; min-height: 66px; border-top: 1px solid #f0e6da;">
+          <div style="width: 38px; height: 38px; border-radius: 11px; background: rgba(92, 74, 58, 0.08); display: flex; align-items: center; justify-content: center; flex-shrink: 0;">
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#5c4a3a" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><rect x="2.5" y="4" width="19" height="13" rx="2"></rect><path d="M8 20.5h8"></path><path d="M12 17v3.5"></path></svg>
+          </div>
+          <div style="flex-grow: 1;">
+            <div style="font-size: 0.9375rem; font-weight: 700;">Screen link</div>
+            <div style="font-size: 0.8125rem; color: #9a8677;">dinkydash.co/s/kt7rm2xq</div>
+          </div>
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#c4b3a3" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"></polyline></svg>
+        </div>
+
+        <div style="display: flex; align-items: center; gap: 13px; padding: 13px 14px; min-height: 66px; border-top: 1px solid #f0e6da;">
+          <div style="width: 38px; height: 38px; border-radius: 11px; background: rgba(92, 74, 58, 0.08); display: flex; align-items: center; justify-content: center; flex-shrink: 0;">
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#5c4a3a" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="8.6"></circle><path d="M12 7.6v4.8l3 1.9"></path></svg>
+          </div>
+          <div style="flex-grow: 1;">
+            <div style="font-size: 0.9375rem; font-weight: 700;">Account</div>
+            <div style="font-size: 0.8125rem; color: #7c5cbf; font-weight: 600;">Trial &mdash; 9 days left</div>
+          </div>
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#c4b3a3" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"></polyline></svg>
+        </div>
+
+      </div>
+    </div>
+
+    <div style="text-align: center; font-size: 0.875rem; font-weight: 700; color: #9a8677; padding-top: 2px;">Sign out</div>
+
+  </div>
+</div>
+</x-dc>
+</body>
+</html>

--- a/design/settings-ui/People.dc.html
+++ b/design/settings-ui/People.dc.html
@@ -1,0 +1,88 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800&display=swap">
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: 'Nunito', system-ui, -apple-system, sans-serif; background: #fffaf5; color: #2d2319; line-height: 1.5; -webkit-font-smoothing: antialiased; }
+    a { color: #e85d24; text-decoration: none; }
+    a:hover { color: #c44d1a; }
+  </style>
+</helmet>
+
+<div style="width: 390px; height: 844px; background: #fffaf5; display: flex; flex-direction: column; overflow: hidden;">
+
+  <div style="display: flex; align-items: center; gap: 4px; height: 56px; padding: 0 12px; border-bottom: 1px solid #f0e6da; flex-shrink: 0;">
+    <div style="display: flex; align-items: center; justify-content: center; width: 44px; height: 44px; margin-left: -10px;">
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="#5c4a3a" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"></polyline></svg>
+    </div>
+    <div style="font-size: 1.0625rem; font-weight: 800; letter-spacing: -0.01em; flex-grow: 1;">People</div>
+    <div style="display: flex; align-items: center; justify-content: center; height: 44px; padding: 0 6px; font-size: 0.9375rem; font-weight: 700; color: #e85d24;">Reorder</div>
+  </div>
+
+  <div style="flex-grow: 1; padding: 16px; display: flex; flex-direction: column; gap: 16px; overflow: hidden;">
+
+    <div style="background: #ffffff; border: 1px solid #f0e6da; border-radius: 16px; overflow: hidden;">
+
+      <div style="display: flex; align-items: center; gap: 13px; padding: 12px 14px; min-height: 76px;">
+        <div style="width: 52px; height: 52px; border-radius: 50%; background: rgba(124, 92, 191, 0.14); display: flex; align-items: center; justify-content: center; font-size: 1.6rem; flex-shrink: 0;">🦖</div>
+        <div style="flex-grow: 1;">
+          <div style="font-size: 1rem; font-weight: 800;">Mia</div>
+          <div style="font-size: 0.8125rem; color: #9a8677;">8 years old &middot; born 15 March</div>
+          <div style="display: inline-flex; align-items: center; gap: 5px; margin-top: 5px; padding: 2px 9px; border-radius: 999px; background: rgba(232, 93, 36, 0.1);">
+            <div style="font-size: 0.6875rem; font-weight: 800; color: #c44d1a;">Birthday in 12 days</div>
+          </div>
+        </div>
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#c4b3a3" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"></polyline></svg>
+      </div>
+
+      <div style="display: flex; align-items: center; gap: 13px; padding: 12px 14px; min-height: 76px; border-top: 1px solid #f0e6da;">
+        <div style="width: 52px; height: 52px; border-radius: 50%; background: rgba(59, 130, 246, 0.13); display: flex; align-items: center; justify-content: center; font-size: 1.6rem; flex-shrink: 0;">⚽</div>
+        <div style="flex-grow: 1;">
+          <div style="font-size: 1rem; font-weight: 800;">Theo</div>
+          <div style="font-size: 0.8125rem; color: #9a8677;">6 years old &middot; born 20 June</div>
+        </div>
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#c4b3a3" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"></polyline></svg>
+      </div>
+
+      <div style="display: flex; align-items: center; gap: 13px; padding: 12px 14px; min-height: 76px; border-top: 1px solid #f0e6da;">
+        <div style="width: 52px; height: 52px; border-radius: 50%; background: rgba(219, 39, 119, 0.11); display: flex; align-items: center; justify-content: center; font-size: 1.6rem; flex-shrink: 0;">🎨</div>
+        <div style="flex-grow: 1;">
+          <div style="font-size: 1rem; font-weight: 800;">Ines</div>
+          <div style="font-size: 0.8125rem; color: #9a8677;">4 years old &middot; born 2 November</div>
+        </div>
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#c4b3a3" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"></polyline></svg>
+      </div>
+
+      <div style="display: flex; align-items: center; gap: 13px; padding: 12px 14px; min-height: 76px; border-top: 1px solid #f0e6da;">
+        <div style="width: 52px; height: 52px; border-radius: 50%; background: rgba(22, 163, 74, 0.12); display: flex; align-items: center; justify-content: center; font-size: 1.6rem; flex-shrink: 0;">☕</div>
+        <div style="flex-grow: 1;">
+          <div style="font-size: 1rem; font-weight: 800;">Sam</div>
+          <div style="font-size: 0.8125rem; color: #9a8677;">38 years old &middot; born 10 September</div>
+        </div>
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#c4b3a3" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"></polyline></svg>
+      </div>
+
+    </div>
+
+    <div style="display: flex; align-items: center; justify-content: center; gap: 9px; height: 52px; border: 2px dashed #e2d7c9; border-radius: 14px; font-size: 0.9375rem; font-weight: 700; color: #5c4a3a;">
+      <svg width="19" height="19" viewBox="0 0 24 24" fill="none" stroke="#5c4a3a" stroke-width="2.2" stroke-linecap="round"><path d="M12 5v14"></path><path d="M5 12h14"></path></svg>
+      Add a person
+    </div>
+
+    <div style="background: #fff5ec; border-radius: 14px; padding: 13px 15px; display: flex; gap: 11px;">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#9a8677" stroke-width="1.9" stroke-linecap="round" style="flex-shrink: 0; margin-top: 2px;"><circle cx="12" cy="12" r="8.8"></circle><path d="M12 11.2v5"></path><path d="M12 7.9h.01"></path></svg>
+      <div style="font-size: 0.8125rem; color: #5c4a3a; line-height: 1.55;">Ages and birthday countdowns are worked out from these dates every morning &mdash; you never update them by hand.</div>
+    </div>
+
+  </div>
+</div>
+</x-dc>
+</body>
+</html>

--- a/design/settings-ui/PersonEdit.dc.html
+++ b/design/settings-ui/PersonEdit.dc.html
@@ -1,0 +1,85 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800&display=swap">
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: 'Nunito', system-ui, -apple-system, sans-serif; background: #fffaf5; color: #2d2319; line-height: 1.5; -webkit-font-smoothing: antialiased; }
+    a { color: #e85d24; text-decoration: none; }
+    a:hover { color: #c44d1a; }
+  </style>
+</helmet>
+
+<div style="width: 390px; height: 844px; background: #fffaf5; display: flex; flex-direction: column; overflow: hidden;">
+
+  <div style="display: flex; align-items: center; height: 56px; padding: 0 14px; border-bottom: 1px solid #f0e6da; flex-shrink: 0;">
+    <div style="font-size: 0.9375rem; font-weight: 700; color: #9a8677; width: 62px;">Cancel</div>
+    <div style="font-size: 1.0625rem; font-weight: 800; letter-spacing: -0.01em; flex-grow: 1; text-align: center;">Mia</div>
+    <div style="font-size: 0.9375rem; font-weight: 800; color: #e85d24; width: 62px; text-align: right;">Save</div>
+  </div>
+
+  <div style="flex-grow: 1; padding: 16px; display: flex; flex-direction: column; gap: 14px; overflow: hidden;">
+
+    <div style="background: #ffffff; border: 1px solid #f0e6da; border-radius: 16px; padding: 16px; display: flex; flex-direction: column; gap: 14px;">
+
+      <div style="display: flex; flex-direction: column; align-items: center; gap: 7px;">
+        <div style="width: 76px; height: 76px; border-radius: 50%; background: rgba(124, 92, 191, 0.14); display: flex; align-items: center; justify-content: center; font-size: 2.4rem;">🦖</div>
+        <div style="font-size: 0.75rem; color: #9a8677; font-weight: 600;">How Mia appears on the board</div>
+      </div>
+
+      <div style="display: flex; gap: 7px;">
+        <div style="flex-grow: 1; height: 46px; border-radius: 12px; border: 2px solid #e85d24; background: rgba(232, 93, 36, 0.06); display: flex; align-items: center; justify-content: center; font-size: 1.35rem;">🦖</div>
+        <div style="flex-grow: 1; height: 46px; border-radius: 12px; border: 1.5px solid #f0e6da; display: flex; align-items: center; justify-content: center; font-size: 1.35rem;">🎨</div>
+        <div style="flex-grow: 1; height: 46px; border-radius: 12px; border: 1.5px solid #f0e6da; display: flex; align-items: center; justify-content: center; font-size: 1.35rem;">🚀</div>
+        <div style="flex-grow: 1; height: 46px; border-radius: 12px; border: 1.5px solid #f0e6da; display: flex; align-items: center; justify-content: center; font-size: 1.35rem;">🐙</div>
+        <div style="flex-grow: 1; height: 46px; border-radius: 12px; border: 1.5px solid #f0e6da; display: flex; align-items: center; justify-content: center; font-size: 1.35rem;">🎸</div>
+        <div style="flex-grow: 1; height: 46px; border-radius: 12px; border: 1.5px solid #f0e6da; display: flex; align-items: center; justify-content: center;">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#9a8677" stroke-width="2.4" stroke-linecap="round"><circle cx="5.5" cy="12" r="0.6"></circle><circle cx="12" cy="12" r="0.6"></circle><circle cx="18.5" cy="12" r="0.6"></circle></svg>
+        </div>
+      </div>
+
+      <div style="display: flex; gap: 10px; justify-content: space-between; padding: 0 2px;">
+        <div style="width: 30px; height: 30px; border-radius: 50%; background: #7c5cbf; box-shadow: 0 0 0 2.5px #ffffff, 0 0 0 5px #7c5cbf;"></div>
+        <div style="width: 30px; height: 30px; border-radius: 50%; background: #3b82f6;"></div>
+        <div style="width: 30px; height: 30px; border-radius: 50%; background: #16a34a;"></div>
+        <div style="width: 30px; height: 30px; border-radius: 50%; background: #db2777;"></div>
+        <div style="width: 30px; height: 30px; border-radius: 50%; background: #e85d24;"></div>
+        <div style="width: 30px; height: 30px; border-radius: 50%; background: #d97706;"></div>
+        <div style="width: 30px; height: 30px; border-radius: 50%; background: #0d9488;"></div>
+      </div>
+
+    </div>
+
+    <div style="background: #ffffff; border: 1px solid #f0e6da; border-radius: 16px; padding: 15px; display: flex; flex-direction: column; gap: 13px;">
+      <div>
+        <div style="font-size: 0.6875rem; font-weight: 800; letter-spacing: 0.07em; text-transform: uppercase; color: #9a8677; margin-bottom: 6px;">Name</div>
+        <div style="height: 48px; border: 1.5px solid #f0e6da; border-radius: 12px; padding: 0 14px; display: flex; align-items: center; font-size: 0.9375rem; font-weight: 600;">Mia</div>
+      </div>
+      <div>
+        <div style="font-size: 0.6875rem; font-weight: 800; letter-spacing: 0.07em; text-transform: uppercase; color: #9a8677; margin-bottom: 6px;">Date of birth</div>
+        <div style="height: 48px; border: 1.5px solid #f0e6da; border-radius: 12px; padding: 0 14px; display: flex; align-items: center; gap: 10px; font-size: 0.9375rem; font-weight: 600;">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#9a8677" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="5" width="18" height="16" rx="2.4"></rect><path d="M3 10h18"></path><path d="M8 3v4"></path><path d="M16 3v4"></path></svg>
+          15 March 2017
+        </div>
+      </div>
+    </div>
+
+    <div style="background: #ffffff; border: 1px solid #f0e6da; border-radius: 16px; padding: 15px;">
+      <div style="font-size: 0.6875rem; font-weight: 800; letter-spacing: 0.07em; text-transform: uppercase; color: #9a8677; margin-bottom: 6px;">Interests</div>
+      <div style="min-height: 74px; border: 1.5px solid #f0e6da; border-radius: 12px; padding: 11px 14px; font-size: 0.9375rem; font-weight: 600; line-height: 1.5;">dinosaurs, drawing, swimming lessons</div>
+      <div style="font-size: 0.75rem; color: #9a8677; line-height: 1.55; margin-top: 8px;">Used to write Mia's part of the daily brief &mdash; the fun fact and challenge lean on these.</div>
+    </div>
+
+    <div style="text-align: center; font-size: 0.875rem; font-weight: 700; color: #c0392b; padding-top: 2px;">Remove Mia from the board</div>
+
+  </div>
+</div>
+</x-dc>
+</body>
+</html>

--- a/design/settings-ui/Pets.dc.html
+++ b/design/settings-ui/Pets.dc.html
@@ -1,0 +1,83 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800&display=swap">
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: 'Nunito', system-ui, -apple-system, sans-serif; background: #fffaf5; color: #2d2319; line-height: 1.5; -webkit-font-smoothing: antialiased; }
+    a { color: #e85d24; text-decoration: none; }
+    a:hover { color: #c44d1a; }
+  </style>
+</helmet>
+
+<div style="width: 390px; height: 844px; background: #fffaf5; display: flex; flex-direction: column; overflow: hidden;">
+
+  <div style="display: flex; align-items: center; gap: 4px; height: 56px; padding: 0 12px; border-bottom: 1px solid #f0e6da; flex-shrink: 0;">
+    <div style="display: flex; align-items: center; justify-content: center; width: 44px; height: 44px; margin-left: -10px;">
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="#5c4a3a" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"></polyline></svg>
+    </div>
+    <div style="font-size: 1.0625rem; font-weight: 800; letter-spacing: -0.01em; flex-grow: 1;">Pets</div>
+  </div>
+
+  <div style="flex-grow: 1; padding: 16px; display: flex; flex-direction: column; gap: 16px; overflow: hidden;">
+
+    <div style="background: #ffffff; border: 1px solid #f0e6da; border-radius: 16px; display: flex; align-items: center; gap: 13px; padding: 12px 14px; min-height: 76px;">
+      <div style="width: 52px; height: 52px; border-radius: 50%; background: rgba(217, 119, 6, 0.12); display: flex; align-items: center; justify-content: center; font-size: 1.6rem; flex-shrink: 0;">🐕</div>
+      <div style="flex-grow: 1;">
+        <div style="font-size: 1rem; font-weight: 800;">Biscuit</div>
+        <div style="font-size: 0.8125rem; color: #9a8677;">Dog</div>
+      </div>
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#c4b3a3" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"></polyline></svg>
+    </div>
+
+    <div style="background: #ffffff; border: 2px solid #e85d24; border-radius: 16px; padding: 16px; display: flex; flex-direction: column; gap: 14px; box-shadow: 0 4px 20px rgba(232, 93, 36, 0.1);">
+
+      <div style="font-size: 0.9375rem; font-weight: 800;">Add a pet</div>
+
+      <div style="display: flex; gap: 7px;">
+        <div style="flex-grow: 1; height: 46px; border-radius: 12px; border: 1.5px solid #f0e6da; display: flex; align-items: center; justify-content: center; font-size: 1.35rem;">🐕</div>
+        <div style="flex-grow: 1; height: 46px; border-radius: 12px; border: 2px solid #e85d24; background: rgba(232, 93, 36, 0.06); display: flex; align-items: center; justify-content: center; font-size: 1.35rem;">🐈</div>
+        <div style="flex-grow: 1; height: 46px; border-radius: 12px; border: 1.5px solid #f0e6da; display: flex; align-items: center; justify-content: center; font-size: 1.35rem;">🐰</div>
+        <div style="flex-grow: 1; height: 46px; border-radius: 12px; border: 1.5px solid #f0e6da; display: flex; align-items: center; justify-content: center; font-size: 1.35rem;">🐠</div>
+        <div style="flex-grow: 1; height: 46px; border-radius: 12px; border: 1.5px solid #f0e6da; display: flex; align-items: center; justify-content: center; font-size: 1.35rem;">🐹</div>
+        <div style="flex-grow: 1; height: 46px; border-radius: 12px; border: 1.5px solid #f0e6da; display: flex; align-items: center; justify-content: center;">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#9a8677" stroke-width="2.4" stroke-linecap="round"><circle cx="5.5" cy="12" r="0.6"></circle><circle cx="12" cy="12" r="0.6"></circle><circle cx="18.5" cy="12" r="0.6"></circle></svg>
+        </div>
+      </div>
+
+      <div>
+        <div style="font-size: 0.6875rem; font-weight: 800; letter-spacing: 0.07em; text-transform: uppercase; color: #9a8677; margin-bottom: 6px;">Name</div>
+        <div style="height: 48px; border: 1.5px solid #f0e6da; border-radius: 12px; padding: 0 14px; display: flex; align-items: center; font-size: 0.9375rem; color: #c4b3a3; font-weight: 600;">Marmalade</div>
+      </div>
+
+      <div>
+        <div style="font-size: 0.6875rem; font-weight: 800; letter-spacing: 0.07em; text-transform: uppercase; color: #9a8677; margin-bottom: 6px;">Kind of animal</div>
+        <div style="height: 48px; border: 1.5px solid #f0e6da; border-radius: 12px; padding: 0 14px; display: flex; align-items: center; justify-content: space-between; font-size: 0.9375rem; font-weight: 600;">
+          Cat
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#9a8677" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"></polyline></svg>
+        </div>
+      </div>
+
+      <div style="display: flex; gap: 10px; padding-top: 2px;">
+        <div style="flex-grow: 1; display: flex; align-items: center; justify-content: center; height: 46px; border: 2px solid #f0e6da; border-radius: 12px; font-weight: 700; font-size: 0.9375rem; color: #5c4a3a;">Cancel</div>
+        <div style="flex-grow: 1; display: flex; align-items: center; justify-content: center; height: 46px; background: #e85d24; color: #ffffff; border-radius: 12px; font-weight: 700; font-size: 0.9375rem; box-shadow: 0 2px 8px rgba(232, 93, 36, 0.25);">Add pet</div>
+      </div>
+
+    </div>
+
+    <div style="background: #fff5ec; border-radius: 14px; padding: 13px 15px; display: flex; gap: 11px;">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#9a8677" stroke-width="1.9" stroke-linecap="round" style="flex-shrink: 0; margin-top: 2px;"><circle cx="12" cy="12" r="8.8"></circle><path d="M12 11.2v5"></path><path d="M12 7.9h.01"></path></svg>
+      <div style="font-size: 0.8125rem; color: #5c4a3a; line-height: 1.55;">Each pet gets a &ldquo;pet corner&rdquo; line on the board &mdash; a small invented update about their day.</div>
+    </div>
+
+  </div>
+</div>
+</x-dc>
+</body>
+</html>

--- a/design/settings-ui/Screen.dc.html
+++ b/design/settings-ui/Screen.dc.html
@@ -1,0 +1,122 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800&display=swap">
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: 'Nunito', system-ui, -apple-system, sans-serif; background: #fffaf5; color: #2d2319; line-height: 1.5; -webkit-font-smoothing: antialiased; }
+    a { color: #e85d24; text-decoration: none; }
+    a:hover { color: #c44d1a; }
+  </style>
+</helmet>
+
+<div style="width: 390px; height: 844px; background: #fffaf5; display: flex; flex-direction: column; overflow: hidden;">
+
+  <div style="display: flex; align-items: center; gap: 4px; height: 56px; padding: 0 12px; border-bottom: 1px solid #f0e6da; flex-shrink: 0;">
+    <div style="display: flex; align-items: center; justify-content: center; width: 44px; height: 44px; margin-left: -10px;">
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="#5c4a3a" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"></polyline></svg>
+    </div>
+    <div style="font-size: 1.0625rem; font-weight: 800; letter-spacing: -0.01em; flex-grow: 1;">Screen link</div>
+  </div>
+
+  <div style="flex-grow: 1; padding: 16px; display: flex; flex-direction: column; gap: 14px; overflow: hidden;">
+
+    <div style="background: #ffffff; border: 1px solid #f0e6da; border-radius: 16px; padding: 18px 16px 16px; display: flex; flex-direction: column; align-items: center; gap: 13px; flex-shrink: 0;">
+      <svg width="128" height="128" viewBox="0 0 200 200" style="display: block;">
+        <rect x="0" y="0" width="200" height="200" fill="#ffffff"></rect>
+        <path d="{{qr}}" fill="#2d2319"></path>
+        <path d="M0 0h56v56H0z" fill="#2d2319"></path>
+        <path d="M8 8h40v40H8z" fill="#ffffff"></path>
+        <path d="M16 16h24v24H16z" fill="#2d2319"></path>
+        <path d="M144 0h56v56h-56z" fill="#2d2319"></path>
+        <path d="M152 8h40v40h-40z" fill="#ffffff"></path>
+        <path d="M160 16h24v24h-24z" fill="#2d2319"></path>
+        <path d="M0 144h56v56H0z" fill="#2d2319"></path>
+        <path d="M8 152h40v40H8z" fill="#ffffff"></path>
+        <path d="M16 160h24v24H16z" fill="#2d2319"></path>
+      </svg>
+      <div style="display: flex; align-items: center; gap: 10px; background: #fff5ec; border-radius: 12px; padding: 11px 14px; width: 100%;">
+        <div style="flex-grow: 1; font-size: 0.875rem; font-weight: 700; letter-spacing: -0.01em; word-break: break-all;">dinkydash.co/s/kt7rm2xq</div>
+        <svg width="19" height="19" viewBox="0 0 24 24" fill="none" stroke="#e85d24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="flex-shrink: 0;"><rect x="9" y="9" width="11.5" height="11.5" rx="2.2"></rect><path d="M15 5.5A2.5 2.5 0 0 0 12.5 3h-7A2.5 2.5 0 0 0 3 5.5v7A2.5 2.5 0 0 0 5.5 15"></path></svg>
+      </div>
+      <div style="display: flex; align-items: center; justify-content: center; height: 48px; background: #e85d24; color: #ffffff; border-radius: 12px; font-weight: 700; font-size: 0.9375rem; width: 100%; box-shadow: 0 2px 8px rgba(232, 93, 36, 0.25);">Copy link</div>
+      <div style="font-size: 0.75rem; color: #9a8677; line-height: 1.5; text-align: center;">Open it on the TV, tablet or Pi you want the board on, then leave the page up.</div>
+    </div>
+
+    <div style="flex-shrink: 0;">
+      <div style="font-size: 0.6875rem; font-weight: 800; letter-spacing: 0.08em; text-transform: uppercase; color: #9a8677; padding: 0 4px 8px;">Colours</div>
+      <div style="display: flex; gap: 10px;">
+
+        <div style="flex-grow: 1; flex-basis: 0; border: 2px solid #e85d24; border-radius: 14px; background: #ffffff; padding: 9px 9px 10px; display: flex; flex-direction: column; gap: 8px;">
+          <div style="height: 60px; border-radius: 9px; background: #ffffff; border: 1px solid #f0e6da; padding: 8px 9px; display: flex; flex-direction: column; gap: 5px;">
+            <div style="width: 32px; height: 4px; border-radius: 2px; background: #e85d24;"></div>
+            <div style="width: 100%; height: 7px; border-radius: 3px; background: #2d2319;"></div>
+            <div style="width: 70%; height: 5px; border-radius: 3px; background: #c4b3a3;"></div>
+            <div style="width: 84%; height: 5px; border-radius: 3px; background: #c4b3a3;"></div>
+          </div>
+          <div style="display: flex; align-items: center; justify-content: center; gap: 6px;">
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#e85d24" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"></circle><polyline points="8 12.4 11 15.4 16 9.4"></polyline></svg>
+            <div style="font-size: 0.875rem; font-weight: 800; color: #c44d1a;">Light</div>
+          </div>
+        </div>
+
+        <div style="flex-grow: 1; flex-basis: 0; border: 1.5px solid #f0e6da; border-radius: 14px; background: #ffffff; padding: 9px 9px 10px; display: flex; flex-direction: column; gap: 8px;">
+          <div style="height: 60px; border-radius: 9px; background: #17120f; padding: 8px 9px; display: flex; flex-direction: column; gap: 5px;">
+            <div style="width: 32px; height: 4px; border-radius: 2px; background: #ff7a45;"></div>
+            <div style="width: 100%; height: 7px; border-radius: 3px; background: #f6efe7;"></div>
+            <div style="width: 70%; height: 5px; border-radius: 3px; background: #6f6053;"></div>
+            <div style="width: 84%; height: 5px; border-radius: 3px; background: #6f6053;"></div>
+          </div>
+          <div style="display: flex; align-items: center; justify-content: center; gap: 6px;">
+            <div style="font-size: 0.875rem; font-weight: 700; color: #5c4a3a;">Dark</div>
+          </div>
+        </div>
+
+      </div>
+      <div style="font-size: 0.75rem; color: #9a8677; line-height: 1.5; padding: 9px 4px 0;">Applies to every screen showing this board. Dark suits a kitchen that stays lit in the evening.</div>
+    </div>
+
+    <div style="background: #ffffff; border: 1px solid #f0e6da; border-radius: 16px; padding: 14px; display: flex; gap: 11px; flex-shrink: 0;">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#9a8677" stroke-width="1.9" stroke-linecap="round" style="flex-shrink: 0; margin-top: 2px;"><rect x="4.5" y="10.5" width="15" height="9.5" rx="2.2"></rect><path d="M8 10.5V7.6a4 4 0 0 1 8 0v2.9"></path></svg>
+      <div style="font-size: 0.8125rem; color: #5c4a3a; line-height: 1.55;">Anyone with the link can see the board &mdash; there's no password. It's kept out of search engines.</div>
+    </div>
+
+    <div style="display: flex; flex-direction: column; gap: 7px; flex-shrink: 0;">
+      <div style="display: flex; align-items: center; justify-content: center; gap: 9px; height: 48px; border: 2px solid #f0e6da; border-radius: 12px; font-weight: 700; font-size: 0.9375rem; color: #2d2319;">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#5c4a3a" stroke-width="2.1" stroke-linecap="round" stroke-linejoin="round"><path d="M20.5 12a8.5 8.5 0 1 1-2.7-6.2"></path><polyline points="20.8 4.2 20.8 9.4 15.6 9.4"></polyline></svg>
+        Get a new link
+      </div>
+      <div style="font-size: 0.75rem; color: #9a8677; line-height: 1.5; text-align: center; padding: 0 6px;">The old one stops working straight away.</div>
+    </div>
+
+  </div>
+</div>
+</x-dc>
+
+<script data-dc-script>
+class Component extends DCLogic {
+  renderVals() {
+    const N = 25;
+    let s = 20260903;
+    const rnd = () => { s = (s * 16807) % 2147483647; return s / 2147483647; };
+    let d = '';
+    for (let y = 0; y < N; y++) {
+      for (let x = 0; x < N; x++) {
+        const inFinder = (x < 8 && y < 8) || (x > N - 9 && y < 8) || (x < 8 && y > N - 9);
+        const r = rnd();
+        if (inFinder) continue;
+        if (r > 0.5) { d += 'M' + (x * 8) + ' ' + (y * 8) + 'h8v8h-8z'; }
+      }
+    }
+    return { qr: d };
+  }
+}
+</script>
+</body>
+</html>

--- a/design/settings-ui/SpecialDates.dc.html
+++ b/design/settings-ui/SpecialDates.dc.html
@@ -1,0 +1,78 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800&display=swap">
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: 'Nunito', system-ui, -apple-system, sans-serif; background: #fffaf5; color: #2d2319; line-height: 1.5; -webkit-font-smoothing: antialiased; }
+    a { color: #e85d24; text-decoration: none; }
+    a:hover { color: #c44d1a; }
+  </style>
+</helmet>
+
+<div style="width: 390px; height: 844px; background: #fffaf5; display: flex; flex-direction: column; overflow: hidden;">
+
+  <div style="display: flex; align-items: center; gap: 4px; height: 56px; padding: 0 12px; border-bottom: 1px solid #f0e6da; flex-shrink: 0;">
+    <div style="display: flex; align-items: center; justify-content: center; width: 44px; height: 44px; margin-left: -10px;">
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="#5c4a3a" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"></polyline></svg>
+    </div>
+    <div style="font-size: 1.0625rem; font-weight: 800; letter-spacing: -0.01em; flex-grow: 1;">Special dates</div>
+  </div>
+
+  <div style="flex-grow: 1; padding: 16px; display: flex; flex-direction: column; gap: 16px; overflow: hidden;">
+
+    <div style="background: #ffffff; border: 1px solid #f0e6da; border-radius: 16px; overflow: hidden;">
+
+      <div style="display: flex; align-items: center; gap: 13px; padding: 12px 14px; min-height: 72px;">
+        <div style="width: 44px; height: 44px; border-radius: 13px; background: #fff5ec; display: flex; align-items: center; justify-content: center; font-size: 1.45rem; flex-shrink: 0;">🚂</div>
+        <div style="flex-grow: 1;">
+          <div style="font-size: 0.9375rem; font-weight: 800;">Grandma &amp; Grandad visit</div>
+          <div style="font-size: 0.8125rem; color: #9a8677;">18 October</div>
+        </div>
+        <div style="padding: 4px 10px; border-radius: 999px; background: rgba(232, 93, 36, 0.1); font-size: 0.75rem; font-weight: 800; color: #c44d1a; white-space: nowrap;">45 days</div>
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#c4b3a3" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"></polyline></svg>
+      </div>
+
+      <div style="display: flex; align-items: center; gap: 13px; padding: 12px 14px; min-height: 72px; border-top: 1px solid #f0e6da;">
+        <div style="width: 44px; height: 44px; border-radius: 13px; background: #fff5ec; display: flex; align-items: center; justify-content: center; font-size: 1.45rem; flex-shrink: 0;">🎄</div>
+        <div style="flex-grow: 1;">
+          <div style="font-size: 0.9375rem; font-weight: 800;">Christmas</div>
+          <div style="font-size: 0.8125rem; color: #9a8677;">25 December</div>
+        </div>
+        <div style="padding: 4px 10px; border-radius: 999px; background: rgba(154, 134, 119, 0.12); font-size: 0.75rem; font-weight: 800; color: #5c4a3a; white-space: nowrap;">113 days</div>
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#c4b3a3" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"></polyline></svg>
+      </div>
+
+      <div style="display: flex; align-items: center; gap: 13px; padding: 12px 14px; min-height: 72px; border-top: 1px solid #f0e6da;">
+        <div style="width: 44px; height: 44px; border-radius: 13px; background: #fff5ec; display: flex; align-items: center; justify-content: center; font-size: 1.45rem; flex-shrink: 0;">☀️</div>
+        <div style="flex-grow: 1;">
+          <div style="font-size: 0.9375rem; font-weight: 800;">Summer holidays</div>
+          <div style="font-size: 0.8125rem; color: #9a8677;">1 July</div>
+        </div>
+        <div style="padding: 4px 10px; border-radius: 999px; background: rgba(154, 134, 119, 0.12); font-size: 0.75rem; font-weight: 800; color: #5c4a3a; white-space: nowrap;">301 days</div>
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#c4b3a3" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"></polyline></svg>
+      </div>
+
+    </div>
+
+    <div style="display: flex; align-items: center; justify-content: center; gap: 9px; height: 52px; border: 2px dashed #e2d7c9; border-radius: 14px; font-size: 0.9375rem; font-weight: 700; color: #5c4a3a;">
+      <svg width="19" height="19" viewBox="0 0 24 24" fill="none" stroke="#5c4a3a" stroke-width="2.2" stroke-linecap="round"><path d="M12 5v14"></path><path d="M5 12h14"></path></svg>
+      Add a date
+    </div>
+
+    <div style="background: #fff5ec; border-radius: 14px; padding: 13px 15px; display: flex; gap: 11px;">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#9a8677" stroke-width="1.9" stroke-linecap="round" style="flex-shrink: 0; margin-top: 2px;"><circle cx="12" cy="12" r="8.8"></circle><path d="M12 11.2v5"></path><path d="M12 7.9h.01"></path></svg>
+      <div style="font-size: 0.8125rem; color: #5c4a3a; line-height: 1.55;">These come back every year, so there's no year to fill in. Birthdays are already counted down from the People screen &mdash; no need to add them here.</div>
+    </div>
+
+  </div>
+</div>
+</x-dc>
+</body>
+</html>

--- a/design/settings-ui/canvas.json
+++ b/design/settings-ui/canvas.json
@@ -1,0 +1,132 @@
+{
+  "artboards": [
+    {
+      "file": "Main.dc.html",
+      "x": 0,
+      "y": 0,
+      "w": 390,
+      "h": 844,
+      "title": "Settings home"
+    },
+    {
+      "file": "People.dc.html",
+      "x": 470,
+      "y": 0,
+      "w": 390,
+      "h": 844,
+      "title": "People"
+    },
+    {
+      "file": "PersonEdit.dc.html",
+      "x": 940,
+      "y": 0,
+      "w": 390,
+      "h": 844,
+      "title": "Edit a person"
+    },
+    {
+      "file": "Pets.dc.html",
+      "x": 1410,
+      "y": 0,
+      "w": 390,
+      "h": 844,
+      "title": "Pets \u2014 adding one"
+    },
+    {
+      "file": "Chores.dc.html",
+      "x": 0,
+      "y": 964,
+      "w": 390,
+      "h": 844,
+      "title": "Chores"
+    },
+    {
+      "file": "ChoreEdit.dc.html",
+      "x": 470,
+      "y": 964,
+      "w": 390,
+      "h": 844,
+      "title": "Edit a chore rotation"
+    },
+    {
+      "file": "SpecialDates.dc.html",
+      "x": 940,
+      "y": 964,
+      "w": 390,
+      "h": 844,
+      "title": "Special dates"
+    },
+    {
+      "file": "Calendars.dc.html",
+      "x": 1410,
+      "y": 964,
+      "w": 390,
+      "h": 844,
+      "title": "Calendars"
+    },
+    {
+      "file": "AddCalendar.dc.html",
+      "x": 0,
+      "y": 1928,
+      "w": 390,
+      "h": 844,
+      "title": "Add a calendar"
+    },
+    {
+      "file": "Screen.dc.html",
+      "x": 470,
+      "y": 1928,
+      "w": 390,
+      "h": 844,
+      "title": "Screen link"
+    },
+    {
+      "file": "Account.dc.html",
+      "x": 940,
+      "y": 1928,
+      "w": 390,
+      "h": 844,
+      "title": "Account"
+    }
+  ],
+  "annotations": [
+    {
+      "id": "intro",
+      "x": 0,
+      "y": -190,
+      "w": 860,
+      "text": "DinkyDash \u2014 ongoing settings, mobile (390\u00d7844)\n\nThe hub at top-left is the whole map: every row is one Phase 1 section, and each row's subtitle carries live state so problems surface before you tap in. Static mockups; nothing is clickable."
+    },
+    {
+      "id": "rotation-note",
+      "x": 470,
+      "y": 1852,
+      "w": 390,
+      "text": "Chore rotation was undefined in PLAN.md. Proposal: an explicit ordered list plus a next-week preview, so the day-of-year modulo is visible rather than mysterious. Reordering takes effect tomorrow \u2014 today's board is already written."
+    },
+    {
+      "id": "calendar-note",
+      "x": 1410,
+      "y": 1852,
+      "w": 390,
+      "text": "The three states PLAN.md's calendars table implies: healthy, consecutive_failures > 0, and enabled = false. The failure card explains the likely cause and offers exactly one fix."
+    },
+    {
+      "id": "open-note",
+      "x": 1410,
+      "y": 2820,
+      "w": 390,
+      "text": "Still open: no drag-reorder interaction is drawn (the Reorder affordance is a placeholder), and lapse behaviour after trial isn't shown \u2014 it's an open question in PLAN.md."
+    },
+    {
+      "id": "theme-note",
+      "x": 470,
+      "y": 2820,
+      "w": 390,
+      "text": "Light/Dark lives here rather than in Account: it is a property of the screen on the wall, not of the person editing. An Auto option (dark after sunset, using the family timezone) would suit a kitchen board \u2014 not drawn, say the word."
+    }
+  ],
+  "launch": {
+    "view": "canvas"
+  }
+}


### PR DESCRIPTION
Visual mockups for two phases of the hosted MVP, as fixed-size HTML
artboards plus the canvas manifests that lay them out and record the
reasoning. Design artefacts only — nothing here is imported or served.

settings-ui/ covers Phase 1: a hub whose rows carry live state, chore
rotation as an explicit ordered list with a next-week preview, and
add-a-calendar validating on paste with a real event count.

board-ui/ covers Phase 3: the agenda is the board, sized to read across
a room, with no person cards and a single prose box carrying whatever
was generated that day. Wide-and-short screens get two columns, tall
ones get one. Light and dark palettes, chosen per screen rather than
per account. The stale state keeps the computed halves of the payload —
ages, countdowns, rotation, agenda — and marks only the prose.

Styling is lifted from website/templates so the two stay in step.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BmzXkDDQPwt7efeA5HMVcR