### PR TITLE
Re-check every competitor price, and fix the one we had 25% too high

### DIFF
--- a/docs/about/index.html
+++ b/docs/about/index.html
@@ -348,7 +348,7 @@
 <div class="container page-content">
     <h1>About DinkyDash</h1>
     <p>DinkyDash is a free, open-source <strong>digital family calendar for screens you already own</strong>. Point a TV, an old tablet, or a Raspberry Pi at it and your family gets one glanceable screen with today's calendar, a self-rotating chore chart, countdowns to the big days — and a daily brief written fresh every morning by AI.</p>
-<p>It was built by <a href="https://casparwre.de">Caspar</a>, an indie developer in Berlin, for his own kids — and open-sourced because a family calendar shouldn't cost $629 plus a subscription.</p>
+<p>It was built by <a href="https://casparwre.de">Caspar</a>, an indie developer in Berlin, for his own kids — and open-sourced because a family calendar shouldn't cost $600 plus a subscription.</p>
 <h2>Why an AI-written dashboard?</h2>
 <p>Most family calendar displays show static information that someone has to curate. DinkyDash takes a different approach: you describe your family once, and AI does the rest.</p>
 <p>Every morning at 6am, DinkyDash automatically:</p>

--- a/docs/best-digital-family-calendar/index.html
+++ b/docs/best-digital-family-calendar/index.html
@@ -350,15 +350,15 @@
     <p>Every "best digital family calendar" list starts from the same assumption: that you need to buy a screen. You might! But the actual decision has two branches, and it's worth choosing the branch before the product.</p>
 <p><img alt="A wall-mounted digital calendar display in a warm family kitchen" src="/images/hero-kitchen.webp" width="1376" height="768" decoding="async" /></p>
 <h2>Path 1: Buy a dedicated calendar display</h2>
-<p>You're paying for plug-and-play: unbox, connect Wi-Fi, done. As of July 2026:</p>
-<p><strong>Skylight Calendar 2 (15″, $299) / Calendar Max (27″, $629)</strong> — the category leader and the safest pick. Best-in-class calendar view, meal planning and AI event import with the optional Plus plan ($79/yr). If you just want it to work, buy this. (<a href="/skylight-calendar-subscription/">What the subscription does and doesn't cover →</a>)</p>
-<p><strong>Hearth Display (27″, $699 + $9/mo)</strong> — the routines specialist. Visual morning/evening checklists kids run themselves; a favorite with ADHD families. Priciest option in the category. (<a href="/hearth-vs-skylight/">Hearth vs Skylight compared →</a>)</p>
-<p><strong>Cozyla</strong> — dedicated hardware whose pitch is "no monthly fees" — features that cost extra elsewhere are included. Less polished than Skylight, but pay-once pricing.</p>
+<p>You're paying for plug-and-play: unbox, connect Wi-Fi, done. As of September 2026:</p>
+<p><strong>Skylight Calendar 2 (15″, $329.99) / Calendar Max (27″, $599.99)</strong> — the category leader and the safest pick. Best-in-class calendar view, meal planning and AI event import with the optional Plus plan ($79/yr). If you just want it to work, buy this. (<a href="/skylight-calendar-subscription/">What the subscription does and doesn't cover →</a>)</p>
+<p><strong>Hearth Display (27″, $699 + $9/mo, or $86.40/yr billed annually)</strong> — the routines specialist. Visual morning/evening checklists kids run themselves; a favorite with ADHD families. Priciest option in the category. (<a href="/hearth-vs-skylight/">Hearth vs Skylight compared →</a>)</p>
+<p><strong>Cozyla (from $169.99)</strong> — dedicated hardware whose pitch is "no monthly fees" — features that cost extra elsewhere are included. Less polished than Skylight, but pay-once pricing.</p>
 <h2>Path 2: Use a screen you already own</h2>
 <p>A family calendar display is, mechanically, a screen showing a web page. If a spare tablet, a TV, or a $100 Raspberry Pi is available, software gets you there:</p>
 <p><strong>DinkyDash (free, open source)</strong> — our project, and the reason this site exists. Any screen with a browser becomes a family calendar with automatic chore rotation, birthday countdowns, and an AI-written daily brief — a fresh greeting and fun fact every morning, written around your own family, which no hardware calendar offers. Setup takes an afternoon and a bit of terminal comfort (<a href="/getting-started/">guide</a>); a zero-setup hosted version is <a href="https://fffwryhvses.typeform.com/to/yxMMhmFs">in the works</a>.</p>
-<p><strong>Mango Display (free tier; Pro $5.99/mo)</strong> — commercial BYO-screen software with polished apps for smart TVs and tablets. The no-DIY version of this path.</p>
-<p><strong>DAKboard (free tier; $5–8/mo)</strong> — the veteran customizable wall display. Enormous flexibility, more "information dashboard" than "family organizer."</p>
+<p><strong>Mango Display (free tier; Pro $5.99/mo or $59.99/yr)</strong> — commercial BYO-screen software with polished apps for smart TVs and tablets. The no-DIY version of this path.</p>
+<p><strong>DAKboard (free tier; $5–10/mo)</strong> — the veteran customizable wall display. Enormous flexibility, more "information dashboard" than "family organizer."</p>
 <h2>How to decide</h2>
 <ul>
 <li><strong>"I want zero setup and a beautiful object on the wall"</strong> → Skylight (calendar-first) or Hearth (routines-first)</li>
@@ -379,19 +379,19 @@
 <tbody>
 <tr>
 <td>Skylight Cal 2 / Max</td>
-<td>$299 / $629</td>
+<td>$329.99 / $599.99</td>
 <td>$0–79/yr</td>
 <td>Best plug-and-play calendar</td>
 </tr>
 <tr>
 <td>Hearth</td>
 <td>$699</td>
-<td>$108/yr</td>
+<td>$86.40/yr</td>
 <td>Visual routines for kids</td>
 </tr>
 <tr>
 <td>Cozyla</td>
-<td>Varies</td>
+<td>From $169.99</td>
 <td>$0</td>
 <td>Pay-once hardware</td>
 </tr>
@@ -404,18 +404,18 @@
 <tr>
 <td>Mango Display</td>
 <td>$0 (your screen)</td>
-<td>$0–72/yr</td>
+<td>$0–60/yr</td>
 <td>Easiest BYO-screen</td>
 </tr>
 <tr>
 <td>DAKboard</td>
 <td>$0 (your screen)</td>
-<td>$0–96/yr</td>
+<td>$0–120/yr</td>
 <td>Deep customization</td>
 </tr>
 </tbody>
 </table>
-<p><em>Prices checked July 2026.</em></p>
+<p><em>Prices checked September 2026.</em></p>
 <p>Whichever path you take: the win isn't the gadget, it's the behavior change — the family checking one shared screen instead of asking one exhausted parent. The cheapest way to test whether that works in your house is <a href="/getting-started/">the free one</a>.</p>
     <p class="page-updated">Last updated 2026-09-06.</p>
 </div>

--- a/docs/digital-calendar-and-chore-chart/index.html
+++ b/docs/digital-calendar-and-chore-chart/index.html
@@ -317,7 +317,7 @@
   "headline": "A Digital Calendar and Chore Chart in One Screen",
   "description": "Combine the family calendar and the kids\u0027 chore chart on one wall screen \u2014 with chores that rotate automatically every day. No $300 hardware, no subscription, no nagging.",
   "mainEntityOfPage": "https://dinkydash.co/digital-calendar-and-chore-chart/",
-  "dateModified": "2026-09-03",
+  "dateModified": "2026-09-06",
   "author": { "@type": "Person", "name": "Caspar Wrede", "url": "https://casparwre.de" },
   "publisher": { "@id": "https://dinkydash.co/#org" }
 }
@@ -374,23 +374,23 @@
 </tr>
 <tr>
 <td><strong>Skylight Calendar</strong></td>
-<td>$299–$629</td>
+<td>$329.99–$599.99</td>
 <td>Chore chart free; rewards need Plus ($79/yr)</td>
 </tr>
 <tr>
 <td><strong>Hearth Display</strong></td>
-<td>$699 + $9/mo</td>
+<td>$699 + $9/mo ($86.40/yr)</td>
 <td>Routines and task assignments</td>
 </tr>
 </tbody>
 </table>
-<p><em>Prices checked July 2026.</em></p>
+<p><em>Prices checked September 2026.</em></p>
 <p>Skylight and Hearth both do chores well — that's part of why families pay for them. But if the hardware price is the obstacle, the free route gets you the core loop (visible chores, fair rotation, zero nagging) on a screen you already own. Our <a href="/diy-skylight-calendar/">DIY guide</a> shows the whole build, and the <a href="/getting-started/">getting started guide</a> has the copy-paste setup.</p>
 <h2>The countdown trick</h2>
 <p>One more thing that earns its place on the chore screen: countdowns. "8 days until your birthday" and "19 days until vacation" give kids a reason to look at the dashboard voluntarily every morning — and while they're there, they see whose turn the dishes are. That's the whole trick, honestly.</p>
 <p>You can see the effect without installing anything: our <a href="/birthday-countdown/">birthday countdown</a> is the same panel on its own, free and with no sign-up. Add the kids' birthdays and leave it open on a spare screen.</p>
 <p>Set it up this weekend: <strong><a href="/getting-started/">Getting started with DinkyDash</a></strong> — or <a href="https://fffwryhvses.typeform.com/to/yxMMhmFs">join the hosted-version waitlist</a> if you'd rather skip the setup.</p>
-    <p class="page-updated">Last updated 2026-09-03.</p>
+    <p class="page-updated">Last updated 2026-09-06.</p>
 </div>
 
 </main>

--- a/docs/diy-skylight-calendar/index.html
+++ b/docs/diy-skylight-calendar/index.html
@@ -347,7 +347,7 @@
     
 <div class="container page-content">
     <h1>DIY Skylight Calendar: Build a Digital Family Calendar for About $100</h1>
-    <p>A Skylight Calendar Max costs $629, plus $79 a year if you want the Plus features. The thing is, a digital family calendar is fundamentally <em>a screen showing a web page</em> — and that's something you can build yourself for about $100 with a Raspberry Pi, or for <strong>$0</strong> with a tablet you already own.</p>
+    <p>A Skylight Calendar Max costs $599.99, plus $79 a year if you want the Plus features. The thing is, a digital family calendar is fundamentally <em>a screen showing a web page</em> — and that's something you can build yourself for about $100 with a Raspberry Pi, or for <strong>$0</strong> with a tablet you already own.</p>
 <p>Here's exactly how, using <a href="https://github.com/caspii/dinkydash">DinkyDash</a>, our free and open-source family calendar software.</p>
 <p><img alt="A Raspberry Pi with a small touchscreen showing a family dashboard, sitting on a kitchen shelf" src="/images/diy-raspberry-pi-calendar.webp" width="1408" height="768" decoding="async" /></p>
 <h2>What you get</h2>
@@ -358,7 +358,7 @@
 <li><strong>Countdowns</strong> to birthdays, holidays, and vacations</li>
 <li><strong>A daily brief written by AI</strong> — a fresh greeting and fun fact every single morning, personalized to your family</li>
 </ul>
-<p>That last one is something even the $629 hardware doesn't do.</p>
+<p>That last one is something even the $600 hardware doesn't do.</p>
 <p>Want to see the countdown part before you build anything? Our <a href="/birthday-countdown/">birthday countdown</a> runs in a browser tab, free and without a sign-up.</p>
 <h2>The hardware: three routes</h2>
 <table>
@@ -392,7 +392,7 @@
 <h2>Start with the screen you already own</h2>
 <p>Before spending anything, prop up an old tablet or spare monitor in the kitchen and run the dashboard on it for two weeks.</p>
 <p>This sounds like a hedge, but it's the single most useful thing you can do. A family calendar only works if it's somewhere everyone walks past at the right time of day, and you will almost certainly get that spot wrong on the first try. Finding out with a tablet on a cookbook stand costs nothing. Finding out after mounting a Pi behind drywall is annoying.</p>
-<p>If it sticks, buy the hardware. If it doesn't, you've lost an evening instead of $629.</p>
+<p>If it sticks, buy the hardware. If it doesn't, you've lost an evening instead of $600.</p>
 <h2>The build, in five steps</h2>
 <p>The <a href="/getting-started/">full getting-started guide</a> has copy-paste commands for every step. The short version:</p>
 <ol>
@@ -425,7 +425,7 @@
 <tbody>
 <tr>
 <td>Hardware</td>
-<td>$629</td>
+<td>$599.99</td>
 <td>$0–130</td>
 </tr>
 <tr>
@@ -435,7 +435,7 @@
 </tr>
 <tr>
 <td>Three-year cost</td>
-<td>~$866</td>
+<td>~$837</td>
 <td>~$0–130</td>
 </tr>
 <tr>
@@ -455,7 +455,7 @@
 </tr>
 </tbody>
 </table>
-<p><em>Prices checked July 2026.</em></p>
+<p><em>Prices checked September 2026.</em></p>
 <h2>Questions people ask</h2>
 <p><strong>Is there a monthly fee for a DIY calendar?</strong>
 No subscription. The only running cost is the Anthropic API key for the daily brief, which comes to a few cents a month — roughly $0.20–0.40 for a typical family. Skip the AI brief and it's free. (For what Skylight itself charges, see our <a href="/skylight-calendar-subscription/">Skylight subscription breakdown</a>.)</p>

--- a/docs/hearth-vs-skylight/index.html
+++ b/docs/hearth-vs-skylight/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Hearth vs Skylight 2026: Prices, Subscriptions, Which to Buy</title>
-    <meta name="description" content="Hearth Display ($699 + $9/mo) vs Skylight Calendar ($299–$629 + optional $79/yr) compared honestly — plus the third option both companies would rather you didn&#39;t know about.">
+    <meta name="description" content="Hearth Display ($699 + $9/mo) vs Skylight Calendar ($329.99–$599.99 + optional $79/yr) compared honestly — plus the third option both companies would rather you didn&#39;t know about.">
     <link rel="canonical" href="https://dinkydash.co/hearth-vs-skylight/">
     
     <link rel="icon" href="/favicon.ico" sizes="any">
@@ -15,7 +15,7 @@
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://dinkydash.co/hearth-vs-skylight/">
     <meta property="og:image" content="https://dinkydash.co/images/og-hero.jpg">
-    <meta property="og:description" content="Hearth Display ($699 + $9/mo) vs Skylight Calendar ($299–$629 + optional $79/yr) compared honestly — plus the third option both companies would rather you didn&#39;t know about.">
+    <meta property="og:description" content="Hearth Display ($699 + $9/mo) vs Skylight Calendar ($329.99–$599.99 + optional $79/yr) compared honestly — plus the third option both companies would rather you didn&#39;t know about.">
     <meta name="twitter:card" content="summary_large_image">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -315,9 +315,9 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Hearth vs Skylight (2026): Prices, Subscriptions, and Which to Buy",
-  "description": "Hearth Display ($699 + $9/mo) vs Skylight Calendar ($299\u2013$629 + optional $79/yr) compared honestly \u2014 plus the third option both companies would rather you didn\u0027t know about.",
+  "description": "Hearth Display ($699 + $9/mo) vs Skylight Calendar ($329.99\u2013$599.99 + optional $79/yr) compared honestly \u2014 plus the third option both companies would rather you didn\u0027t know about.",
   "mainEntityOfPage": "https://dinkydash.co/hearth-vs-skylight/",
-  "dateModified": "2026-09-03",
+  "dateModified": "2026-09-06",
   "author": { "@type": "Person", "name": "Caspar Wrede", "url": "https://casparwre.de" },
   "publisher": { "@id": "https://dinkydash.co/#org" }
 }
@@ -360,13 +360,13 @@
 <tbody>
 <tr>
 <td>Price</td>
-<td>$299 (15″ Calendar 2) / $629 (27″ Max)</td>
-<td>$699 (27″, sometimes $599 on promo)</td>
+<td>$329.99 (15″ Calendar 2) / $599.99 (27″ Max)</td>
+<td>$699 (27″, often discounted)</td>
 </tr>
 <tr>
 <td>Subscription</td>
 <td>Optional Plus, $79/yr</td>
-<td>$9/mo after the first month</td>
+<td>Required: $9/mo, or $86.40/yr billed annually</td>
 </tr>
 <tr>
 <td>Orientation</td>
@@ -385,16 +385,16 @@
 </tr>
 <tr>
 <td>Realistic 3-year cost</td>
-<td>$629 + $237 ≈ <strong>$866</strong> (Max with Plus)</td>
-<td>$699 + ~$324 ≈ <strong>$1,023</strong></td>
+<td>$599.99 + $237 ≈ <strong>$837</strong> (Max with Plus)</td>
+<td>$699 + $259 ≈ <strong>$958</strong> (annual membership)</td>
 </tr>
 </tbody>
 </table>
-<p><em>Prices checked July 2026.</em></p>
+<p><em>Prices checked September 2026.</em></p>
 <h2>Where Skylight wins</h2>
-<p>Skylight nails the core job: your Google, Apple, or Outlook calendars merged into one big, color-coded family view. The interface is polished, the companion app is solid, and the 15″ model's $299 entry price is the lowest way into a premium dedicated display. Meal planning and its AI-powered "Magic Import" (photograph a school newsletter, get calendar events) are genuinely useful — but note they live behind the $79/year Plus plan. Read more on <a href="/skylight-calendar-subscription/">what Skylight's subscription does and doesn't cover</a>.</p>
+<p>Skylight nails the core job: your Google, Apple, or Outlook calendars merged into one big, color-coded family view. The interface is polished, the companion app is solid, and the 15″ model's $329.99 entry price is the lowest way into a premium dedicated display. Meal planning and its AI-powered "Magic Import" (photograph a school newsletter, get calendar events) are genuinely useful — but note they live behind the $79/year Plus plan. Read more on <a href="/skylight-calendar-subscription/">what Skylight's subscription does and doesn't cover</a>.</p>
 <h2>Where Hearth wins</h2>
-<p>Hearth is designed around <em>routines</em>, not just events: visual morning and evening checklists kids work through themselves, to-do assignments, and a portrait layout that reads like a poster. Families managing ADHD consistently praise it — that focus is real differentiation, and the build quality feels premium. The catch: it's the most expensive option in the category, and the $9/month membership isn't optional, which pushes the three-year cost past $1,000.</p>
+<p>Hearth is designed around <em>routines</em>, not just events: visual morning and evening checklists kids work through themselves, to-do assignments, and a portrait layout that reads like a poster. Families managing ADHD consistently praise it — that focus is real differentiation, and the build quality feels premium. The catch: it's the most expensive option in the category, and the membership isn't optional, which pushes the three-year cost to around $960.</p>
 <h2>The honest bottom line</h2>
 <ul>
 <li>Pick <strong>Skylight</strong> if the job is "everyone sees the family calendar" and you want the lower entry price.</li>
@@ -403,7 +403,7 @@
 <h2>The third option: don't buy a screen at all</h2>
 <p>Both products are, at heart, a screen showing your family's day. If you have an old tablet, a TV, or $100 for a Raspberry Pi, free software gives you the same glanceable calendar — with chore rotations and countdowns — for no subscription at all.</p>
 <p>That's what <a href="/">DinkyDash</a> does (free, open source, and with an AI-written daily brief neither Skylight nor Hearth offers). See <a href="/diy-skylight-calendar/">how to build one in an afternoon</a>, or compare <a href="/skylight-calendar-alternatives/">all seven Skylight alternatives</a>.</p>
-    <p class="page-updated">Last updated 2026-09-03.</p>
+    <p class="page-updated">Last updated 2026-09-06.</p>
 </div>
 
 </main>

--- a/docs/index.html
+++ b/docs/index.html
@@ -873,7 +873,7 @@
         <div class="math-grid">
             <div class="math-card">
                 <div class="math-name">Skylight Calendar Max 27&Prime;</div>
-                <div class="math-price">$629</div>
+                <div class="math-price">$599.99</div>
                 <div class="math-sub">+ $79/yr for Plus features</div>
             </div>
             <div class="math-card">
@@ -887,7 +887,7 @@
                 <div class="math-sub">$29/yr for the first 100 on the list</div>
             </div>
         </div>
-        <p class="math-note">Competitor prices checked July 2026. Skylight and Hearth are lovely products &mdash; you just might not need the hardware. Running DinkyDash on your own machine is free forever, and always will be.</p>
+        <p class="math-note">Competitor prices checked September 2026. Skylight and Hearth are lovely products &mdash; you just might not need the hardware. Running DinkyDash on your own machine is free forever, and always will be.</p>
     </div>
 </section>
 
@@ -1072,7 +1072,7 @@
             </details>
             <details>
                 <summary>How is this different from a Skylight or Hearth?</summary>
-                <p>Skylight and Hearth sell you a dedicated touchscreen ($299–$699) with an optional or required subscription on top. DinkyDash is just the software, running on a screen you already own. It also does something they don't: a line written fresh every morning from your actual day. <a href="/skylight-calendar-alternatives/">See the full comparison</a>.</p>
+                <p>Skylight and Hearth sell you a dedicated touchscreen ($330–$699) with an optional or required subscription on top. DinkyDash is just the software, running on a screen you already own. It also does something they don't: a line written fresh every morning from your actual day. <a href="/skylight-calendar-alternatives/">See the full comparison</a>.</p>
             </details>
         </div>
     </div>
@@ -1166,7 +1166,7 @@
     {
       "@type": "Question",
       "name": "How is this different from a Skylight or Hearth?",
-      "acceptedAnswer": { "@type": "Answer", "text": "Skylight and Hearth sell you a dedicated touchscreen ($299–$699) with an optional or required subscription on top. DinkyDash is just the software, running on a screen you already own. It also does something they don't: a line written fresh every morning from your actual day." }
+      "acceptedAnswer": { "@type": "Answer", "text": "Skylight and Hearth sell you a dedicated touchscreen ($330–$699) with an optional or required subscription on top. DinkyDash is just the software, running on a screen you already own. It also does something they don't: a line written fresh every morning from your actual day." }
     }
   ]
 }

--- a/docs/raspberry-pi-family-calendar/index.html
+++ b/docs/raspberry-pi-family-calendar/index.html
@@ -458,8 +458,8 @@
 </ul>
 <p>Both are covered, with fixes, in the <a href="/getting-started/">troubleshooting section</a>.</p>
 <h2>Why build one instead of buying</h2>
-<p>A Skylight Calendar Max is $629, plus $79 a year for the Plus features. A Hearth Display is $699 plus $9 a month. They're nicely made, and if you want something that works out of the box with a support line, they're reasonable purchases.</p>
-<p>But a digital family calendar is fundamentally a screen showing a web page. If you're comfortable with a terminal, the Pi version costs about a sixth as much, has no subscription, keeps your family's data on your own device, and does one thing the $629 hardware doesn't: writes you a fresh daily brief every morning.</p>
+<p>A Skylight Calendar Max is $599.99, plus $79 a year for the Plus features. A Hearth Display is $699 plus $9 a month. They're nicely made, and if you want something that works out of the box with a support line, they're reasonable purchases.</p>
+<p>But a digital family calendar is fundamentally a screen showing a web page. If you're comfortable with a terminal, the Pi version costs about a sixth as much, has no subscription, keeps your family's data on your own device, and does one thing the $600 hardware doesn't: writes you a fresh daily brief every morning.</p>
 <p>The full cost comparison is on the <a href="/diy-skylight-calendar/">DIY Skylight calendar page</a>.</p>
 <h2>Start building</h2>
 <p>Everything you need is in the <a href="/getting-started/">setup guide</a> — install, config, cron, systemd service and kiosk mode, with the commands to copy. Budget an evening for the first build.</p>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://dinkydash.co/</loc>
-    <lastmod>2026-09-03</lastmod>
+    <lastmod>2026-09-06</lastmod>
   </url>
   <url>
     <loc>https://dinkydash.co/about/</loc>
@@ -18,7 +18,7 @@
   </url>
   <url>
     <loc>https://dinkydash.co/digital-calendar-and-chore-chart/</loc>
-    <lastmod>2026-09-03</lastmod>
+    <lastmod>2026-09-06</lastmod>
   </url>
   <url>
     <loc>https://dinkydash.co/diy-skylight-calendar/</loc>
@@ -34,7 +34,7 @@
   </url>
   <url>
     <loc>https://dinkydash.co/hearth-vs-skylight/</loc>
-    <lastmod>2026-09-03</lastmod>
+    <lastmod>2026-09-06</lastmod>
   </url>
   <url>
     <loc>https://dinkydash.co/morning-routine/</loc>
@@ -50,10 +50,10 @@
   </url>
   <url>
     <loc>https://dinkydash.co/skylight-calendar-alternatives/</loc>
-    <lastmod>2026-09-03</lastmod>
+    <lastmod>2026-09-06</lastmod>
   </url>
   <url>
     <loc>https://dinkydash.co/skylight-calendar-subscription/</loc>
-    <lastmod>2026-09-03</lastmod>
+    <lastmod>2026-09-06</lastmod>
   </url>
 </urlset>

--- a/docs/skylight-calendar-alternatives/index.html
+++ b/docs/skylight-calendar-alternatives/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>The 7 Best Skylight Calendar Alternatives in 2026 — DinkyDash</title>
-    <meta name="description" content="Looking for a Skylight Calendar alternative without the $299–$629 price tag or the $79/year subscription? Here are 7 options — including free ones that run on screens you already own.">
+    <meta name="description" content="Looking for a Skylight Calendar alternative without the $329.99–$599.99 price tag or the $79/year subscription? Here are 7 options — including free ones that run on screens you already own.">
     <link rel="canonical" href="https://dinkydash.co/skylight-calendar-alternatives/">
     
     <link rel="icon" href="/favicon.ico" sizes="any">
@@ -15,7 +15,7 @@
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://dinkydash.co/skylight-calendar-alternatives/">
     <meta property="og:image" content="https://dinkydash.co/images/og-hero.jpg">
-    <meta property="og:description" content="Looking for a Skylight Calendar alternative without the $299–$629 price tag or the $79/year subscription? Here are 7 options — including free ones that run on screens you already own.">
+    <meta property="og:description" content="Looking for a Skylight Calendar alternative without the $329.99–$599.99 price tag or the $79/year subscription? Here are 7 options — including free ones that run on screens you already own.">
     <meta name="twitter:card" content="summary_large_image">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -315,9 +315,9 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "The 7 Best Skylight Calendar Alternatives in 2026",
-  "description": "Looking for a Skylight Calendar alternative without the $299\u2013$629 price tag or the $79/year subscription? Here are 7 options \u2014 including free ones that run on screens you already own.",
+  "description": "Looking for a Skylight Calendar alternative without the $329.99\u2013$599.99 price tag or the $79/year subscription? Here are 7 options \u2014 including free ones that run on screens you already own.",
   "mainEntityOfPage": "https://dinkydash.co/skylight-calendar-alternatives/",
-  "dateModified": "2026-09-03",
+  "dateModified": "2026-09-06",
   "author": { "@type": "Person", "name": "Caspar Wrede", "url": "https://casparwre.de" },
   "publisher": { "@id": "https://dinkydash.co/#org" }
 }
@@ -347,7 +347,7 @@
     
 <div class="container page-content">
     <h1>The 7 Best Skylight Calendar Alternatives in 2026</h1>
-    <p>The Skylight Calendar is a lovely idea: your family's schedule, big and glanceable, on the kitchen wall. But between the hardware ($299 for the 15″ Calendar 2, $629 for the 27″ Calendar Max) and the optional $79/year Plus subscription for features like meal planning and chore rewards, plenty of families go looking for alternatives before checking out.</p>
+    <p>The Skylight Calendar is a lovely idea: your family's schedule, big and glanceable, on the kitchen wall. But between the hardware ($329.99 for the 15″ Calendar 2, $599.99 for the 27″ Calendar Max) and the optional $79/year Plus subscription for features like meal planning and chore rewards, plenty of families go looking for alternatives before checking out.</p>
 <p>The good news: you have real options — including some that cost nothing because they run on a screen you already own.</p>
 <p><img alt="The same family calendar dashboard running on a TV, an old iPad, and a Raspberry Pi touchscreen" src="/images/any-screen-family-calendar.webp" width="1408" height="768" decoding="async" /></p>
 <h2>Quick comparison</h2>
@@ -376,18 +376,18 @@
 <tr>
 <td><strong>DAKboard</strong></td>
 <td>$0</td>
-<td>Free tier; $5–8/mo</td>
+<td>Free tier; $5–10/mo</td>
 <td>Yes</td>
 </tr>
 <tr>
 <td><strong>Hearth Display</strong></td>
 <td>$699</td>
-<td>$9/mo</td>
+<td>$9/mo ($86.40/yr)</td>
 <td>No</td>
 </tr>
 <tr>
 <td><strong>Cozyla</strong></td>
-<td>Varies by size</td>
+<td>From $169.99</td>
 <td>Advertises no monthly fees</td>
 <td>No</td>
 </tr>
@@ -405,22 +405,22 @@
 </tr>
 </tbody>
 </table>
-<p><em>Prices checked July 2026 — always confirm current pricing before buying.</em></p>
+<p><em>Prices checked September 2026 — always confirm current pricing before buying.</em></p>
 <h2>1. DinkyDash — free, open source, and AI-powered</h2>
 <p>Full disclosure: DinkyDash is our project, so we're biased — but it exists precisely because we wanted a Skylight without the hardware bill. DinkyDash turns any TV, tablet, Raspberry Pi, or spare monitor into a family calendar with a daily chore rotation, birthday countdowns, and something no other option here has: <strong>a daily brief written by AI every morning</strong>, personalized to your family's actual day.</p>
 <p>It's MIT-licensed and free. The trade-off: today you set it up yourself, which means being comfortable with a terminal for an afternoon. Our <a href="/getting-started/">getting started guide</a> walks you through it, and a zero-setup hosted version is in the works.</p>
 <p><strong>Best for:</strong> families with a tinkerer in the house who want $0 hardware and no subscription.</p>
 <h2>2. Mango Display — polished BYO-screen software</h2>
-<p>Mango Display is a commercial take on the same idea: install their app on a smart TV, Fire TV, or tablet and it renders a calendar-centric smart display with widgets for photos, weather, and to-dos. There's a free tier, and the Pro plan is $5.99/month.</p>
+<p>Mango Display is a commercial take on the same idea: install their app on a smart TV, Fire TV, or tablet and it renders a calendar-centric smart display with widgets for photos, weather, and to-dos. There's a free tier (two screens), and the Pro plan is $5.99/month, or $59.99 a year.</p>
 <p><strong>Best for:</strong> families who want bring-your-own-screen without any DIY at all.</p>
 <h2>3. DAKboard — the customizable wall display veteran</h2>
-<p>DAKboard has been the DIY wall-display favorite for years — calendars, photos, weather, and news on any screen, with deep layout customization. Free for a basic screen; $5–8/month unlocks custom layouts and multiple screens. It's more "information display" than "family organizer" — there's no chore system aimed at kids.</p>
+<p>DAKboard has been the DIY wall-display favorite for years — calendars, photos, weather, and news on any screen, with deep layout customization. Free for a basic screen; $5–10/month unlocks custom layouts and multiple screens. It's more "information display" than "family organizer" — there's no chore system aimed at kids.</p>
 <p><strong>Best for:</strong> data-dense household dashboards and tinkerers who want full layout control.</p>
 <h2>4. Hearth Display — the premium hardware rival</h2>
-<p>If what you actually want is <em>nicer</em> dedicated hardware, Hearth's 27″ portrait display ($699 + $9/month membership) focuses on routines and visual schedules — it's especially popular with ADHD and neurodivergent families. It costs more than Skylight over time, but the routine-building features are genuinely different. See our full <a href="/hearth-vs-skylight/">Hearth vs Skylight comparison</a>.</p>
+<p>If what you actually want is <em>nicer</em> dedicated hardware, Hearth's 27″ portrait display ($699 + $9/month, or $86.40 a year) focuses on routines and visual schedules — it's especially popular with ADHD and neurodivergent families. It costs more than Skylight over time, but the routine-building features are genuinely different. See our full <a href="/hearth-vs-skylight/">Hearth vs Skylight comparison</a>.</p>
 <p><strong>Best for:</strong> families who want routines and to-dos front and center, and don't mind the price.</p>
 <h2>5. Cozyla — hardware without the monthly fee</h2>
-<p>Cozyla sells digital calendar displays that advertise no monthly fees — the feature set that Skylight puts behind Plus (like AI-assisted event import) is included. Build quality and app polish get mixed reviews compared to Skylight, but "pay once" is a compelling pitch.</p>
+<p>Cozyla sells digital calendar displays from $169.99 that advertise no monthly fees — the feature set that Skylight puts behind Plus (like AI-assisted event import) is included. Build quality and app polish get mixed reviews compared to Skylight, but "pay once" is a compelling pitch.</p>
 <p><strong>Best for:</strong> families set on dedicated hardware who refuse subscriptions.</p>
 <h2>6. Cozi — the free app (no wall display)</h2>
 <p>Cozi is the most popular shared family calendar app: free, cross-platform, with shopping lists and meal planning. There's no wall-display product — it lives on phones. Some families genuinely don't need the wall screen; if that's you, start here before spending anything.</p>
@@ -437,7 +437,7 @@
 <li><strong>Want hardware but no subscription:</strong> Cozyla</li>
 <li><strong>Not sure you need a wall display at all:</strong> Cozi on your phones, or the old-tablet test</li>
 </ul>
-    <p class="page-updated">Last updated 2026-09-03.</p>
+    <p class="page-updated">Last updated 2026-09-06.</p>
 </div>
 
 </main>

--- a/docs/skylight-calendar-subscription/index.html
+++ b/docs/skylight-calendar-subscription/index.html
@@ -317,7 +317,7 @@
   "headline": "Does the Skylight Calendar Require a Subscription? (2026)",
   "description": "Short answer: no for the basics, but the good stuff costs $79/year. Here\u0027s exactly what Skylight Plus covers in 2026, the real first-year math, and the subscription-free alternatives.",
   "mainEntityOfPage": "https://dinkydash.co/skylight-calendar-subscription/",
-  "dateModified": "2026-09-03",
+  "dateModified": "2026-09-06",
   "author": { "@type": "Person", "name": "Caspar Wrede", "url": "https://casparwre.de" },
   "publisher": { "@id": "https://dinkydash.co/#org" }
 }
@@ -341,7 +341,7 @@
       "name": "How much does Skylight Plus cost?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "$79 per year as of July 2026, with the first month free. Skylight adjusts pricing and bundles regularly, and Costco bundles sometimes include a year of Plus."
+        "text": "$79 per year as of September 2026, with the first month free. Skylight adjusts pricing and bundles regularly, and Costco bundles sometimes include a year of Plus."
       }
     },
     {
@@ -357,7 +357,7 @@
       "name": "What does a Skylight Calendar cost in the first year with Plus?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "About $379 for the 15-inch Calendar 2 ($299 plus $79 a year) and about $708 for the 27-inch Calendar Max ($629 plus $79 a year). Over three years the Max works out at roughly $866."
+        "text": "About $409 for the 15-inch Calendar 2 ($329.99 plus $79 a year) and about $679 for the 27-inch Calendar Max ($599.99 plus $79 a year). Over three years the Max works out at roughly $837."
       }
     },
     {
@@ -395,7 +395,7 @@
 <div class="container page-content">
     <h1>Does the Skylight Calendar Require a Subscription? (2026)</h1>
     <p><strong>Short answer: no — the Skylight Calendar works without a subscription.</strong> Calendar syncing, the shared family view, basic chore charts, and lists all work on the device you bought, forever.</p>
-<p><strong>The longer answer:</strong> the features in most of Skylight's marketing live behind <strong>Skylight Plus, which costs $79 per year</strong> (first month free). As of July 2026, Plus is what unlocks:</p>
+<p><strong>The longer answer:</strong> the features in most of Skylight's marketing live behind <strong>Skylight Plus, which costs $79 per year</strong> (first month free). As of September 2026, Plus is what unlocks:</p>
 <ul>
 <li><strong>Meal planning</strong> — the recipe box and weekly dinner plan on the calendar</li>
 <li><strong>Magic Import</strong> — photograph a school newsletter or forward an email, and AI turns it into calendar events</li>
@@ -414,22 +414,22 @@
 <tbody>
 <tr>
 <td>Skylight Calendar 2 (15″)</td>
-<td>$299</td>
-<td>$299 + $79/yr → <strong>~$379 first year</strong></td>
+<td>$329.99</td>
+<td>$329.99 + $79/yr → <strong>~$409 first year</strong></td>
 </tr>
 <tr>
 <td>Skylight Calendar Max (27″)</td>
-<td>$629</td>
-<td>$629 + $79/yr → <strong>~$708 first year</strong></td>
+<td>$599.99</td>
+<td>$599.99 + $79/yr → <strong>~$679 first year</strong></td>
 </tr>
 <tr>
 <td>Cost over 3 years (Max)</td>
-<td>$629</td>
-<td><strong>~$866</strong></td>
+<td>$599.99</td>
+<td><strong>~$837</strong></td>
 </tr>
 </tbody>
 </table>
-<p><em>Prices checked July 2026 — Skylight adjusts pricing and bundles regularly (Costco bundles sometimes include a year of Plus).</em></p>
+<p><em>Prices checked September 2026 — Skylight adjusts pricing and bundles regularly (Costco bundles sometimes include a year of Plus).</em></p>
 <h2>Is Plus worth $79 a year?</h2>
 <p>If Magic Import and meal planning would genuinely get used weekly in your house, most owners say yes. If you bought the calendar to <em>see the family calendar</em>, you can skip Plus entirely and lose nothing essential — just know that the chore-rewards and photo-frame features you may have seen in ads won't be there.</p>
 <h2>If subscriptions are the dealbreaker</h2>
@@ -444,14 +444,14 @@
 <p><strong>Does the Skylight Calendar require a subscription?</strong>
 No. Calendar syncing, the shared family view, basic chore charts and lists all work on the device you bought, with no subscription. The extras — meal planning, Magic Import, chore rewards and the photo screensaver — need Skylight Plus at $79 per year.</p>
 <p><strong>How much does Skylight Plus cost?</strong>
-$79 per year as of July 2026, with the first month free. Skylight adjusts pricing and bundles regularly, and Costco bundles sometimes include a year of Plus.</p>
+$79 per year as of September 2026, with the first month free. Skylight adjusts pricing and bundles regularly, and Costco bundles sometimes include a year of Plus.</p>
 <p><strong>What does Skylight Plus include?</strong>
 Meal planning with a recipe box and weekly dinner plan, Magic Import (photograph a school newsletter or forward an email and AI turns it into events), chore rewards with stars and tracking, and a photo screensaver for when the calendar is idle.</p>
 <p><strong>What does a Skylight Calendar cost in the first year with Plus?</strong>
-About $379 for the 15-inch Calendar 2 ($299 plus $79 a year) and about $708 for the 27-inch Calendar Max ($629 plus $79 a year). Over three years the Max works out at roughly $866.</p>
+About $409 for the 15-inch Calendar 2 ($329.99 plus $79 a year) and about $679 for the 27-inch Calendar Max ($599.99 plus $79 a year). Over three years the Max works out at roughly $837.</p>
 <p><strong>Is there a family calendar with no subscription at all?</strong>
 Yes. You can keep a Skylight and skip Plus, buy hardware like Cozyla that advertises no monthly fees, or run free open-source software such as <a href="/diy-skylight-calendar/">DinkyDash</a> on a TV, tablet or Raspberry Pi you already own, which costs nothing per month.</p>
-    <p class="page-updated">Last updated 2026-09-03.</p>
+    <p class="page-updated">Last updated 2026-09-06.</p>
 </div>
 
 </main>

--- a/website/content/about.md
+++ b/website/content/about.md
@@ -7,7 +7,7 @@ description: DinkyDash is a free, open-source digital family calendar that runs 
 
 DinkyDash is a free, open-source **digital family calendar for screens you already own**. Point a TV, an old tablet, or a Raspberry Pi at it and your family gets one glanceable screen with today's calendar, a self-rotating chore chart, countdowns to the big days — and a daily brief written fresh every morning by AI.
 
-It was built by [Caspar](https://casparwre.de), an indie developer in Berlin, for his own kids — and open-sourced because a family calendar shouldn't cost $629 plus a subscription.
+It was built by [Caspar](https://casparwre.de), an indie developer in Berlin, for his own kids — and open-sourced because a family calendar shouldn't cost $600 plus a subscription.
 
 ## Why an AI-written dashboard?
 

--- a/website/content/best-digital-family-calendar.md
+++ b/website/content/best-digital-family-calendar.md
@@ -11,13 +11,13 @@ Every "best digital family calendar" list starts from the same assumption: that 
 
 ## Path 1: Buy a dedicated calendar display
 
-You're paying for plug-and-play: unbox, connect Wi-Fi, done. As of July 2026:
+You're paying for plug-and-play: unbox, connect Wi-Fi, done. As of September 2026:
 
-**Skylight Calendar 2 (15″, $299) / Calendar Max (27″, $629)** — the category leader and the safest pick. Best-in-class calendar view, meal planning and AI event import with the optional Plus plan ($79/yr). If you just want it to work, buy this. ([What the subscription does and doesn't cover →](/skylight-calendar-subscription/))
+**Skylight Calendar 2 (15″, $329.99) / Calendar Max (27″, $599.99)** — the category leader and the safest pick. Best-in-class calendar view, meal planning and AI event import with the optional Plus plan ($79/yr). If you just want it to work, buy this. ([What the subscription does and doesn't cover →](/skylight-calendar-subscription/))
 
-**Hearth Display (27″, $699 + $9/mo)** — the routines specialist. Visual morning/evening checklists kids run themselves; a favorite with ADHD families. Priciest option in the category. ([Hearth vs Skylight compared →](/hearth-vs-skylight/))
+**Hearth Display (27″, $699 + $9/mo, or $86.40/yr billed annually)** — the routines specialist. Visual morning/evening checklists kids run themselves; a favorite with ADHD families. Priciest option in the category. ([Hearth vs Skylight compared →](/hearth-vs-skylight/))
 
-**Cozyla** — dedicated hardware whose pitch is "no monthly fees" — features that cost extra elsewhere are included. Less polished than Skylight, but pay-once pricing.
+**Cozyla (from $169.99)** — dedicated hardware whose pitch is "no monthly fees" — features that cost extra elsewhere are included. Less polished than Skylight, but pay-once pricing.
 
 ## Path 2: Use a screen you already own
 
@@ -25,9 +25,9 @@ A family calendar display is, mechanically, a screen showing a web page. If a sp
 
 **DinkyDash (free, open source)** — our project, and the reason this site exists. Any screen with a browser becomes a family calendar with automatic chore rotation, birthday countdowns, and an AI-written daily brief — a fresh greeting and fun fact every morning, written around your own family, which no hardware calendar offers. Setup takes an afternoon and a bit of terminal comfort ([guide](/getting-started/)); a zero-setup hosted version is [in the works](https://fffwryhvses.typeform.com/to/yxMMhmFs).
 
-**Mango Display (free tier; Pro $5.99/mo)** — commercial BYO-screen software with polished apps for smart TVs and tablets. The no-DIY version of this path.
+**Mango Display (free tier; Pro $5.99/mo or $59.99/yr)** — commercial BYO-screen software with polished apps for smart TVs and tablets. The no-DIY version of this path.
 
-**DAKboard (free tier; $5–8/mo)** — the veteran customizable wall display. Enormous flexibility, more "information dashboard" than "family organizer."
+**DAKboard (free tier; $5–10/mo)** — the veteran customizable wall display. Enormous flexibility, more "information dashboard" than "family organizer."
 
 ## How to decide
 
@@ -40,13 +40,13 @@ A family calendar display is, mechanically, a screen showing a web page. If a sp
 
 | | Hardware | Ongoing cost | Standout feature |
 |---|---|---|---|
-| Skylight Cal 2 / Max | $299 / $629 | $0–79/yr | Best plug-and-play calendar |
-| Hearth | $699 | $108/yr | Visual routines for kids |
-| Cozyla | Varies | $0 | Pay-once hardware |
+| Skylight Cal 2 / Max | $329.99 / $599.99 | $0–79/yr | Best plug-and-play calendar |
+| Hearth | $699 | $86.40/yr | Visual routines for kids |
+| Cozyla | From $169.99 | $0 | Pay-once hardware |
 | DinkyDash | $0 (your screen) | $0 | AI daily brief, open source |
-| Mango Display | $0 (your screen) | $0–72/yr | Easiest BYO-screen |
-| DAKboard | $0 (your screen) | $0–96/yr | Deep customization |
+| Mango Display | $0 (your screen) | $0–60/yr | Easiest BYO-screen |
+| DAKboard | $0 (your screen) | $0–120/yr | Deep customization |
 
-*Prices checked July 2026.*
+*Prices checked September 2026.*
 
 Whichever path you take: the win isn't the gadget, it's the behavior change — the family checking one shared screen instead of asking one exhausted parent. The cheapest way to test whether that works in your house is [the free one](/getting-started/).

--- a/website/content/digital-calendar-and-chore-chart.md
+++ b/website/content/digital-calendar-and-chore-chart.md
@@ -25,10 +25,10 @@ Nobody negotiates with a screen. The rotation is provably fair (it cycles throug
 | Option | Cost | Chore features |
 |---|---|---|
 | **DinkyDash** (screen you own) | Free, open source | Automatic daily rotation |
-| **Skylight Calendar** | $299–$629 | Chore chart free; rewards need Plus ($79/yr) |
-| **Hearth Display** | $699 + $9/mo | Routines and task assignments |
+| **Skylight Calendar** | $329.99–$599.99 | Chore chart free; rewards need Plus ($79/yr) |
+| **Hearth Display** | $699 + $9/mo ($86.40/yr) | Routines and task assignments |
 
-*Prices checked July 2026.*
+*Prices checked September 2026.*
 
 Skylight and Hearth both do chores well — that's part of why families pay for them. But if the hardware price is the obstacle, the free route gets you the core loop (visible chores, fair rotation, zero nagging) on a screen you already own. Our [DIY guide](/diy-skylight-calendar/) shows the whole build, and the [getting started guide](/getting-started/) has the copy-paste setup.
 

--- a/website/content/diy-skylight-calendar.md
+++ b/website/content/diy-skylight-calendar.md
@@ -5,7 +5,7 @@ template: page.html
 description: How to build your own Skylight-style digital family calendar with a Raspberry Pi or an old tablet — free, open-source software, no subscription, about $100 in hardware (or $0 if you have a spare screen).
 ---
 
-A Skylight Calendar Max costs $629, plus $79 a year if you want the Plus features. The thing is, a digital family calendar is fundamentally *a screen showing a web page* — and that's something you can build yourself for about $100 with a Raspberry Pi, or for **$0** with a tablet you already own.
+A Skylight Calendar Max costs $599.99, plus $79 a year if you want the Plus features. The thing is, a digital family calendar is fundamentally *a screen showing a web page* — and that's something you can build yourself for about $100 with a Raspberry Pi, or for **$0** with a tablet you already own.
 
 Here's exactly how, using [DinkyDash](https://github.com/caspii/dinkydash), our free and open-source family calendar software.
 
@@ -20,7 +20,7 @@ Your DIY calendar shows everything on one glanceable screen, refreshed automatic
 - **Countdowns** to birthdays, holidays, and vacations
 - **A daily brief written by AI** — a fresh greeting and fun fact every single morning, personalized to your family
 
-That last one is something even the $629 hardware doesn't do.
+That last one is something even the $600 hardware doesn't do.
 
 Want to see the countdown part before you build anything? Our [birthday countdown](/birthday-countdown/) runs in a browser tab, free and without a sign-up.
 
@@ -42,7 +42,7 @@ Before spending anything, prop up an old tablet or spare monitor in the kitchen 
 
 This sounds like a hedge, but it's the single most useful thing you can do. A family calendar only works if it's somewhere everyone walks past at the right time of day, and you will almost certainly get that spot wrong on the first try. Finding out with a tablet on a cookbook stand costs nothing. Finding out after mounting a Pi behind drywall is annoying.
 
-If it sticks, buy the hardware. If it doesn't, you've lost an evening instead of $629.
+If it sticks, buy the hardware. If it doesn't, you've lost an evening instead of $600.
 
 ## The build, in five steps
 
@@ -74,14 +74,14 @@ A cheap tablet wall mount, a picture ledge, or a small easel stand all work. Non
 
 | | Skylight Calendar Max | DIY with DinkyDash |
 |---|---|---|
-| Hardware | $629 | $0–130 |
+| Hardware | $599.99 | $0–130 |
 | Subscription | $79/yr for Plus features | None |
-| Three-year cost | ~$866 | ~$0–130 |
+| Three-year cost | ~$837 | ~$0–130 |
 | Your data | Their cloud | Your device |
 | AI daily brief | No | Yes |
 | Fixable/customizable | No | It's your code |
 
-*Prices checked July 2026.*
+*Prices checked September 2026.*
 
 ## Questions people ask
 

--- a/website/content/hearth-vs-skylight.md
+++ b/website/content/hearth-vs-skylight.md
@@ -2,7 +2,7 @@
 title: "Hearth vs Skylight (2026): Prices, Subscriptions, and Which to Buy"
 seo_title: "Hearth vs Skylight 2026: Prices, Subscriptions, Which to Buy"
 template: page.html
-description: Hearth Display ($699 + $9/mo) vs Skylight Calendar ($299–$629 + optional $79/yr) compared honestly — plus the third option both companies would rather you didn't know about.
+description: Hearth Display ($699 + $9/mo) vs Skylight Calendar ($329.99–$599.99 + optional $79/yr) compared honestly — plus the third option both companies would rather you didn't know about.
 ---
 
 Comparing the two big family-calendar displays? Here's the short version: **Skylight** is the calendar-first option with a lower entry price and an optional subscription. **Hearth** is the routines-first option — beloved by families managing ADHD and complex mornings — with a higher price and a required membership. And there's a third path that costs almost nothing, which we'll get to.
@@ -11,22 +11,22 @@ Comparing the two big family-calendar displays? Here's the short version: **Skyl
 
 | | Skylight Calendar | Hearth Display |
 |---|---|---|
-| Price | $299 (15″ Calendar 2) / $629 (27″ Max) | $699 (27″, sometimes $599 on promo) |
-| Subscription | Optional Plus, $79/yr | $9/mo after the first month |
+| Price | $329.99 (15″ Calendar 2) / $599.99 (27″ Max) | $699 (27″, often discounted) |
+| Subscription | Optional Plus, $79/yr | Required: $9/mo, or $86.40/yr billed annually |
 | Orientation | Landscape or portrait | Portrait |
 | Core strength | Shared calendar, meal planning | Routines, to-dos, visual schedules |
 | Chores | Chore chart; rewards need Plus | Routine and task system built in |
-| Realistic 3-year cost | $629 + $237 ≈ **$866** (Max with Plus) | $699 + ~$324 ≈ **$1,023** |
+| Realistic 3-year cost | $599.99 + $237 ≈ **$837** (Max with Plus) | $699 + $259 ≈ **$958** (annual membership) |
 
-*Prices checked July 2026.*
+*Prices checked September 2026.*
 
 ## Where Skylight wins
 
-Skylight nails the core job: your Google, Apple, or Outlook calendars merged into one big, color-coded family view. The interface is polished, the companion app is solid, and the 15″ model's $299 entry price is the lowest way into a premium dedicated display. Meal planning and its AI-powered "Magic Import" (photograph a school newsletter, get calendar events) are genuinely useful — but note they live behind the $79/year Plus plan. Read more on [what Skylight's subscription does and doesn't cover](/skylight-calendar-subscription/).
+Skylight nails the core job: your Google, Apple, or Outlook calendars merged into one big, color-coded family view. The interface is polished, the companion app is solid, and the 15″ model's $329.99 entry price is the lowest way into a premium dedicated display. Meal planning and its AI-powered "Magic Import" (photograph a school newsletter, get calendar events) are genuinely useful — but note they live behind the $79/year Plus plan. Read more on [what Skylight's subscription does and doesn't cover](/skylight-calendar-subscription/).
 
 ## Where Hearth wins
 
-Hearth is designed around *routines*, not just events: visual morning and evening checklists kids work through themselves, to-do assignments, and a portrait layout that reads like a poster. Families managing ADHD consistently praise it — that focus is real differentiation, and the build quality feels premium. The catch: it's the most expensive option in the category, and the $9/month membership isn't optional, which pushes the three-year cost past $1,000.
+Hearth is designed around *routines*, not just events: visual morning and evening checklists kids work through themselves, to-do assignments, and a portrait layout that reads like a poster. Families managing ADHD consistently praise it — that focus is real differentiation, and the build quality feels premium. The catch: it's the most expensive option in the category, and the membership isn't optional, which pushes the three-year cost to around $960.
 
 ## The honest bottom line
 

--- a/website/content/raspberry-pi-family-calendar.md
+++ b/website/content/raspberry-pi-family-calendar.md
@@ -98,9 +98,9 @@ Both are covered, with fixes, in the [troubleshooting section](/getting-started/
 
 ## Why build one instead of buying
 
-A Skylight Calendar Max is $629, plus $79 a year for the Plus features. A Hearth Display is $699 plus $9 a month. They're nicely made, and if you want something that works out of the box with a support line, they're reasonable purchases.
+A Skylight Calendar Max is $599.99, plus $79 a year for the Plus features. A Hearth Display is $699 plus $9 a month. They're nicely made, and if you want something that works out of the box with a support line, they're reasonable purchases.
 
-But a digital family calendar is fundamentally a screen showing a web page. If you're comfortable with a terminal, the Pi version costs about a sixth as much, has no subscription, keeps your family's data on your own device, and does one thing the $629 hardware doesn't: writes you a fresh daily brief every morning.
+But a digital family calendar is fundamentally a screen showing a web page. If you're comfortable with a terminal, the Pi version costs about a sixth as much, has no subscription, keeps your family's data on your own device, and does one thing the $600 hardware doesn't: writes you a fresh daily brief every morning.
 
 The full cost comparison is on the [DIY Skylight calendar page](/diy-skylight-calendar/).
 

--- a/website/content/skylight-calendar-alternatives.md
+++ b/website/content/skylight-calendar-alternatives.md
@@ -1,10 +1,10 @@
 ---
 title: The 7 Best Skylight Calendar Alternatives in 2026
 template: page.html
-description: Looking for a Skylight Calendar alternative without the $299–$629 price tag or the $79/year subscription? Here are 7 options — including free ones that run on screens you already own.
+description: Looking for a Skylight Calendar alternative without the $329.99–$599.99 price tag or the $79/year subscription? Here are 7 options — including free ones that run on screens you already own.
 ---
 
-The Skylight Calendar is a lovely idea: your family's schedule, big and glanceable, on the kitchen wall. But between the hardware ($299 for the 15″ Calendar 2, $629 for the 27″ Calendar Max) and the optional $79/year Plus subscription for features like meal planning and chore rewards, plenty of families go looking for alternatives before checking out.
+The Skylight Calendar is a lovely idea: your family's schedule, big and glanceable, on the kitchen wall. But between the hardware ($329.99 for the 15″ Calendar 2, $599.99 for the 27″ Calendar Max) and the optional $79/year Plus subscription for features like meal planning and chore rewards, plenty of families go looking for alternatives before checking out.
 
 The good news: you have real options — including some that cost nothing because they run on a screen you already own.
 
@@ -16,13 +16,13 @@ The good news: you have real options — including some that cost nothing becaus
 |---|---|---|---|
 | **DinkyDash** | $0 | None — open source | Yes |
 | **Mango Display** | $0 | Free tier; Pro $5.99/mo | Yes |
-| **DAKboard** | $0 | Free tier; $5–8/mo | Yes |
-| **Hearth Display** | $699 | $9/mo | No |
-| **Cozyla** | Varies by size | Advertises no monthly fees | No |
+| **DAKboard** | $0 | Free tier; $5–10/mo | Yes |
+| **Hearth Display** | $699 | $9/mo ($86.40/yr) | No |
+| **Cozyla** | From $169.99 | Advertises no monthly fees | No |
 | **Cozi** | $0 (phone app) | Free with ads | No wall display |
 | **Google Calendar on an old tablet** | $0 | None | Yes |
 
-*Prices checked July 2026 — always confirm current pricing before buying.*
+*Prices checked September 2026 — always confirm current pricing before buying.*
 
 ## 1. DinkyDash — free, open source, and AI-powered
 
@@ -34,25 +34,25 @@ It's MIT-licensed and free. The trade-off: today you set it up yourself, which m
 
 ## 2. Mango Display — polished BYO-screen software
 
-Mango Display is a commercial take on the same idea: install their app on a smart TV, Fire TV, or tablet and it renders a calendar-centric smart display with widgets for photos, weather, and to-dos. There's a free tier, and the Pro plan is $5.99/month.
+Mango Display is a commercial take on the same idea: install their app on a smart TV, Fire TV, or tablet and it renders a calendar-centric smart display with widgets for photos, weather, and to-dos. There's a free tier (two screens), and the Pro plan is $5.99/month, or $59.99 a year.
 
 **Best for:** families who want bring-your-own-screen without any DIY at all.
 
 ## 3. DAKboard — the customizable wall display veteran
 
-DAKboard has been the DIY wall-display favorite for years — calendars, photos, weather, and news on any screen, with deep layout customization. Free for a basic screen; $5–8/month unlocks custom layouts and multiple screens. It's more "information display" than "family organizer" — there's no chore system aimed at kids.
+DAKboard has been the DIY wall-display favorite for years — calendars, photos, weather, and news on any screen, with deep layout customization. Free for a basic screen; $5–10/month unlocks custom layouts and multiple screens. It's more "information display" than "family organizer" — there's no chore system aimed at kids.
 
 **Best for:** data-dense household dashboards and tinkerers who want full layout control.
 
 ## 4. Hearth Display — the premium hardware rival
 
-If what you actually want is *nicer* dedicated hardware, Hearth's 27″ portrait display ($699 + $9/month membership) focuses on routines and visual schedules — it's especially popular with ADHD and neurodivergent families. It costs more than Skylight over time, but the routine-building features are genuinely different. See our full [Hearth vs Skylight comparison](/hearth-vs-skylight/).
+If what you actually want is *nicer* dedicated hardware, Hearth's 27″ portrait display ($699 + $9/month, or $86.40 a year) focuses on routines and visual schedules — it's especially popular with ADHD and neurodivergent families. It costs more than Skylight over time, but the routine-building features are genuinely different. See our full [Hearth vs Skylight comparison](/hearth-vs-skylight/).
 
 **Best for:** families who want routines and to-dos front and center, and don't mind the price.
 
 ## 5. Cozyla — hardware without the monthly fee
 
-Cozyla sells digital calendar displays that advertise no monthly fees — the feature set that Skylight puts behind Plus (like AI-assisted event import) is included. Build quality and app polish get mixed reviews compared to Skylight, but "pay once" is a compelling pitch.
+Cozyla sells digital calendar displays from $169.99 that advertise no monthly fees — the feature set that Skylight puts behind Plus (like AI-assisted event import) is included. Build quality and app polish get mixed reviews compared to Skylight, but "pay once" is a compelling pitch.
 
 **Best for:** families set on dedicated hardware who refuse subscriptions.
 

--- a/website/content/skylight-calendar-subscription.md
+++ b/website/content/skylight-calendar-subscription.md
@@ -7,18 +7,18 @@ faq:
   - q: "Does the Skylight Calendar require a subscription?"
     a: "No. Calendar syncing, the shared family view, basic chore charts and lists all work on the device you bought, with no subscription. The extras — meal planning, Magic Import, chore rewards and the photo screensaver — need Skylight Plus at $79 per year."
   - q: "How much does Skylight Plus cost?"
-    a: "$79 per year as of July 2026, with the first month free. Skylight adjusts pricing and bundles regularly, and Costco bundles sometimes include a year of Plus."
+    a: "$79 per year as of September 2026, with the first month free. Skylight adjusts pricing and bundles regularly, and Costco bundles sometimes include a year of Plus."
   - q: "What does Skylight Plus include?"
     a: "Meal planning with a recipe box and weekly dinner plan, Magic Import (photograph a school newsletter or forward an email and AI turns it into events), chore rewards with stars and tracking, and a photo screensaver for when the calendar is idle."
   - q: "What does a Skylight Calendar cost in the first year with Plus?"
-    a: "About $379 for the 15-inch Calendar 2 ($299 plus $79 a year) and about $708 for the 27-inch Calendar Max ($629 plus $79 a year). Over three years the Max works out at roughly $866."
+    a: "About $409 for the 15-inch Calendar 2 ($329.99 plus $79 a year) and about $679 for the 27-inch Calendar Max ($599.99 plus $79 a year). Over three years the Max works out at roughly $837."
   - q: "Is there a family calendar with no subscription at all?"
     a: "Yes. You can keep a Skylight and skip Plus, buy hardware like Cozyla that advertises no monthly fees, or run free open-source software such as DinkyDash on a TV, tablet or Raspberry Pi you already own, which costs nothing per month."
 ---
 
 **Short answer: no — the Skylight Calendar works without a subscription.** Calendar syncing, the shared family view, basic chore charts, and lists all work on the device you bought, forever.
 
-**The longer answer:** the features in most of Skylight's marketing live behind **Skylight Plus, which costs $79 per year** (first month free). As of July 2026, Plus is what unlocks:
+**The longer answer:** the features in most of Skylight's marketing live behind **Skylight Plus, which costs $79 per year** (first month free). As of September 2026, Plus is what unlocks:
 
 - **Meal planning** — the recipe box and weekly dinner plan on the calendar
 - **Magic Import** — photograph a school newsletter or forward an email, and AI turns it into calendar events
@@ -29,11 +29,11 @@ faq:
 
 | | Without Plus | With Plus |
 |---|---|---|
-| Skylight Calendar 2 (15″) | $299 | $299 + $79/yr → **~$379 first year** |
-| Skylight Calendar Max (27″) | $629 | $629 + $79/yr → **~$708 first year** |
-| Cost over 3 years (Max) | $629 | **~$866** |
+| Skylight Calendar 2 (15″) | $329.99 | $329.99 + $79/yr → **~$409 first year** |
+| Skylight Calendar Max (27″) | $599.99 | $599.99 + $79/yr → **~$679 first year** |
+| Cost over 3 years (Max) | $599.99 | **~$837** |
 
-*Prices checked July 2026 — Skylight adjusts pricing and bundles regularly (Costco bundles sometimes include a year of Plus).*
+*Prices checked September 2026 — Skylight adjusts pricing and bundles regularly (Costco bundles sometimes include a year of Plus).*
 
 ## Is Plus worth $79 a year?
 
@@ -55,13 +55,13 @@ For the full field, see our guide to [the 7 best Skylight Calendar alternatives]
 No. Calendar syncing, the shared family view, basic chore charts and lists all work on the device you bought, with no subscription. The extras — meal planning, Magic Import, chore rewards and the photo screensaver — need Skylight Plus at $79 per year.
 
 **How much does Skylight Plus cost?**
-$79 per year as of July 2026, with the first month free. Skylight adjusts pricing and bundles regularly, and Costco bundles sometimes include a year of Plus.
+$79 per year as of September 2026, with the first month free. Skylight adjusts pricing and bundles regularly, and Costco bundles sometimes include a year of Plus.
 
 **What does Skylight Plus include?**
 Meal planning with a recipe box and weekly dinner plan, Magic Import (photograph a school newsletter or forward an email and AI turns it into events), chore rewards with stars and tracking, and a photo screensaver for when the calendar is idle.
 
 **What does a Skylight Calendar cost in the first year with Plus?**
-About $379 for the 15-inch Calendar 2 ($299 plus $79 a year) and about $708 for the 27-inch Calendar Max ($629 plus $79 a year). Over three years the Max works out at roughly $866.
+About $409 for the 15-inch Calendar 2 ($329.99 plus $79 a year) and about $679 for the 27-inch Calendar Max ($599.99 plus $79 a year). Over three years the Max works out at roughly $837.
 
 **Is there a family calendar with no subscription at all?**
 Yes. You can keep a Skylight and skip Plus, buy hardware like Cozyla that advertises no monthly fees, or run free open-source software such as [DinkyDash](/diy-skylight-calendar/) on a TV, tablet or Raspberry Pi you already own, which costs nothing per month.

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -551,7 +551,7 @@
         <div class="math-grid">
             <div class="math-card">
                 <div class="math-name">Skylight Calendar Max 27&Prime;</div>
-                <div class="math-price">$629</div>
+                <div class="math-price">$599.99</div>
                 <div class="math-sub">+ $79/yr for Plus features</div>
             </div>
             <div class="math-card">
@@ -565,7 +565,7 @@
                 <div class="math-sub">$29/yr for the first 100 on the list</div>
             </div>
         </div>
-        <p class="math-note">Competitor prices checked July 2026. Skylight and Hearth are lovely products &mdash; you just might not need the hardware. Running DinkyDash on your own machine is free forever, and always will be.</p>
+        <p class="math-note">Competitor prices checked September 2026. Skylight and Hearth are lovely products &mdash; you just might not need the hardware. Running DinkyDash on your own machine is free forever, and always will be.</p>
     </div>
 </section>
 
@@ -750,7 +750,7 @@
             </details>
             <details>
                 <summary>How is this different from a Skylight or Hearth?</summary>
-                <p>Skylight and Hearth sell you a dedicated touchscreen ($299–$699) with an optional or required subscription on top. DinkyDash is just the software, running on a screen you already own. It also does something they don't: a line written fresh every morning from your actual day. <a href="/skylight-calendar-alternatives/">See the full comparison</a>.</p>
+                <p>Skylight and Hearth sell you a dedicated touchscreen ($330–$699) with an optional or required subscription on top. DinkyDash is just the software, running on a screen you already own. It also does something they don't: a line written fresh every morning from your actual day. <a href="/skylight-calendar-alternatives/">See the full comparison</a>.</p>
             </details>
         </div>
     </div>
@@ -813,7 +813,7 @@
     {
       "@type": "Question",
       "name": "How is this different from a Skylight or Hearth?",
-      "acceptedAnswer": { "@type": "Answer", "text": "Skylight and Hearth sell you a dedicated touchscreen ($299–$699) with an optional or required subscription on top. DinkyDash is just the software, running on a screen you already own. It also does something they don't: a line written fresh every morning from your actual day." }
+      "acceptedAnswer": { "@type": "Answer", "text": "Skylight and Hearth sell you a dedicated touchscreen ($330–$699) with an optional or required subscription on top. DinkyDash is just the software, running on a screen you already own. It also does something they don't: a line written fresh every morning from your actual day." }
     }
   ]
 }


### PR DESCRIPTION
Every competitor price on the marketing site was re-fetched from the vendor's own page on 6 September 2026, because the pages were stamped "checked July 2026" against a quarterly rule and four of the figures had drifted.

The one that mattered: Hearth's subscription was listed at **$108/yr**, which was $9/mo multiplied by twelve — they sell an annual plan at **$86.40**, so we were publishing a rival's price a quarter above what they charge, and the error propagated into a three-year comparison claiming Hearth "pushes the three-year cost past $1,000" when the real figure is $958.

Also corrected: Skylight 15" $299 → **$329.99** and 27" $629 → **$599.99** (two of these ran against us — the small one is dearer than we said, the large one cheaper), Mango's annual $0–72/yr → **$59.99/yr**, DAKboard $5–8/mo → **$5–10/mo**, Cozyla "Varies" → **from $169.99**, and the derived first-year and three-year sums that depend on all of the above.

Rounded rhetorical figures such as "no $300 hardware" are left alone because they still hold with the cheapest Skylight at $329.99, and the Raspberry Pi part prices keep their August 2026 stamp since they were not re-checked.

`docs/` is the rebuilt output of `website/` with no hand edits, and the 157 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
