### PR TITLE
Top up the agenda with tomorrow, and re-fit when the font lands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,8 @@ Yesterday's fetch reached 14 days ahead, so today's agenda is still in it. The s
 replaced by a computed one (`"3 things on today, starting at 08:20."`) because a day-old AI headline
 can be actively wrong.
 
+That same 14-day window is where **tomorrow's** agenda comes from, so it survives a failed run too.
+
 ### The daily cycle
 
 ```
@@ -177,6 +179,27 @@ searches the largest `html { font-size }` whose content still fits the viewport,
 `height:100vh;overflow:hidden`, nothing ever reports an overflow — so the script lets the page lay
 out freely for one measurement (`height:auto`) and puts it straight back.
 
+It re-fits on `document.fonts.ready` as well as on resize, and that is not optional. Nunito arrives
+after the first paint and sets taller lines than the system fallback, so a size measured before it
+lands can overflow once it swaps in — measured at 557px of content in a 480px panel. The board only
+looks right because it re-measures when the font arrives.
+
+**The agenda's row budget.** `MAX_EVENTS = 5` is the budget for the whole agenda, not today's cap.
+Today fills it first; tomorrow tops up whatever is left, capped again at `MAX_TOMORROW = 3` so it
+stays a footnote even on an empty day. A five-event day therefore renders exactly as it did before
+tomorrow existed. This is what "if there is space" means in code — a fixed row count, decided by a
+pure function, rather than a layout measurement.
+
+What those rows cost depends on which column is taller, so measure against a real config rather
+than `config.example.yaml`. In two-column mode the side column (chores plus countdowns) usually
+sets the page height, and the agenda grows into slack it was already wasting. On a config with
+three chores and four birthdays the 800x480 root moves 14.23px -> 14.10px on a three-event day —
+under 1% — and 14.23px -> 13.32px on a quiet one. The two-chore example config has a shorter side
+column, so there the agenda *is* the constraint and the same change costs 8% and 13%. The stacked
+single-column layout (an iPad in portrait) has no side column to hide behind and always pays the
+full price, around 13-18%. Everything fits at all three sizes in every case. Raising either
+constant spends more type size, so measure at `/preview` before you do.
+
 In two-column mode the body is a grid, and **the note sits under the agenda, not across the
 bottom**. The agenda is short on a quiet day while chores plus countdowns are not, so a full-width
 note left the lower left quarter of an 800x480 panel empty. Under the agenda it balances the two
@@ -214,6 +237,14 @@ columns instead: on a five-event day the left column measures 311px against the 
   confirm it by reading `window.innerHeight` out of the page rather than trusting the flag. Chrome
   also reuses a running instance unless each run gets its own `--user-data-dir`, which silently
   makes every size in a loop return the first one's numbers.
+- **Do not trust `--window-size` for layout work at all.** Even with the +87 correction it has been
+  seen to ignore the flag and report a 756x469 viewport, which silently puts the board on the wrong
+  side of the `3/2` media query. Size the page with an **iframe of exactly the target dimensions**
+  instead, the way `/preview` already does, and read the numbers out of `iframe.contentWindow`. That
+  is deterministic; the flag is not.
+- **The board's `<meta http-equiv="refresh">` stops headless Chrome ever exiting.** `--screenshot`
+  and `--dump-dom` both hang until the timeout, though they do write their output first. Strip the
+  tag when rendering a copy for measurement, and wrap the call in `timeout` regardless.
 - The honest check is `scrot` over SSH on the Pi itself: a real 800x480 panel, a real kiosk browser,
   no capture artifacts. The board refreshes itself every 5 minutes, so a change takes one refresh to
   appear.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Every morning, DinkyDash merges your calendars into one agenda, works out whose 
 ## What the board shows
 
 - Today's agenda, in time order, merged from as many iCal feeds as you like
+- A look at tomorrow underneath it, on the days today leaves room
 - Whose turn each chore is — rotated daily, nothing to tick off
 - Countdowns to birthdays, holidays and special dates
 - An AI-written headline, and one line that is some days a fact, some days

--- a/dinkydash/board.py
+++ b/dinkydash/board.py
@@ -7,12 +7,18 @@ generation fails, the times and turns on the wall are still today's — only the
 written line is yesterday's, and it says so.
 """
 
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from .calendars import events_on
 from .context import build_countdowns, compute_chore_assignments
 
+# The agenda's row budget, not just today's cap. Today fills it first and
+# tomorrow tops up whatever is left, so a quiet day stops leaving the column
+# half empty while a busy one is never made to shrink to fit.
 MAX_EVENTS = 5
+# Tomorrow stays a footnote even when today is empty, so the agenda always
+# reads as today's first.
+MAX_TOMORROW = 3
 MAX_COUNTDOWNS = 3
 
 
@@ -46,6 +52,7 @@ def build_view(config, payload, today):
         "chores": chores,
         "countdowns": countdowns,
         "events": [],
+        "tomorrow": [],
         "headline": "",
         "note": "",
         "stale": False,
@@ -55,8 +62,14 @@ def build_view(config, payload, today):
     if not payload:
         return view
 
-    events = events_on(payload.get("events") or [], today)[:MAX_EVENTS]
+    fetched = payload.get("events") or []
+    events = events_on(fetched, today)[:MAX_EVENTS]
     view["events"] = events
+    # The fetch reaches 14 days ahead, so tomorrow is in the payload even when
+    # it is a day old. Slots are what today did not use, which is why a busy
+    # day silently drops tomorrow rather than overflowing the panel.
+    slots = min(MAX_TOMORROW, MAX_EVENTS - len(events))
+    view["tomorrow"] = events_on(fetched, today + timedelta(days=1))[:slots] if slots else []
 
     stale = payload.get("generated_for_date") != today.isoformat()
     view["stale"] = stale

--- a/tests/test_board.py
+++ b/tests/test_board.py
@@ -116,11 +116,72 @@ class TestStaleBoard:
         assert view["note"] == "An octopus fact"
 
 
+class TestTomorrow:
+    """Tomorrow tops up the agenda, but only with the rows today did not use."""
+
+    def test_a_quiet_today_is_topped_up_from_tomorrow(self):
+        data = payload("2026-09-03", [
+            event("2026-09-04", "09:00", "Term starts"),
+            event("2026-09-04", "14:15", "Dentist"),
+        ])
+        view = build_view(CONFIG, data, TODAY)
+        assert view["events"] == []
+        assert [e["title"] for e in view["tomorrow"]] == ["Term starts", "Dentist"]
+
+    def test_today_takes_the_rows_first(self):
+        data = payload("2026-09-03", [
+            event("2026-09-03", "08:20", "School run"),
+            event("2026-09-03", "15:45", "Swimming"),
+            event("2026-09-03", "18:00", "Football"),
+            event("2026-09-04", "09:00", "Term starts"),
+            event("2026-09-04", "14:15", "Dentist"),
+            event("2026-09-04", "16:30", "Piano"),
+        ])
+        view = build_view(CONFIG, data, TODAY)
+        assert len(view["events"]) == 3
+        # Two rows left in the budget of five, so only two of tomorrow's three.
+        assert [e["title"] for e in view["tomorrow"]] == ["Term starts", "Dentist"]
+
+    def test_a_full_today_crowds_tomorrow_out(self):
+        data = payload("2026-09-03", [
+            event("2026-09-03", f"{hour:02d}:00", f"Thing {hour}")
+            for hour in range(8, 13)
+        ] + [event("2026-09-04", "09:00", "Term starts")])
+        view = build_view(CONFIG, data, TODAY)
+        assert len(view["events"]) == 5
+        assert view["tomorrow"] == []
+
+    def test_tomorrow_stays_a_footnote_on_a_completely_empty_day(self):
+        # Nothing today and a packed tomorrow still reads as today's agenda.
+        data = payload("2026-09-03", [
+            event("2026-09-04", f"{hour:02d}:00", f"Thing {hour}")
+            for hour in range(8, 13)
+        ])
+        view = build_view(CONFIG, data, TODAY)
+        assert len(view["tomorrow"]) == 3
+
+    def test_the_day_after_tomorrow_is_not_included(self):
+        data = payload("2026-09-03", [
+            event("2026-09-04", "09:00", "Term starts"),
+            event("2026-09-05", "09:00", "Too far off"),
+        ])
+        view = build_view(CONFIG, data, TODAY)
+        assert [e["title"] for e in view["tomorrow"]] == ["Term starts"]
+
+    def test_a_stale_payload_still_knows_tomorrow(self):
+        # Yesterday's fetch reached 14 days ahead, so tomorrow is in it too.
+        data = payload("2026-09-02", [event("2026-09-04", "09:00", "Term starts")])
+        view = build_view(CONFIG, data, TODAY)
+        assert view["stale"] is True
+        assert [e["title"] for e in view["tomorrow"]] == ["Term starts"]
+
+
 class TestEmptyStates:
     def test_no_payload_at_all_is_the_waiting_screen(self):
         view = build_view(CONFIG, None, TODAY)
         assert view["state"] == "waiting"
         assert view["events"] == []
+        assert view["tomorrow"] == []
         # Chores and countdowns still work — they never needed the model.
         assert view["chores"]
         assert view["countdowns"]

--- a/web/templates/board.html
+++ b/web/templates/board.html
@@ -1,3 +1,12 @@
+{% macro event_row(event) %}
+<div class="event">
+    <div class="event-time{{ ' all-day' if event.all_day }}">{{ "All day" if event.all_day else event.time }}</div>
+    <div class="event-title">
+        {{ event.title }}
+        {% if event.location %}<span class="event-where">&mdash; {{ event.location }}</span>{% endif %}
+    </div>
+</div>
+{% endmacro -%}
 <!doctype html>
 <html lang="en" data-theme="{{ view.theme }}">
 <head>
@@ -140,6 +149,8 @@
             margin-bottom: 0.75rem;
         }
 
+        .agenda { display: flex; flex-direction: column; }
+
         .events { display: flex; flex-direction: column; gap: 0.6rem; }
         .event { display: flex; gap: 1.1rem; align-items: baseline; }
         .event-time {
@@ -152,6 +163,15 @@
         .event-time.all-day { font-size: 1rem; }
         .event-title { font-size: 1.5rem; font-weight: 700; }
         .event-where { color: var(--text-muted); font-weight: 600; }
+
+        /* Tomorrow only appears when today left room. It reads a step back from
+           today — smaller and muted — so a time is never taken for today's. The
+           time column keeps its 5.2rem width, so both days share a left edge. */
+        .tomorrow { margin-top: 1.5rem; }
+        .tomorrow .events { gap: 0.45rem; }
+        .tomorrow .event-time { font-size: 1.15rem; color: var(--text-muted); }
+        .tomorrow .event-time.all-day { font-size: 0.82rem; }
+        .tomorrow .event-title { font-size: 1.15rem; color: var(--text-mid); }
 
         .empty {
             background: var(--box);
@@ -269,21 +289,22 @@
             {% if view.events %}
             <div class="label">Today</div>
             <div class="events">
-                {% for event in view.events %}
-                <div class="event">
-                    <div class="event-time{{ ' all-day' if event.all_day }}">{{ "All day" if event.all_day else event.time }}</div>
-                    <div class="event-title">
-                        {{ event.title }}
-                        {% if event.location %}<span class="event-where">&mdash; {{ event.location }}</span>{% endif %}
-                    </div>
-                </div>
-                {% endfor %}
+                {% for event in view.events %}{{ event_row(event) }}{% endfor %}
             </div>
             {% else %}
             <div class="empty">
                 <div class="label">Today</div>
                 <div class="empty-head">The calendar is empty.</div>
                 <div class="empty-sub">Nothing between now and bedtime.</div>
+            </div>
+            {% endif %}
+
+            {% if view.tomorrow %}
+            <div class="tomorrow">
+                <div class="label">Tomorrow</div>
+                <div class="events">
+                    {% for event in view.tomorrow %}{{ event_row(event) }}{% endfor %}
+                </div>
             </div>
             {% endif %}
         </div>
@@ -370,6 +391,10 @@
 
     fit();
     window.addEventListener("resize", fit);
+    /* Nunito arrives after the first paint and sets taller lines than the
+       fallback, so a size measured before it lands can overflow once it swaps
+       in — measured at 557px of content in a 480px panel. Re-fit when it does. */
+    if (document.fonts && document.fonts.ready) { document.fonts.ready.then(fit); }
 })();
 </script>
 </body>


### PR DESCRIPTION
The agenda sat half empty on a quiet day while the side column did not, so tomorrow's events now fill the rows today leaves unused: `MAX_EVENTS = 5` becomes the budget for the whole agenda, today fills it first, and tomorrow tops up the remainder capped at `MAX_TOMORROW = 3` — so a five-event day renders exactly as before, and a stale board keeps tomorrow because the 14-day fetch already reaches it. Tomorrow reads a step back from today (smaller, muted, its own label, sharing the 5.2rem time column), and the duplicated event row markup became a Jinja macro.

Measured with no overflow at 800x480, 1280x720 and 1024x768 across 0, 2, 3 and 5 events: the cost is under 1% of type size on a config whose side column sets the page height, 8-13% on the shorter two-chore example config, and 13-18% in the stacked single-column layout.

Separately this fixes a race that predates the change — the fit script measured before Nunito loaded and could pick a root size that overflowed once the font swapped in, caught at 557px of content in a 480px panel — by re-fitting on `document.fonts.ready`; adding rows removed the slack that had been hiding it.

`CLAUDE.md` gains the row budget, the measured costs and two traps found on the way (`--window-size` is unreliable even with the documented +87 correction, so size the page with an exact iframe the way `/preview` does; and the board's meta refresh stops headless Chrome ever exiting), and `README.md` lists the new line. Six new tests cover the budget split, the crowd-out, the day-after boundary and the stale case; 152 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)