### PR TITLE
Give settings items stable ids, and settle how config is stored

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ dinkydash/
 ├── claude_client.py   the API call, with structured outputs
 ├── generate.py        orchestrator: config + date + events -> payload
 ├── board.py           payload + config -> what the template renders
-├── config.py          config.yaml load/save (ruamel round-trip)
+├── config.py          config.yaml load/save (ruamel round-trip), item ids
 ├── history.py         rolling record of recent notes, to avoid repeats
 └── runner.py          the one place that does I/O around the engine
 
@@ -88,6 +88,17 @@ changes exactly the lines it means to.
 
 `config.example.yaml` documents every key. Two are migrated on load: a single `calendar_url` becomes
 the first entry in `calendars`, and `calendar_filter_emails` is dropped with a warning.
+
+Every item in the five edited lists — people, pets, recurring, special_dates, calendars — carries a
+short `id`. The settings UI addresses items by it, because a position is not an identity: delete the
+first person and everyone below renumbers onto somebody else's edit form. Ids are backfilled by
+`ensure_ids`, which the settings UI calls on load and saves once if it added any. Deliberately not
+part of `load_config` — loading must not rewrite the file, and the engine never reads ids.
+`_add_id` puts the id *first* in the mapping: ruamel hangs the comment introducing the next section
+off the last item of the previous one, so an appended key lands under the wrong heading.
+
+Ids are also what lets one settings UI serve both modes later. `PLAN.md` decision 10: the config
+dict is the storage contract, a file in self-hosted mode and a `jsonb` column when hosted.
 
 ## Development Commands
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,6 +1,6 @@
 # DinkyDash Hosted MVP — Plan
 
-*Last updated: August 10, 2026. Supersedes `HOSTING_ANALYSIS.md` (deleted — it predated both the AI generation feature and the July 2026 calendar-display repositioning, and its recommended stack and data model no longer matched the product).*
+*Last updated: September 5, 2026. Supersedes `HOSTING_ANALYSIS.md` (deleted — it predated both the AI generation feature and the July 2026 calendar-display repositioning, and its recommended stack and data model no longer matched the product).*
 
 Companion to [STRATEGY.md](STRATEGY.md), which covers positioning, pricing anchors, and SEO. This document covers **how the hosted version gets built and launched**.
 
@@ -27,6 +27,7 @@ Turn DinkyDash from a single-family Raspberry Pi app into a hosted product a non
 | 7 | **Stripe direct.** | Reuse of existing KeepTheScore setup. See open questions re: EU VAT. |
 | 8 | **Fork KeepTheScore's privacy policy and ToS** as the starting point. | Faster than drafting; same jurisdiction and entity. |
 | 9 | **Self-hosting stays, community-supported only.** | See below. |
+| 10 | **The config dict is the storage contract.** `config.yaml` in single mode, a `jsonb` column in cloud mode. Not SQLite on the Pi. | The engine already takes a plain dict, so both modes can produce the same one. Self-hosters expect a file they can edit and copy, and a Pi should not have to run migrations to gain a field. One shape means one settings UI. |
 
 ### On self-hosting (decision 9)
 
@@ -53,33 +54,69 @@ Currently MIT, and the website says "MIT-licensed and free forever" in two place
 ### One app, two modes
 
 ```
-DINKYDASH_MODE=single   SQLite · auth off · billing off · one family · local cron
+DINKYDASH_MODE=single   config.yaml · auth off · billing off · one family · local cron
 DINKYDASH_MODE=cloud    Postgres · magic links · Stripe · many families · worker + scheduler
 ```
 
 The generation engine, dashboard template, CSS, and calendar handling are shared verbatim. Mode only gates auth, billing, storage backend, and how the scheduler is driven.
 
+### Where the config lives
+
+`dinkydash.config.load_config` returns a plain dict, and everything above the
+engine takes that dict. The file is one way to write it down; a database row is
+another. Neither the engine, the board, nor the settings UI is told which.
+
+So single mode keeps `config.yaml` — an editable, diffable, copy-to-back-it-up
+file is most of why anyone self-hosts, and ruamel round-trip mode means an edit
+made from a phone leaves the comments alone. Cloud mode stores the same dict in
+a `jsonb` column. `with_defaults` and its migrations then run once for both.
+
+The one thing this needs is that list items have identities rather than
+positions. Every person, pet, chore, date and calendar carries a short `id`,
+backfilled the first time the settings UI opens a file without them. That is
+what lets one set of settings routes address a row in Postgres and an entry in
+a YAML list without knowing the difference — and it fixes a real single-mode
+bug on the way, where deleting anyone shifted everybody below onto somebody
+else's edit form.
+
 ### Repository layout
 
+Built (as of #28):
+
 ```
-dinkydash/
-├── dinkydash/              # the engine — pure, no I/O side effects
-│   ├── context.py          # ages, birthdays, countdowns, chore rotation
-│   ├── calendar.py         # iCal fetch, parse, recurring expansion, merge feeds
-│   ├── prompt.py           # system + user prompt construction
-│   ├── claude.py           # API call, structured output, retry
-│   └── generate.py         # orchestrator: config dict + date → payload dict
-├── web/                    # Flask app (both modes)
-│   ├── routes/             # dashboard, auth, config UI, billing, admin
-│   ├── models.py
-│   ├── templates/
-│   └── static/
-├── worker/                 # scheduler + generation runner (cloud mode)
-├── selfhost/               # docker-compose, config.yaml loader, Pi docs
-├── migrations/
-├── tests/
-└── website/                # marketing site generator (unchanged)
+dinkydash/                  # the engine — pure, no clock, no file reads
+├── context.py              # ages, birthdays, countdowns, chore rotation
+├── calendars.py            # iCal fetch, parse, recurrence expansion, merge feeds
+├── prompt.py               # system + user prompt, note kinds, response schema
+├── claude_client.py        # the API call, with structured outputs
+├── generate.py             # orchestrator: config + date + events -> payload
+├── board.py                # payload + config -> what the template renders
+├── config.py               # the config dict: load, save, defaults, migrations, ids
+├── history.py              # rolling record of recent notes, to avoid repeats
+└── runner.py               # the one place that does I/O around the engine
+
+web/
+├── __init__.py             # create_app()
+├── routes/board.py         # the board and the preview harness
+├── routes/settings.py      # the settings UI (one table drives every list section)
+└── templates/              # board.html, preview.html, settings/*.html
+
+tests/
+website/                    # marketing site generator (unchanged)
 ```
+
+Still to come:
+
+```
+web/models.py               # cloud mode only — families, users, generations
+web/routes/                 # auth, billing, admin
+worker/                     # scheduler + generation runner (cloud mode)
+migrations/
+selfhost/                   # docker-compose and Pi docs
+```
+
+No `selfhost/` config loader: single and cloud mode both go through
+`dinkydash/config.py`, which is the point of decision 10.
 
 ### The engine boundary
 
@@ -129,35 +166,61 @@ At $5/mo, AI is 4–8% of revenue on Sonnet. Three notes:
 
 ### Data model sketch
 
+Config is one document, not five tables. Nothing in the product ever asks which
+families have a child born in March, so a table each for people, pets, chores,
+dates and calendars buys five sets of CRUD code and no answers. Real columns are
+for what the *platform* queries or writes; the parent's own settings stay in the
+dict the engine already takes.
+
 ```
-families         id, name, timezone, location, plan, status, trial_ends_at,
-                 stripe_customer_id, screen_token, screen_token_rotated_at
+families         id, plan, status, trial_ends_at, stripe_customer_id,
+                 screen_token, screen_token_rotated_at,
+                 config (jsonb)     -- the same dict config.yaml holds
 users            id, family_id, email, email_verified_at, last_login_at
 login_tokens     id, user_id, token_hash, expires_at, used_at
-people           id, family_id, name, date_of_birth, avatar_emoji, avatar_color,
-                 interests, position
-pets             id, family_id, name, type, avatar_emoji
-chores           id, family_id, title, emoji, choices (jsonb), position
-special_dates    id, family_id, title, emoji, month, day
-calendars        id, family_id, label, ical_url, enabled, last_fetch_at,
-                 last_fetch_status, consecutive_failures
+calendar_health  id, family_id, calendar_id, last_fetch_at, last_fetch_status,
+                 consecutive_failures    -- calendar_id is the id inside config
 generations      id, family_id, generated_for_date, generated_at, status,
                  payload (jsonb), input_tokens, output_tokens, cost_cents,
                  model, error       -- unique (family_id, generated_for_date)
-content_history  id, family_id, date, fun_fact, daily_challenge, pet_corner, headline
+content_history  id, family_id, date, headline, note, note_kind
 ```
+
+Three notes:
+
+- **The scheduler selects on `config->>'timezone'`.** An expression index on
+  that path is as fast as a column and leaves no second copy to drift.
+- **`calendar_health` is keyed on the calendar's config id**, which exists
+  precisely because list items now carry stable ids. Fetch state is something
+  the platform writes, so it does not belong in the parent's config.
+- **A config change needs no migration.** `with_defaults` already migrates old
+  shapes on load, and it runs in both modes.
+
+What this gives up: no database constraints on config contents, and no SQL
+across them without a jsonb query. Both are analytics conveniences, not product
+needs, and jsonb answers them when they arise.
 
 ---
 
 ## Bugs to fix before multi-tenancy
 
-These are latent on a single Pi and actively harmful hosted:
+These are latent on a single Pi and actively harmful hosted.
 
-1. **`generate.py:119` sorts events by formatted string.** `events.sort(key=lambda e: e["date"])` sorts `"Friday, August 15 at 03:30 PM"` alphabetically by weekday name. Today's 8:30am school run can land after next Tuesday. Sort on the underlying datetime.
-2. **`date.today()` / `datetime.now()` use server local time.** On a UTC host a family in Auckland gets the wrong day. The engine must take an injected, timezone-aware date.
-3. **`calendar_filter_emails` requires all listed emails as `ATTENDEE`s.** Most personal Google Calendar events have no `ATTENDEE` property at all, so this silently returns zero events. Remove it — multiple calendars replaces it.
-4. **No tests.** A nightly unattended job that costs money needs at least date/timezone, calendar parsing, and chore rotation covered.
-5. **Stale `.env` keys.** `DATABASE_URL`, `SECRET_KEY`, `UPLOAD_FOLDER`, `MAX_CONTENT_LENGTH` are leftovers from an abandoned plan.
+**Fixed in #28:**
+
+1. ~~**`generate.py:119` sorts events by formatted string.**~~ `events.sort(key=lambda e: e["date"])` sorted `"Friday, August 15 at 03:30 PM"` alphabetically by weekday name, so today's 8:30am school run could land after next Tuesday. Now sorted on `(date, all_day, start)` in `calendars.py`.
+2. ~~**`date.today()` / `datetime.now()` use server local time.**~~ On a UTC host a family in Auckland got the wrong day. The engine now takes an injected date, from `config_module.today_for(config)`.
+3. ~~**`calendar_filter_emails` requires all listed emails as `ATTENDEE`s.**~~ Most personal Google Calendar events have no `ATTENDEE` property at all, so it silently returned zero events. Dropped on load, with a warning; multiple calendars replaces it.
+4. ~~**No tests.**~~ 145 of them, in under a second.
+
+**Also fixed, found while settling decision 10:**
+
+5. ~~**The settings UI addressed list items by position.**~~ `items[int(item_id)]`, so removing anyone renumbered everybody below and an open edit form silently pointed at the wrong person. Items now carry stable ids.
+
+**Still open:**
+
+6. **Stale `.env` keys.** `DATABASE_URL`, `SECRET_KEY`, `UPLOAD_FOLDER`, `MAX_CONTENT_LENGTH` are leftovers from an abandoned plan. There is still no `.env.example`.
+7. **No CI.** The suite runs in under a second and nothing runs it on push.
 
 ---
 

--- a/dinkydash/config.py
+++ b/dinkydash/config.py
@@ -6,6 +6,7 @@ round-trip mode: your comments and key order survive an edit made from a phone.
 
 import logging
 import os
+import secrets
 import tempfile
 from datetime import datetime
 from pathlib import Path
@@ -39,6 +40,14 @@ THEMES = ("light", "dark")
 # Avatar colours the board and the settings UI both understand. Names rather
 # than hex so a theme change doesn't strand a colour nobody can read.
 AVATAR_COLORS = ("purple", "blue", "green", "pink", "orange", "amber", "teal")
+
+# The lists the settings UI edits. Every item in them carries a stable `id`.
+LIST_KEYS = ("people", "pets", "recurring", "special_dates", "calendars")
+
+# Ids are short and typed by nobody, but they end up in URLs and get read aloud
+# when something goes wrong, so leave out the characters that look like others.
+ID_ALPHABET = "23456789abcdefghjkmnpqrstuvwxyz"
+ID_LENGTH = 8
 
 
 def _yaml():
@@ -106,6 +115,62 @@ def with_defaults(raw):
         config["theme"] = "light"
 
     return config
+
+
+def new_id(taken=()):
+    """A short id for a list item, avoiding any already in `taken`."""
+    taken = set(taken)
+    while True:
+        value = "".join(secrets.choice(ID_ALPHABET) for _ in range(ID_LENGTH))
+        if value not in taken:
+            return value
+
+
+def ensure_ids(config):
+    """Give every list item an id. True if any were added.
+
+    A position is not an identity: delete the first person and everyone below
+    renumbers, so an edit form opened a moment earlier now points at somebody
+    else. Ids make the settings UI address a person rather than a slot, which
+    is also what lets the same routes run over a database row later.
+
+    Deliberately not part of load_config — loading must not rewrite the file,
+    and the engine never looks at ids. The settings UI calls this and saves.
+    """
+    added = False
+    for key in LIST_KEYS:
+        items = config.get(key) or []
+        taken = {item.get("id") for item in items if isinstance(item, dict)}
+        for item in items:
+            if not isinstance(item, dict) or item.get("id"):
+                continue
+            _add_id(item, new_id(taken))
+            taken.add(item["id"])
+            added = True
+    return added
+
+
+def _add_id(item, value):
+    """Put the id first in the mapping.
+
+    Appending looks tidier but breaks the file: ruamel hangs the blank line and
+    comment that introduce the *next* section off the last item of this one, so
+    an appended key lands underneath somebody else's heading. First is safe
+    everywhere, and it is where a database would put it anyway.
+    """
+    insert = getattr(item, "insert", None)  # ruamel's CommentedMap has one
+    if callable(insert):
+        insert(0, "id", value)
+    else:
+        item["id"] = value
+
+
+def find_item(items, item_id):
+    """(index, item) for the item with this id, or (None, None)."""
+    for index, item in enumerate(items or []):
+        if isinstance(item, dict) and item.get("id") == item_id:
+            return index, item
+    return None, None
 
 
 def tzinfo_for(config):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -142,6 +142,81 @@ class TestRoundTrip:
         assert config_file.read_text() == original
 
 
+class TestIds:
+    """Positions renumber; ids do not. The settings UI addresses items by id."""
+
+    def test_every_list_item_gets_one(self, config_file):
+        config = config_module.load_config(config_file)
+        assert config_module.ensure_ids(config) is True
+        assert config["people"][0]["id"]
+        assert config["calendars"][0]["id"]
+
+    def test_running_twice_changes_nothing(self, config_file):
+        config = config_module.load_config(config_file)
+        config_module.ensure_ids(config)
+        before = config["people"][0]["id"]
+        assert config_module.ensure_ids(config) is False
+        assert config["people"][0]["id"] == before
+
+    def test_hand_written_ids_are_left_alone(self, tmp_path):
+        path = tmp_path / "config.yaml"
+        path.write_text('people:\n  - name: "Mia"\n    id: "mia"\n')
+        config = config_module.load_config(path)
+        assert config_module.ensure_ids(config) is False
+        assert config["people"][0]["id"] == "mia"
+
+    def test_ids_within_a_list_are_unique(self):
+        config = {"people": [{"name": str(n)} for n in range(50)]}
+        config_module.ensure_ids(config)
+        assert len({p["id"] for p in config["people"]}) == 50
+
+    def test_no_lookalike_characters(self):
+        # Ids show up in URLs and get read aloud when something breaks.
+        assert not set("01lOI") & set(config_module.ID_ALPHABET)
+
+    def test_loading_does_not_add_them(self, config_file):
+        # load_config must not mutate the file on disk, and the engine never
+        # looks at ids — so backfilling is the settings UI's job, not load's.
+        config = config_module.load_config(config_file)
+        assert "id" not in config["people"][0]
+
+    def test_find_item_returns_the_position_and_the_item(self):
+        items = [{"id": "a", "name": "Mia"}, {"id": "b", "name": "Theo"}]
+        assert config_module.find_item(items, "b") == (1, items[1])
+
+    def test_find_item_on_a_stranger(self):
+        assert config_module.find_item([{"id": "a"}], "zzz") == (None, None)
+
+    def test_an_id_does_not_land_under_the_next_heading(self, tmp_path):
+        # ruamel hangs the comment introducing the next section off the last
+        # item of the previous one, so an id appended there ends up beneath
+        # somebody else's heading. Valid YAML, unreadable file.
+        path = tmp_path / "config.yaml"
+        path.write_text(
+            'calendars:\n'
+            '  - label: "Family"\n'
+            '    url: "https://example.com/basic.ics"\n'
+            '\n'
+            '# Birthdays here become countdowns.\n'
+            'people:\n'
+            '  - name: "Mia"\n'
+        )
+        config = config_module.load_config(path)
+        config_module.ensure_ids(config)
+        config_module.save_config(config, path)
+
+        lines = [line for line in path.read_text().splitlines() if line.strip()]
+        heading = lines.index("# Birthdays here become countdowns.")
+        assert lines[heading + 1] == "people:"
+
+    def test_an_inline_comment_stays_with_its_key(self, config_file):
+        config = config_module.load_config(config_file)
+        config_module.ensure_ids(config)
+        config_module.save_config(config, config_file)
+        written = config_file.read_text()
+        assert 'name: "Mia"          # the eldest' in written
+
+
 class TestTimezone:
     def test_today_uses_the_family_timezone(self, tmp_path):
         path = tmp_path / "config.yaml"

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,145 @@
+"""The settings routes, which are the only thing that writes config.yaml.
+
+The claim being tested: an item's URL means the same person tomorrow as it did
+when the page was rendered. It used to be a list position, so deleting anyone
+above shifted everybody below onto somebody else's edit form.
+"""
+
+import pytest
+
+from dinkydash import config as config_module
+from web import create_app
+
+CONFIG = """\
+family_name: "The Wilsons"
+timezone: "Europe/Berlin"
+
+people:
+  - name: "Mia"
+    date_of_birth: "2017-03-15"
+  - name: "Theo"
+    date_of_birth: "2019-06-20"
+  - name: "Ines"
+    date_of_birth: "2022-01-09"
+
+recurring:
+  - title: "Set the table"
+    choices: ["Mia", "Theo"]
+  - title: "Feed the dog"
+    choices: ["Theo", "Mia"]
+"""
+
+
+@pytest.fixture
+def config_path(tmp_path, monkeypatch):
+    path = tmp_path / "config.yaml"
+    path.write_text(CONFIG)
+    monkeypatch.setenv("DINKYDASH_CONFIG", str(path))
+    return path
+
+
+@pytest.fixture
+def client(config_path):
+    app = create_app()
+    app.config["TESTING"] = True
+    return app.test_client()
+
+
+def people(config_path):
+    return config_module.load_config(config_path)["people"]
+
+
+def ids_for(config_path, key="people"):
+    return [item["id"] for item in config_module.load_config(config_path)[key]]
+
+
+class TestBackfill:
+    def test_opening_a_list_gives_the_file_ids(self, client, config_path):
+        assert "id" not in people(config_path)[0]
+        assert client.get("/settings/people").status_code == 200
+        assert all(p["id"] for p in people(config_path))
+
+    def test_the_ids_do_not_change_on_a_second_visit(self, client, config_path):
+        client.get("/settings/people")
+        first = ids_for(config_path)
+        client.get("/settings/people")
+        assert ids_for(config_path) == first
+
+    def test_the_list_links_to_ids_not_positions(self, client, config_path):
+        html = client.get("/settings/people").get_data(as_text=True)
+        for person_id in ids_for(config_path):
+            assert f"/settings/people/{person_id}" in html
+
+
+class TestEditing:
+    def test_an_edit_form_opens_by_id(self, client, config_path):
+        client.get("/settings/people")
+        theo = ids_for(config_path)[1]
+        page = client.get(f"/settings/people/{theo}").get_data(as_text=True)
+        assert "Theo" in page
+
+    def test_saving_keeps_the_id(self, client, config_path):
+        client.get("/settings/people")
+        theo = ids_for(config_path)[1]
+        client.post(f"/settings/people/{theo}",
+                    data={"name": "Theodore", "date_of_birth": "2019-06-20"})
+        after = people(config_path)
+        assert after[1]["name"] == "Theodore"
+        assert after[1]["id"] == theo
+
+    def test_a_new_person_gets_an_id_of_their_own(self, client, config_path):
+        client.get("/settings/people")
+        before = set(ids_for(config_path))
+        client.post("/settings/people/new",
+                    data={"name": "Otto", "date_of_birth": "2024-04-02"})
+        after = ids_for(config_path)
+        assert len(after) == 4
+        assert after[3] not in before
+
+    def test_an_unknown_id_is_a_404(self, client, config_path):
+        client.get("/settings/people")
+        assert client.get("/settings/people/nosuchid").status_code == 404
+
+
+class TestDeleting:
+    def test_delete_removes_the_named_person(self, client, config_path):
+        client.get("/settings/people")
+        theo = ids_for(config_path)[1]
+        client.post(f"/settings/people/{theo}/delete")
+        assert [p["name"] for p in people(config_path)] == ["Mia", "Ines"]
+
+    def test_a_deletion_does_not_move_anyone_elses_url(self, client, config_path):
+        # The bug this whole change exists to prevent: with positions, removing
+        # Mia turned Theo's open edit form into Ines's.
+        client.get("/settings/people")
+        mia, _theo, ines = ids_for(config_path)
+        client.post(f"/settings/people/{mia}/delete")
+        page = client.get(f"/settings/people/{ines}").get_data(as_text=True)
+        assert "Ines" in page
+
+    def test_deleting_a_stranger_is_a_404(self, client, config_path):
+        client.get("/settings/people")
+        assert client.post("/settings/people/nosuchid/delete").status_code == 404
+
+
+class TestReordering:
+    """Chore rotation follows list order, so moving a job has to be exact."""
+
+    def test_moving_down_swaps_with_the_next_one(self, client, config_path):
+        client.get("/settings/recurring")
+        first = ids_for(config_path, "recurring")[0]
+        client.post(f"/settings/recurring/{first}/move", data={"direction": "down"})
+        titles = [c["title"] for c in config_module.load_config(config_path)["recurring"]]
+        assert titles == ["Feed the dog", "Set the table"]
+
+    def test_moving_the_top_one_up_does_nothing(self, client, config_path):
+        client.get("/settings/recurring")
+        first = ids_for(config_path, "recurring")[0]
+        client.post(f"/settings/recurring/{first}/move", data={"direction": "up"})
+        titles = [c["title"] for c in config_module.load_config(config_path)["recurring"]]
+        assert titles == ["Set the table", "Feed the dog"]
+
+    def test_moving_a_stranger_is_a_404(self, client, config_path):
+        client.get("/settings/recurring")
+        assert client.post("/settings/recurring/nosuchid/move",
+                           data={"direction": "up"}).status_code == 404

--- a/web/routes/settings.py
+++ b/web/routes/settings.py
@@ -107,7 +107,12 @@ MONTHS = ["January", "February", "March", "April", "May", "June", "July",
 
 
 def current_config():
-    return config_module.load_config(current_app.config["CONFIG_PATH"])
+    config = config_module.load_config(current_app.config["CONFIG_PATH"])
+    if config_module.ensure_ids(config):
+        # A config written by hand, or before ids existed. Give its items ids
+        # once, so the links on this page keep meaning the same thing.
+        save(config)
+    return config
 
 
 def save(config):
@@ -238,10 +243,8 @@ def section_edit(section_name, item_id):
         item = {"enabled": True} if section_name == "calendars" else {}
         index = None
     else:
-        try:
-            index = int(item_id)
-            item = items[index]
-        except (ValueError, IndexError):
+        index, item = config_module.find_item(items, item_id)
+        if item is None:
             abort(404)
 
     problems, checked = [], None
@@ -258,8 +261,12 @@ def section_edit(section_name, item_id):
             problems = validate(section, submitted)
             if not problems:
                 if is_new:
+                    submitted["id"] = config_module.new_id(
+                        i.get("id") for i in items if isinstance(i, dict)
+                    )
                     items.append(submitted)
                 else:
+                    submitted["id"] = item_id
                     items[index] = submitted
                 save(config)
                 flash(f"Saved {submitted.get('name') or submitted.get('title') or submitted.get('label') or 'it'}.", "ok")
@@ -299,27 +306,31 @@ def check_feed(item, config):
             f"Next up: {nxt['title']}, {nxt['date']} at {when}."}
 
 
-@bp.route("/<section_name>/<int:index>/delete", methods=["POST"])
-def section_delete(section_name, index):
+@bp.route("/<section_name>/<item_id>/delete", methods=["POST"])
+def section_delete(section_name, item_id):
     section = section_or_404(section_name)
     config = current_config()
     items = config.get(section["key"]) or []
-    if not 0 <= index < len(items):
+    index, removed = config_module.find_item(items, item_id)
+    if removed is None:
         abort(404)
-    removed = items.pop(index)
+    items.pop(index)
     save(config)
     flash(f"Removed {removed.get('name') or removed.get('title') or removed.get('label') or 'it'}.", "ok")
     return redirect(url_for("settings.section_list", section_name=section_name))
 
 
-@bp.route("/<section_name>/<int:index>/move", methods=["POST"])
-def section_move(section_name, index):
+@bp.route("/<section_name>/<item_id>/move", methods=["POST"])
+def section_move(section_name, item_id):
     """Reorder within a list — chore rotation order is the reason this exists."""
     section = section_or_404(section_name)
     config = current_config()
     items = config.get(section["key"]) or []
+    index, item = config_module.find_item(items, item_id)
+    if item is None:
+        abort(404)
     target = index + (-1 if request.form.get("direction") == "up" else 1)
-    if 0 <= index < len(items) and 0 <= target < len(items):
+    if 0 <= target < len(items):
         items[index], items[target] = items[target], items[index]
         save(config)
     return redirect(url_for("settings.section_list", section_name=section_name))

--- a/web/templates/settings/edit.html
+++ b/web/templates/settings/edit.html
@@ -104,7 +104,7 @@
 </form>
 
 {% if not is_new %}
-<form method="post" action="{{ url_for('settings.section_delete', section_name=section_name, index=item_id) }}"
+<form method="post" action="{{ url_for('settings.section_delete', section_name=section_name, item_id=item_id) }}"
       onsubmit="return confirm('Remove this for good?');">
     <button class="btn danger" type="submit">Remove this {{ section.singular }}</button>
 </form>

--- a/web/templates/settings/list.html
+++ b/web/templates/settings/list.html
@@ -18,7 +18,7 @@
         <div class="avatar square">{{ item.emoji }}</div>
         {% endif %}
 
-        <a class="row-main" href="{{ url_for('settings.section_edit', section_name=section_name, item_id=loop.index0) }}">
+        <a class="row-main" href="{{ url_for('settings.section_edit', section_name=section_name, item_id=item.id) }}">
             <div class="row-title">{{ item.name or item.title or item.label }}</div>
             <div class="row-sub">
                 {% if section_name == 'people' %}
@@ -45,10 +45,10 @@
         {% endif %}
 
         <div class="move">
-            <form class="inline-form" method="post" action="{{ url_for('settings.section_move', section_name=section_name, index=loop.index0) }}">
+            <form class="inline-form" method="post" action="{{ url_for('settings.section_move', section_name=section_name, item_id=item.id) }}">
                 <input type="hidden" name="direction" value="up"><button type="submit" title="Move up">&#9650;</button>
             </form>
-            <form class="inline-form" method="post" action="{{ url_for('settings.section_move', section_name=section_name, index=loop.index0) }}">
+            <form class="inline-form" method="post" action="{{ url_for('settings.section_move', section_name=section_name, item_id=item.id) }}">
                 <input type="hidden" name="direction" value="down"><button type="submit" title="Move down">&#9660;</button>
             </form>
         </div>


### PR DESCRIPTION
The settings UI addressed list items by position (`items[int(item_id)]`), so deleting anyone renumbered everybody below and an open edit form silently wrote to the wrong person. Every item in the five edited lists now carries a short `id`, and the edit, delete and reorder routes look items up by it — backfilled by `ensure_ids`, which the settings UI calls rather than `load_config`, because loading must not rewrite the file and the engine never reads ids. `_add_id` puts the id *first* in each mapping: ruamel hangs the comment introducing the next section off the last item of the previous one, so an appended key lands under the wrong heading — valid YAML, unreadable file, and there is a test for it.

This also settles what PLAN.md left as SQLite-on-the-Pi: the config dict is the storage contract, a file self-hosted and a `jsonb` column when hosted, so `with_defaults` runs once and these same routes can address a Postgres row and a YAML entry without knowing the difference (decision 10, plus a repository layout and bug list that now match the merged code). `tests/test_settings.py` is new — the settings routes had no coverage at all, which is how this survived — taking the suite to 145 tests in under a second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)