### PR TITLE
Run the tests on every push, and fail the build on a leaked secret (DIN-16)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Copy to .env and fill in. .env is gitignored and must never be committed.
+#
+# This is the whole file — ANTHROPIC_API_KEY and nothing else. Nothing in the
+# app reads FLASK_ENV, SECRET_KEY, DATABASE_URL or UPLOAD_FOLDER; the session
+# key comes from DINKYDASH_SECRET_KEY in the environment, not from here.
+#
+# Get a key at https://console.anthropic.com/settings/keys. It is used once a
+# day, for the headline and the one written line. Everything else on the board
+# — the agenda, the chore turns, the countdowns — is computed locally and works
+# without one.
+ANTHROPIC_API_KEY=

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,56 @@
+# Runs on every push and pull request. Two independent jobs, so a secret in a
+# commit and a broken test are separate red X's rather than one.
+name: Tests
+
+on: [push, pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: pytest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v7
+        with:
+          # The version the Pi runs and the version the tests are written
+          # against. strftime("%-d") is glibc-specific, so this must stay Linux.
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: |
+            requirements.txt
+            requirements-dev.txt
+
+      # requirements-dev.txt pulls in requirements.txt, so this installs both.
+      - run: pip install -r requirements-dev.txt
+
+      - run: python -m pytest tests/ -q
+
+  gitleaks:
+    name: gitleaks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # Full history. gitleaks scans commits, not the working tree, so a
+          # shallow clone would only ever look at the tip.
+          fetch-depth: 0
+
+      # The upstream gitleaks-action is a bundled JavaScript blob under a
+      # commercial licence. gitleaks itself is MIT and ships a static binary,
+      # so run that instead — one fewer thing with a token in our CI. Pinned,
+      # for the same reason requirements.txt is.
+      - name: Install gitleaks
+        env:
+          GITLEAKS_VERSION: "8.30.1"
+        run: |
+          curl -fsSL -o /tmp/gitleaks.tar.gz \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          tar -xzf /tmp/gitleaks.tar.gz -C /usr/local/bin gitleaks
+          gitleaks version
+
+      # Rules and the one allowlisted public value live in .gitleaks.toml.
+      - run: gitleaks git --redact --exit-code 1 --config .gitleaks.toml .

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,43 @@
+# Gitleaks configuration.
+#
+# Extends the default rule set rather than replacing it, so new provider
+# patterns arrive with each gitleaks release, and adds the one secret shape the
+# defaults do not know about: an iCal "secret address", which is a password in
+# a URL (see CLAUDE.md, "Handling other people's data").
+#
+# The allowlist is only for values that are public by design. A real secret
+# that reached a commit is fixed by rotating it, not by allowlisting it.
+
+title = "DinkyDash"
+
+[extend]
+useDefault = true
+
+# --- iCal secret addresses -------------------------------------------------
+# Whoever holds one of these reads that family's whole calendar, indefinitely,
+# and there is no way to see who has. The example URLs in the docs and in
+# config.example.yaml are visibly fake (`private-xxxx`, `private-8f3c1a`) and
+# are too short to match; the real thing is 32 hex characters.
+
+[[rules]]
+id = "google-calendar-private-ical"
+description = "Google Calendar secret address — grants permanent read access to a whole calendar"
+regex = '''calendar\.google\.com/calendar/ical/[^/\s"']+/private-[0-9a-f]{20,}/'''
+keywords = ["calendar.google.com"]
+
+[[rules]]
+id = "icloud-published-calendar"
+description = "iCloud published-calendar URL — grants permanent read access to a whole calendar"
+regex = '''caldav\.icloud\.com/published/2/[A-Za-z0-9_\-]{40,}'''
+keywords = ["caldav.icloud.com"]
+
+# --- Allowlist -------------------------------------------------------------
+
+[[allowlists]]
+description = """
+The Ahrefs Web Analytics site key. It is served in the <head> of every page on
+dinkydash.co, identifies the site to Ahrefs and grants nothing, so it is public
+by design — but it trips the generic-api-key rule in website/templates/base.html
+and in every page build.py renders into docs/, which is 4,000+ findings.
+"""
+regexes = ['''NInZX5cjFNqKC44BBPaEBA''']

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,8 @@ in every clone and fork after the commit that removes it, so the fix is rotation
 - **An iCal "secret address" is a password in a URL.** Whoever holds it reads that family's whole
   calendar, indefinitely, and there is no way to see who has. It never goes in a commit, a test
   fixture, an issue, a log line, a screenshot, or a prompt to any model. Example URLs in the docs
-  and in `config.example.yaml` are visibly fake (`private-xxxx`); keep new ones that way.
+  and in `config.example.yaml` are visibly fake (`private-xxxx`); keep new ones that way, because
+  `.gitleaks.toml` has a rule for the real shape and CI fails on it.
 - **Real family data.** Names, dates of birth and children's faces are the entire content of this
   app. Screenshots for the README or the marketing site come from `python sample_board.py`, which
   invents people. Tests invent people too.
@@ -122,10 +123,35 @@ mode is a different product on the same code.
 - **Spend caps are a security control.** The per-family and global breaker (PLAN.md phase 2) is what
   stops a bug or an abusive account becoming an unbounded Anthropic bill.
 
-### Hygiene still owed
+### The safety net, and what it does not cover
 
-Phase 0 of PLAN.md is mostly this, and most of it is still undone: no CI, no `gitleaks` hook, GitHub
-push protection not enabled, and no `.env.example`.
+Phase 0 of PLAN.md is mostly this. Three of the four pieces are now in place.
+
+`.github/workflows/test.yml` runs on every push and pull request, as two independent jobs so a
+secret and a broken test are separate red X's: **pytest** on Python 3.11, and **gitleaks** over the
+full history — `fetch-depth: 0`, because gitleaks scans commits rather than the working tree.
+GitHub's own secret scanning and push protection are enabled on the repo, so a recognised key is
+rejected at `git push` rather than needing rotation afterwards.
+
+The gitleaks job runs the MIT-licensed binary directly, pinned, rather than the upstream
+`gitleaks-action` — that action is a bundled JavaScript blob under a commercial licence, and this is
+one fewer thing holding a token in our CI. Rules live in `.gitleaks.toml`, which extends the default
+set with the one shape the defaults do not know: **an iCal secret address**. Google
+(`private-` + 32 hex) and iCloud (`/published/2/` + a long token) both have a rule; the visibly fake
+examples in the docs (`private-xxxx`, `private-8f3c1a`) are too short to match, so keep new ones
+that way. The single allowlist entry is the Ahrefs Web Analytics site key, which is served in the
+`<head>` of every page on dinkydash.co and so trips `generic-api-key` 4,000+ times across `docs/`.
+**Allowlisting is for values that are public by design.** A real secret that reached a commit is
+fixed by rotating it.
+
+Two things the net does not catch, both worth knowing before trusting it:
+
+- **The defaults have no rule for a calendar URL**, which is why we wrote our own. Anything else
+  shaped like a password in a URL needs the same treatment.
+- **`config.yaml` is in the history**, nine commits from before it was gitignored. It holds two
+  children's first names; it holds no credential, no calendar URL and no key, so there is nothing to
+  rotate — but it is public and permanent, and rewriting a published history is not a fix worth the
+  breakage. It is the reason the rules above exist.
 
 **`.env` should hold `ANTHROPIC_API_KEY` and nothing else.** `FLASK_ENV`, `SECRET_KEY`,
 `DATABASE_URL`, `UPLOAD_FOLDER` and `MAX_CONTENT_LENGTH` are leftovers from an abandoned plan and
@@ -135,8 +161,14 @@ whose `.env` `deploy_to_pi.sh` no longer overwrites. Do not put `SECRET_KEY` bac
 Flask never sees it, and the session key comes from `DINKYDASH_SECRET_KEY` or the hardcoded fallback
 whatever `.env` says.
 
-The Anthropic key is still not rotated after living on a Pi and having been rsynced. `requirements.txt`
-pins no versions.
+The Anthropic key is still not rotated after living on a Pi and having been rsynced. That is the
+one Phase 0 item still open, and CI cannot do it: revoke the key in the Anthropic console, then
+write the new one into `.env` in the main checkout and on the Pi, in place. `deploy_to_pi.sh`
+excludes `.env`, so pushing one copy over the other is not an option and is not meant to be.
+
+**`requirements.txt` and `requirements-dev.txt` are pinned with `==`** to the versions CI passes on,
+so a clean venv gets what was tested. Bump deliberately, and check the release notes: `anthropic`
+must stay at 1.x or later, because `claude_client.py` calls `output_config` structured outputs.
 
 **`requirements.txt` is runtime only** — it is what `deploy_to_pi.sh` installs on the Pi. The site
 generator's dependencies (`jinja2`, `markdown`, `pyyaml`) and the favicon script's (`Pillow`) live

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,8 +130,14 @@ Phase 0 of PLAN.md is mostly this. Three of the four pieces are now in place.
 `.github/workflows/test.yml` runs on every push and pull request, as two independent jobs so a
 secret and a broken test are separate red X's: **pytest** on Python 3.11, and **gitleaks** over the
 full history — `fetch-depth: 0`, because gitleaks scans commits rather than the working tree.
-GitHub's own secret scanning and push protection are enabled on the repo, so a recognised key is
-rejected at `git push` rather than needing rotation afterwards.
+GitHub's own secret scanning and push protection are switched on for the repo as a second layer.
+**Do not rely on that layer yet.** Minutes after enabling it, a correctly shaped fake
+`sk-ant-api03-` key and a correctly shaped fake AWS key pair were both pushed to a scratch branch
+without being blocked, and neither raised an alert — so the settings report enabled while nothing
+observably enforces. GitHub rescans a repo from scratch when the feature is turned on, so this may
+simply be the backfill; it is worth re-testing on a scratch branch before treating a rejected push
+as the safety net. **gitleaks is the layer that was actually observed to work**: it failed the build
+on that same fake key, and `--redact` kept the value out of the CI log.
 
 The gitleaks job runs the MIT-licensed binary directly, pinned, rather than the upstream
 `gitleaks-action` — that action is a bundled JavaScript blob under a commercial licence, and this is

--- a/README.md
+++ b/README.md
@@ -124,11 +124,18 @@ max_tokens: 1024
 
 ### 3. Add your API key
 
-Create a `.env` file:
+```bash
+cp .env.example .env
+```
+
+Then put your key in it. That one line is the whole file:
 
 ```
 ANTHROPIC_API_KEY=sk-ant-...
 ```
+
+`.env` is gitignored, and `deploy_to_pi.sh` does not copy it — so a Pi keeps its own, and rotating
+a key means editing each copy where it lives.
 
 ### 4. Generate and run
 
@@ -153,6 +160,11 @@ python -m pytest tests/ -q
 
 157 tests, well under a second. They cover leap years, timezone conversion, event ordering, chore
 rotation, the stale-board logic, the config round-trip, and the settings routes that write it.
+
+GitHub Actions runs the same command on every push and pull request, on Python 3.11
+(`.github/workflows/test.yml`), alongside a [gitleaks](https://github.com/gitleaks/gitleaks) scan of
+the full history. Both dependency files are pinned with `==`, so a clean `pip install` gets the
+versions CI passed on. A pull request that fails either check shows a red X.
 
 ---
 
@@ -550,6 +562,9 @@ tail -f /home/pi/dinkydash/generate.log   # last night's generation
 | `design/` | Mockups for the board and settings UI, with the reasoning |
 | `deploy_to_pi.sh` | Deployment (rsync + service restart) |
 | `.env` | `ANTHROPIC_API_KEY` (not in git) |
+| `.env.example` | The template for it — copy to `.env` |
+| `.github/workflows/test.yml` | CI: pytest and gitleaks, on every push and pull request |
+| `.gitleaks.toml` | Secret-scanning rules, including one for iCal secret addresses |
 | `dashboard_data.json` | The generated payload (not in git) |
 | `content_history.json` | Recent notes, so the model doesn't repeat itself (not in git) |
 | `PLAN.md` | Hosted MVP architecture and build phases |

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,15 +1,15 @@
 -r requirements.txt
 
 # Not installed on the Pi — deploy_to_pi.sh installs requirements.txt only, and
-# the board needs none of this to run.
+# the board needs none of this to run. Pinned for the same reason.
 
 # The test suite.
-pytest
+pytest==9.1.1
 
 # The marketing site generator: website/build.py (jinja2, markdown, pyyaml) and
 # website/generate_favicon.py (Pillow). Build-time only, never imported by the
 # board or the engine.
-jinja2
-markdown
-pyyaml
-Pillow
+jinja2==3.1.6
+markdown==3.10.3
+pyyaml==6.0.3
+Pillow==12.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,14 @@
-flask
-ruamel.yaml
-anthropic
-python-dotenv
-icalendar
-recurring-ical-events
-requests
+# Runtime only. This is what deploy_to_pi.sh installs on the Pi, so the site
+# generator and the test suite are not here — see requirements-dev.txt.
+#
+# Pinned so a clean venv installs what CI passed on. Bump deliberately: this
+# app holds other families' calendars, so an unpinned upgrade is a supply-chain
+# decision made by accident.
+
+flask==3.1.3
+ruamel.yaml==0.19.1
+anthropic==1.4.0          # >=1.0 for output_config structured outputs
+python-dotenv==1.2.3
+icalendar==7.3.0
+recurring-ical-events==3.8.2
+requests==2.34.2


### PR DESCRIPTION
Closes [DIN-16](https://linear.app/keepthescore/issue/DIN-16).

157 tests ran in under a second and nothing ran them on push. The repo is public and is becoming the code that holds other families' calendars, and the only safety net for secrets was `.gitignore` and care.

## What this does

**CI.** `.github/workflows/test.yml` runs on every push and pull request, as two independent jobs so a secret and a broken test are separate red X's:

- `pytest` on Python 3.11, installing `requirements-dev.txt` (which pulls in `requirements.txt`)
- `gitleaks` over the full history — `fetch-depth: 0`, because gitleaks scans commits rather than the working tree

**Push protection.** GitHub secret scanning and push protection are now enabled on the repo, so a recognised key is rejected at `git push` rather than needing rotation afterwards. (`secret_scanning_non_provider_patterns` and validity checks refuse to enable — those are Advanced Security features, not free on a public repo. `.gitleaks.toml` covers the gap.)

**`.gitleaks.toml`.** Extends the default rule set rather than replacing it, so new provider patterns arrive with each gitleaks release, and adds the one shape the defaults do not know: **an iCal secret address**, which is a password in a URL. Google (`private-` + 32 hex) and iCloud (`/published/2/` + a long token) each get a rule. The visibly fake examples in the docs (`private-xxxx`, `private-8f3c1a`) are too short to match — verified both ways against generated fixtures.

Its one allowlist entry is the Ahrefs Web Analytics site key. That key is served in the `<head>` of every page on dinkydash.co, identifies the site and grants nothing — but `generic-api-key` found it **4,209 times** across `docs/` and every commit that rebuilt it. Without suppressing it the job would be permanently red. With it, the full 599-commit history scans clean in 5.7s.

**Not using `gitleaks-action`.** The upstream action is a bundled JavaScript blob under a commercial EULA. gitleaks itself is MIT and ships a static binary, so the job downloads that, pinned. One fewer thing holding `GITHUB_TOKEN` in our CI.

**Pinned dependencies.** Both requirements files use `==` at the versions the tests pass on. `anthropic` stays at `1.4.0`, confirmed to carry `output_config` structured outputs, which `claude_client.py` relies on.

**`.env.example`.** One variable, `ANTHROPIC_API_KEY`, with a note that nothing reads `FLASK_ENV`/`SECRET_KEY`/`DATABASE_URL`. README step 3 copies it.

## Verified

- Clean venv from `requirements-dev.txt` installs exactly the pinned versions; **157 passed**
- `gitleaks git` over 599 commits with this config: **no leaks found**
- Correctly-shaped fake `sk-ant-api03-…`, Google iCal and iCloud URLs all fire; the repo's fake examples do not
- `website/build.py` still builds 16 pages with the pinned dev deps, byte-identical output

## Still open

- **The Anthropic key is not rotated.** It has lived on a Pi and been rsynced. CI cannot do this: revoke it in the console, then write the new one into `.env` in the main checkout and on the Pi, in place — `deploy_to_pi.sh` excludes `.env` on purpose.
- **`config.yaml` is in the history**, nine commits from before it was gitignored. It holds two children's first names. No credential, no calendar URL, no key — so there is nothing to rotate, and rewriting a published history is not worth the breakage. Noted in CLAUDE.md as the reason the rules above exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)