### PR TITLE
Bring the docs back in line with the rebuilt app

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -160,7 +160,7 @@ Roughly 2,500 input / 350 output tokens per family per day:
 
 At $5/mo, AI is 4–8% of revenue on Sonnet. Three notes:
 
-- Config still pins `claude-sonnet-4-5-20250929` — update it
+- ~~Config still pins `claude-sonnet-4-5-20250929`~~ — now `claude-haiku-4-5`
 - **Sonnet 5 runs adaptive thinking by default**, which eats into `max_tokens: 2048` and can truncate the JSON. Set `thinking` explicitly.
 - Switch to structured outputs (`output_config.format`) and the three-attempt JSON-parse retry loop can be deleted
 

--- a/README.md
+++ b/README.md
@@ -135,8 +135,8 @@ pip install -r requirements-dev.txt   # adds pytest; not needed on the Pi
 python -m pytest tests/ -q
 ```
 
-122 tests, well under a second. They cover leap years, timezone conversion, event ordering, chore
-rotation, the stale-board logic, and the config round-trip.
+145 tests, well under a second. They cover leap years, timezone conversion, event ordering, chore
+rotation, the stale-board logic, the config round-trip, and the settings routes that write it.
 
 ---
 
@@ -254,6 +254,7 @@ Nothing to do to your config — it is migrated on load. But be aware:
 | `history_days` | Days of past notes sent back so the model doesn't repeat itself |
 | `data_file` | Path for the generated JSON |
 | `content_history_file` | Path for the rolling note history |
+| `id` | Added to each `people[]`, `pets[]`, `recurring[]`, `special_dates[]` and `calendars[]` entry the first time you open `/settings`. Leave it alone — it is how the settings UI tells one entry from another, so deleting somebody does not renumber everyone below onto the wrong edit form |
 
 Upgrading from an older config? A single `calendar_url` is migrated into `calendars` automatically,
 and `calendar_filter_emails` is dropped — it required every listed address to appear as an
@@ -519,7 +520,7 @@ tail -f /home/pi/dinkydash/generate.log   # last night's generation
 | `app.py` | Flask entry point |
 | `config.yaml` | All configuration. The settings UI writes this same file |
 | `config.example.yaml` | Template config, documenting every key |
-| `tests/` | 122 tests. Run them before committing |
+| `tests/` | 145 tests. Run them before committing |
 | `design/` | Mockups for the board and settings UI, with the reasoning |
 | `deploy_to_pi.sh` | Deployment (rsync + service restart) |
 | `.env` | `ANTHROPIC_API_KEY` (not in git) |

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,6 +1,8 @@
 # DinkyDash configuration
 # Copy this file to config.yaml and make it yours. The settings UI at
-# /settings writes this same file, and keeps your comments.
+# /settings writes this same file, and keeps your comments. It also adds a
+# short `id` to each person, pet, chore, date and calendar the first time you
+# open it — leave those alone, they are how it tells one entry from another.
 
 # Shown in the corner of the board.
 family_name: "Our family"

--- a/docs/about/index.html
+++ b/docs/about/index.html
@@ -362,12 +362,10 @@
 <h2>What the dashboard shows</h2>
 <ul>
 <li><strong>A daily headline</strong> — a cheerful, AI-written greeting for your family</li>
-<li><strong>Person cards</strong> — each family member with their photo and key info</li>
+<li><strong>Today's agenda</strong> — what's happening today, in time order, merged from every calendar you add</li>
 <li><strong>Chore rotation</strong> — who does what today, rotated automatically and fairly</li>
 <li><strong>Countdowns</strong> — days until birthdays, holidays, vacations, and special events</li>
-<li><strong>Calendar events</strong> — what's happening today, pulled from your shared calendar</li>
-<li><strong>Fun facts and challenges</strong> — something new to read every morning</li>
-<li><strong>Pet corner</strong> — because pets are family too</li>
+<li><strong>A daily line</strong> — a fun fact, a family challenge, or something about the pet, different every morning</li>
 </ul>
 <h2>The principles</h2>
 <ul>

--- a/docs/family-dashboard/index.html
+++ b/docs/family-dashboard/index.html
@@ -361,10 +361,9 @@
 <p>Imagine it's a Tuesday in November. Your family wakes up and walks past the dashboard in the kitchen. Today it shows:</p>
 <ul>
 <li>A cheerful headline: "Happy Tuesday! Only 3 more days until the weekend."</li>
-<li>Person cards for each family member with their photo</li>
 <li>Chore badges showing it's Lily's turn for dishes and Sam's turn to feed the dog</li>
 <li>A <a href="/birthday-countdown/">countdown</a>: 28 days until Christmas, 5 days until Dad's birthday</li>
-<li>Today's calendar: school pickup at 3pm, swimming at 5pm, dinner at grandma's at 7pm</li>
+<li>Today's calendar in time order, merged from both parents' feeds: school pickup at 3pm, swimming at 5pm, dinner at grandma's at 7pm</li>
 <li>A fun fact about space that Sam will probably talk about all day</li>
 <li>A daily challenge: "Try to make someone laugh before breakfast"</li>
 </ul>

--- a/docs/getting-started/index.html
+++ b/docs/getting-started/index.html
@@ -365,76 +365,78 @@ pip install -r requirements.txt
 <h2>Step 2: Create your config</h2>
 <pre><code class="language-bash">cp config.example.yaml config.yaml
 </code></pre>
-<p>Open <code>config.yaml</code> and fill in your family's details. Here's what a typical config looks like:</p>
-<pre><code class="language-yaml">location: &quot;Berlin, Germany&quot;
+<p>Open <code>config.yaml</code> and fill in your family's details — or skip ahead, start the app, and do the whole thing from your phone at <code>/settings</code>. Here's what a typical config looks like:</p>
+<pre><code class="language-yaml">family_name: &quot;The Wilsons&quot;
+timezone: &quot;Europe/Berlin&quot;     # decides when &quot;today&quot; rolls over
+location: &quot;Berlin, Germany&quot;   # optional, flavours the daily line
+theme: light                  # or dark
 
-calendar_url: &quot;https://calendar.google.com/calendar/ical/your-email/basic.ics&quot;
-
-calendar_filter_emails:
-  - &quot;spouse@example.com&quot;
+calendars:                    # as many as you like; merged into one agenda
+  - label: &quot;Alice's Google&quot;
+    url: &quot;https://calendar.google.com/calendar/ical/your-email/basic.ics&quot;
+    enabled: true
 
 people:
   - name: &quot;Alice&quot;
     date_of_birth: &quot;2015-03-15&quot;
-    sex: &quot;female&quot;
-    image: &quot;alice.jpg&quot;
-    email: &quot;alice@example.com&quot;
+    avatar_emoji: &quot;🦖&quot;
+    avatar_color: purple
     interests: &quot;drawing, dinosaurs&quot;
   - name: &quot;Bob&quot;
     date_of_birth: &quot;2017-06-20&quot;
-    sex: &quot;male&quot;
-    image: &quot;bob.jpg&quot;
-    interests: &quot;legos, soccer&quot;
+    avatar_emoji: &quot;⚽&quot;
+    avatar_color: blue
+    interests: &quot;lego, football&quot;
 
 pets:
   - name: &quot;Buddy&quot;
     type: &quot;dog&quot;
-    image: &quot;pet.jpg&quot;
+    avatar_emoji: &quot;🐕&quot;
 
-recurring:
-  - title: &quot;Set Table&quot;
+recurring:                    # rotated one person per day, in this order
+  - title: &quot;Set the table&quot;
     emoji: &quot;🍽&quot;
     choices: [&quot;Alice&quot;, &quot;Bob&quot;]
-  - title: &quot;Feed Pet&quot;
-    emoji: &quot;🐕&quot;
+  - title: &quot;Feed Buddy&quot;
+    emoji: &quot;🦴&quot;
     choices: [&quot;Bob&quot;, &quot;Alice&quot;]
 
-special_dates:
+special_dates:                # repeat every year, so no year to set
   - title: &quot;Christmas&quot;
     emoji: &quot;🎄&quot;
     date: &quot;12/25&quot;
-  - title: &quot;Summer Vacation&quot;
+  - title: &quot;Summer holidays&quot;
     emoji: &quot;☀️&quot;
     date: &quot;07/01&quot;
 
-claude_model: &quot;claude-sonnet-4-5-20250929&quot;
-max_tokens: 2048
-data_file: &quot;dashboard_data.json&quot;
-anthropic_api_key_env: &quot;ANTHROPIC_API_KEY&quot;
+claude_model: &quot;claude-haiku-4-5&quot;
+max_tokens: 1024
 </code></pre>
 <h3>Config fields explained</h3>
 <ul>
-<li><strong>location</strong> — Your city and country. The AI uses this for context.</li>
-<li><strong>calendar_url</strong> — Your Google Calendar's public iCal URL.</li>
-<li><strong>calendar_filter_emails</strong> — Only show events where these people are attendees.</li>
-<li><strong>people</strong> — Each family member with their name, date of birth (YYYY-MM-DD), sex, photo filename, email, and interests.</li>
-<li><strong>pets</strong> — Your family pets with name, type, and photo filename.</li>
-<li><strong>recurring</strong> — Daily chores that rotate automatically. Each chore lists the people it rotates between.</li>
-<li><strong>special_dates</strong> — Countdowns to holidays, vacations, and other events (MM/DD format).</li>
-<li><strong>claude_model</strong> — Which Claude model generates your dashboard.</li>
+<li><strong>family_name</strong> — Shown in the corner of the board.</li>
+<li><strong>timezone</strong> — IANA name, like <code>Europe/Berlin</code>. Decides when "today" rolls over and how event times are shown. Set it even on a Pi whose clock is already local.</li>
+<li><strong>location</strong> — Your city and country. Optional; gives the daily line some local flavour.</li>
+<li><strong>theme</strong> — <code>light</code> or <code>dark</code>.</li>
+<li><strong>calendars</strong> — One entry per iCal feed, each with a <code>label</code>, a <code>url</code> and <code>enabled</code>. Add one per parent; they are merged into a single agenda.</li>
+<li><strong>people</strong> — Name, date of birth (YYYY-MM-DD), an <code>avatar_emoji</code>, an <code>avatar_color</code>, and <code>interests</code> that feed the daily line.</li>
+<li><strong>pets</strong> — Name, type, and an <code>avatar_emoji</code>.</li>
+<li><strong>recurring</strong> — Daily chores that rotate automatically. Each chore lists the people it rotates between, in order.</li>
+<li><strong>special_dates</strong> — Countdowns to holidays and other yearly events (MM/DD, no year).</li>
+<li><strong>claude_model</strong> — <code>claude-haiku-4-5</code> costs roughly $0.13 a month. <code>claude-sonnet-5</code> writes better for about three times that.</li>
 <li><strong>max_tokens</strong> — Maximum length of the AI response.</li>
 </ul>
+<p>The settings UI adds a short <code>id</code> to each person, pet, chore, date and calendar the first time you open it. Leave them alone — they are how the UI tells one entry from another.</p>
+<p>Upgrading from an older config? A single <code>calendar_url</code> becomes the first entry in <code>calendars</code> automatically. <code>calendar_filter_emails</code> is dropped, because it required every listed address to appear as an <code>ATTENDEE</code> and most personal calendar events have none — use one feed per person instead. Photos are gone; the board uses an emoji and a colour.</p>
 <h2>Step 3: Add your API key</h2>
 <p>Create a <code>.env</code> file in the project root:</p>
 <pre><code>ANTHROPIC_API_KEY=sk-ant-...
 </code></pre>
-<h2>Step 4: Add family photos</h2>
-<p>Copy photos into the <code>static/</code> directory. The filenames must match the <code>image</code> field in your config — for example, if you set <code>image: "alice.jpg"</code>, there should be a <code>static/alice.jpg</code>.</p>
-<h2>Step 5: Generate and run</h2>
+<h2>Step 4: Generate and run</h2>
 <pre><code class="language-bash">python generate.py        # Generate today's dashboard
-flask run --host=0.0.0.0  # Start the server
+python app.py             # Start the server
 </code></pre>
-<p>Open <strong>http://localhost:5000</strong> to see your dashboard. Use <strong>http://localhost:5000/preview</strong> for an 800x480 preview that matches the Raspberry Pi display size.</p>
+<p>Open <strong>http://localhost:5000</strong> to see your dashboard. <strong>http://localhost:5000/settings</strong> is the settings UI — it writes the same <code>config.yaml</code>, keeps your comments, and works from a phone. <strong>http://localhost:5000/preview</strong> shows the board at all three screen sizes at once.</p>
 <hr />
 <h2>Deploying to a Raspberry Pi</h2>
 <p>Once you've confirmed it works locally, here's how to set it up as a permanent dashboard on a Raspberry Pi.</p>
@@ -582,8 +584,10 @@ fi
 <h2>Quick reference</h2>
 <pre><code class="language-bash"># Local development
 source venv/bin/activate
-python generate.py
-flask run --host=0.0.0.0
+python generate.py                    # today's board (one API call)
+python generate.py --date 2026-12-24  # any date, for testing a countdown
+python app.py                         # board at /, settings at /settings
+python -m pytest tests/ -q            # the test suite
 
 # On the Raspberry Pi
 sudo systemctl status dinkydash      # Check service

--- a/website/content/about.md
+++ b/website/content/about.md
@@ -25,12 +25,10 @@ The result is a screen that feels alive. It knows it's someone's birthday week. 
 ## What the dashboard shows
 
 - **A daily headline** — a cheerful, AI-written greeting for your family
-- **Person cards** — each family member with their photo and key info
+- **Today's agenda** — what's happening today, in time order, merged from every calendar you add
 - **Chore rotation** — who does what today, rotated automatically and fairly
 - **Countdowns** — days until birthdays, holidays, vacations, and special events
-- **Calendar events** — what's happening today, pulled from your shared calendar
-- **Fun facts and challenges** — something new to read every morning
-- **Pet corner** — because pets are family too
+- **A daily line** — a fun fact, a family challenge, or something about the pet, different every morning
 
 ## The principles
 

--- a/website/content/family-dashboard.md
+++ b/website/content/family-dashboard.md
@@ -23,10 +23,9 @@ That means:
 Imagine it's a Tuesday in November. Your family wakes up and walks past the dashboard in the kitchen. Today it shows:
 
 - A cheerful headline: "Happy Tuesday! Only 3 more days until the weekend."
-- Person cards for each family member with their photo
 - Chore badges showing it's Lily's turn for dishes and Sam's turn to feed the dog
 - A [countdown](/birthday-countdown/): 28 days until Christmas, 5 days until Dad's birthday
-- Today's calendar: school pickup at 3pm, swimming at 5pm, dinner at grandma's at 7pm
+- Today's calendar in time order, merged from both parents' feeds: school pickup at 3pm, swimming at 5pm, dinner at grandma's at 7pm
 - A fun fact about space that Sam will probably talk about all day
 - A daily challenge: "Try to make someone laugh before breakfast"
 

--- a/website/content/getting-started.md
+++ b/website/content/getting-started.md
@@ -29,67 +29,73 @@ pip install -r requirements.txt
 cp config.example.yaml config.yaml
 ```
 
-Open `config.yaml` and fill in your family's details. Here's what a typical config looks like:
+Open `config.yaml` and fill in your family's details — or skip ahead, start the app, and do the whole thing from your phone at `/settings`. Here's what a typical config looks like:
 
 ```yaml
-location: "Berlin, Germany"
+family_name: "The Wilsons"
+timezone: "Europe/Berlin"     # decides when "today" rolls over
+location: "Berlin, Germany"   # optional, flavours the daily line
+theme: light                  # or dark
 
-calendar_url: "https://calendar.google.com/calendar/ical/your-email/basic.ics"
-
-calendar_filter_emails:
-  - "spouse@example.com"
+calendars:                    # as many as you like; merged into one agenda
+  - label: "Alice's Google"
+    url: "https://calendar.google.com/calendar/ical/your-email/basic.ics"
+    enabled: true
 
 people:
   - name: "Alice"
     date_of_birth: "2015-03-15"
-    sex: "female"
-    image: "alice.jpg"
-    email: "alice@example.com"
+    avatar_emoji: "🦖"
+    avatar_color: purple
     interests: "drawing, dinosaurs"
   - name: "Bob"
     date_of_birth: "2017-06-20"
-    sex: "male"
-    image: "bob.jpg"
-    interests: "legos, soccer"
+    avatar_emoji: "⚽"
+    avatar_color: blue
+    interests: "lego, football"
 
 pets:
   - name: "Buddy"
     type: "dog"
-    image: "pet.jpg"
+    avatar_emoji: "🐕"
 
-recurring:
-  - title: "Set Table"
+recurring:                    # rotated one person per day, in this order
+  - title: "Set the table"
     emoji: "🍽"
     choices: ["Alice", "Bob"]
-  - title: "Feed Pet"
-    emoji: "🐕"
+  - title: "Feed Buddy"
+    emoji: "🦴"
     choices: ["Bob", "Alice"]
 
-special_dates:
+special_dates:                # repeat every year, so no year to set
   - title: "Christmas"
     emoji: "🎄"
     date: "12/25"
-  - title: "Summer Vacation"
+  - title: "Summer holidays"
     emoji: "☀️"
     date: "07/01"
 
-claude_model: "claude-sonnet-4-5-20250929"
-max_tokens: 2048
-data_file: "dashboard_data.json"
-anthropic_api_key_env: "ANTHROPIC_API_KEY"
+claude_model: "claude-haiku-4-5"
+max_tokens: 1024
 ```
 
 ### Config fields explained
 
-- **location** — Your city and country. The AI uses this for context.
-- **calendar_url** — Your Google Calendar's public iCal URL.
-- **calendar_filter_emails** — Only show events where these people are attendees.
-- **people** — Each family member with their name, date of birth (YYYY-MM-DD), sex, photo filename, email, and interests.
-- **pets** — Your family pets with name, type, and photo filename.
-- **recurring** — Daily chores that rotate automatically. Each chore lists the people it rotates between.
-- **special_dates** — Countdowns to holidays, vacations, and other events (MM/DD format).
-- **claude_model** — Which Claude model generates your dashboard.
+- **family_name** — Shown in the corner of the board.
+- **timezone** — IANA name, like `Europe/Berlin`. Decides when "today" rolls over and how event times are shown. Set it even on a Pi whose clock is already local.
+- **location** — Your city and country. Optional; gives the daily line some local flavour.
+- **theme** — `light` or `dark`.
+- **calendars** — One entry per iCal feed, each with a `label`, a `url` and `enabled`. Add one per parent; they are merged into a single agenda.
+- **people** — Name, date of birth (YYYY-MM-DD), an `avatar_emoji`, an `avatar_color`, and `interests` that feed the daily line.
+- **pets** — Name, type, and an `avatar_emoji`.
+- **recurring** — Daily chores that rotate automatically. Each chore lists the people it rotates between, in order.
+- **special_dates** — Countdowns to holidays and other yearly events (MM/DD, no year).
+- **claude_model** — `claude-haiku-4-5` costs roughly $0.13 a month. `claude-sonnet-5` writes better for about three times that.
 - **max_tokens** — Maximum length of the AI response.
+
+The settings UI adds a short `id` to each person, pet, chore, date and calendar the first time you open it. Leave them alone — they are how the UI tells one entry from another.
+
+Upgrading from an older config? A single `calendar_url` becomes the first entry in `calendars` automatically. `calendar_filter_emails` is dropped, because it required every listed address to appear as an `ATTENDEE` and most personal calendar events have none — use one feed per person instead. Photos are gone; the board uses an emoji and a colour.
 
 ## Step 3: Add your API key
 
@@ -99,18 +105,14 @@ Create a `.env` file in the project root:
 ANTHROPIC_API_KEY=sk-ant-...
 ```
 
-## Step 4: Add family photos
-
-Copy photos into the `static/` directory. The filenames must match the `image` field in your config — for example, if you set `image: "alice.jpg"`, there should be a `static/alice.jpg`.
-
-## Step 5: Generate and run
+## Step 4: Generate and run
 
 ```bash
 python generate.py        # Generate today's dashboard
-flask run --host=0.0.0.0  # Start the server
+python app.py             # Start the server
 ```
 
-Open **http://localhost:5000** to see your dashboard. Use **http://localhost:5000/preview** for an 800x480 preview that matches the Raspberry Pi display size.
+Open **http://localhost:5000** to see your dashboard. **http://localhost:5000/settings** is the settings UI — it writes the same `config.yaml`, keeps your comments, and works from a phone. **http://localhost:5000/preview** shows the board at all three screen sizes at once.
 
 ---
 
@@ -338,8 +340,10 @@ Add to crontab:
 ```bash
 # Local development
 source venv/bin/activate
-python generate.py
-flask run --host=0.0.0.0
+python generate.py                    # today's board (one API call)
+python generate.py --date 2026-12-24  # any date, for testing a countdown
+python app.py                         # board at /, settings at /settings
+python -m pytest tests/ -q            # the test suite
 
 # On the Raspberry Pi
 sudo systemctl status dinkydash      # Check service


### PR DESCRIPTION
The published self-host guide still documented the pre-rebuild config: it told readers to write `calendar_url`, `calendar_filter_emails`, `sex:`, `image:` and `claude-sonnet-4-5-20250929`, gave photos a step of their own, and never mentioned the settings UI — so anyone following it built a config the app no longer reads. It is rewritten against the current schema, with the migration and the new `id` key explained. Two more pages described a board that no longer exists: `about.md` and `family-dashboard.md` both promised person cards with photos, and `about.md` listed the fun fact, challenge and pet corner as three sections when they are one line that rotates between three kinds — facts corrected, marketing voice left alone, since these pages rank.

Smaller things: README's test count was 122, and its config reference had no `id` row; `config.example.yaml` did not warn that ids appear and should be left alone; PLAN.md still asked for a model update that has already happened. `docs/` is rebuilt for GitHub Pages, and only the three edited pages changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)