### PR TITLE
Re-verify every competitor price, and correct the Skylight 15" by $30 (DIN-4)

### DIFF
--- a/docs/best-digital-family-calendar/index.html
+++ b/docs/best-digital-family-calendar/index.html
@@ -352,14 +352,15 @@
 <p><img alt="A wall-mounted digital calendar display in a warm family kitchen" src="/images/hero-kitchen.webp" width="1376" height="768" decoding="async" /></p>
 <h2>Path 1: Buy a dedicated calendar display</h2>
 <p>You're paying for plug-and-play: unbox, connect Wi-Fi, done. As of September 2026:</p>
-<p><strong>Skylight Calendar 2 (15″, $329.99) / Calendar Max (27″, $599.99)</strong> — the category leader and the safest pick. Best-in-class calendar view, meal planning and AI event import with the optional Plus plan ($79/yr). If you just want it to work, buy this. (<a href="/skylight-calendar-subscription/">What the subscription does and doesn't cover →</a>)</p>
+<p><strong>Skylight Calendar 2 (15″, $299.99) / Calendar Max (27″, $599.99)</strong> — the category leader and the safest pick. Best-in-class calendar view, meal planning and AI event import with the optional Plus plan ($79/yr). If you just want it to work, buy this. (<a href="/skylight-calendar-subscription/">What the subscription does and doesn't cover →</a>)</p>
 <p><strong>Hearth Display (27″, $699 + $9/mo, or $86.40/yr billed annually)</strong> — the routines specialist. Visual morning/evening checklists kids run themselves; a favorite with ADHD families. Priciest option in the category. (<a href="/hearth-vs-skylight/">Hearth vs Skylight compared →</a>)</p>
-<p><strong>Cozyla (from $169.99)</strong> — dedicated hardware whose pitch is "no monthly fees" — features that cost extra elsewhere are included. Less polished than Skylight, but pay-once pricing.</p>
+<p><strong>Cozyla (from $169.99)</strong> — dedicated hardware whose pitch is "no monthly fees," and the core calendar, chores and routines do work without one. Watch for the optional Calendar Essential plan, which auto-renews at $79.99/yr after a 30-day trial and covers meal planning and the AI voice agent. Less polished than Skylight, but pay-once pricing.</p>
+<p><strong>Dæly (€299)</strong> — a 15.6″ German alternative with no subscription and EU data storage, sold in euros and shipped from Germany. Worth knowing if you are buying in the German-speaking market; awkward to buy from anywhere else.</p>
 <h2>Path 2: Use a screen you already own</h2>
 <p>A family calendar display is, mechanically, a screen showing a web page. If a spare tablet, a TV, or a $100 Raspberry Pi is available, software gets you there:</p>
 <p><strong>DinkyDash (free, open source)</strong> — our project, and the reason this site exists. Any screen with a browser becomes a family calendar with automatic chore rotation, birthday countdowns, and an AI-written daily brief — a fresh greeting and fun fact every morning, written around your own family, which no hardware calendar offers. Setup takes an afternoon and a bit of terminal comfort (<a href="/getting-started/">guide</a>); a zero-setup hosted version is <a href="https://fffwryhvses.typeform.com/to/yxMMhmFs">in the works</a>.</p>
-<p><strong>Mango Display (free tier; Pro $5.99/mo or $59.99/yr)</strong> — commercial BYO-screen software with polished apps for smart TVs and tablets. The no-DIY version of this path.</p>
-<p><strong>DAKboard (free tier; $5–10/mo)</strong> — the veteran customizable wall display. Enormous flexibility, more "information dashboard" than "family organizer." The free tier is narrower than it looks — one predefined screen and two calendars — so see the <a href="/dakboard-alternatives/">DAKboard alternatives comparison</a> before committing.</p>
+<p><strong>Mango Display (free tier; Pro $5.99/mo or $59.99/yr)</strong> — commercial BYO-screen software with polished apps for smart TVs and tablets. The no-DIY version of this path — but budget for Pro, because the free plan has no calendar.</p>
+<p><strong>DAKboard (free tier; $5–10/mo)</strong> — the veteran customizable wall display. Enormous flexibility, and a chore chart with points and rewards on the paid plans, though it is still a dashboard first. The free tier is narrower than it looks — one predefined screen and two calendars — so see the <a href="/dakboard-alternatives/">DAKboard alternatives comparison</a> before committing.</p>
 <h2>How to decide</h2>
 <ul>
 <li><strong>"I want zero setup and a beautiful object on the wall"</strong> → Skylight (calendar-first) or Hearth (routines-first)</li>
@@ -380,7 +381,7 @@
 <tbody>
 <tr>
 <td>Skylight Cal 2 / Max</td>
-<td>$329.99 / $599.99</td>
+<td>$299.99 / $599.99</td>
 <td>$0–79/yr</td>
 <td>Best plug-and-play calendar</td>
 </tr>
@@ -393,7 +394,7 @@
 <tr>
 <td>Cozyla</td>
 <td>From $169.99</td>
-<td>$0</td>
+<td>$0, or $79.99/yr optional</td>
 <td>Pay-once hardware</td>
 </tr>
 <tr>
@@ -416,7 +417,7 @@
 </tr>
 </tbody>
 </table>
-<p><em>Prices checked September 2026.</em></p>
+<p><em>Prices checked 6 September 2026.</em></p>
 <p>Whichever path you take: the win isn't the gadget, it's the behavior change — the family checking one shared screen instead of asking one exhausted parent. The cheapest way to test whether that works in your house is <a href="/getting-started/">the free one</a>.</p>
     <p class="page-updated">Last updated 2026-09-06.</p>
 </div>

--- a/docs/dakboard-alternatives/index.html
+++ b/docs/dakboard-alternatives/index.html
@@ -449,7 +449,7 @@
 <tr>
 <td><strong>Skylight Calendar</strong></td>
 <td>Optional $79/yr</td>
-<td>$329.99–$599.99</td>
+<td>$299.99–$599.99</td>
 <td>No</td>
 <td>No</td>
 </tr>
@@ -474,7 +474,7 @@
 <p>Three reasons come up repeatedly, and they point at different replacements.</p>
 <p><strong>The free tier is narrower than it looks.</strong> DAKboard's free plan gives you <strong>one predefined screen and two calendars</strong>, with predefined layouts only, DAKboard branding on the screen, a 60-minute calendar refresh and a cap of 20 content blocks. Custom layouts — the thing DAKboard is known for — start on Essential at $6/month, or $5/month billed annually. Plus is $10/month, or $8/month annually, and that is where unlimited calendars and 15-minute refreshes live.</p>
 <p><strong>It is not open source.</strong> You can run the display on your own Raspberry Pi, which reads like self-hosting, but the service runs on DAKboard's servers and the source is not published. If your reason for building a wall display was keeping the family's schedule on your own hardware, that is the wrong shape.</p>
-<p><strong>It is a dashboard, not a family organizer.</strong> DAKboard's strength is arranging many data sources on one screen. If what you wanted was "whose turn is it to feed the dog", you are configuring a general tool into a specific one.</p>
+<p><strong>It is a dashboard first, a family organizer second.</strong> DAKboard does now market a chore chart — a column per family member, one tap to check something off, points that convert into rewards you set, and a child lock so siblings can't clear each other's lists. It is on Essential and Plus, not the free tier. But the product underneath is still a way of arranging many data sources on one screen, so "whose turn is it to feed the dog" means pointing a general tool at a specific job.</p>
 <h2>1. DinkyDash — free, open source, family-shaped</h2>
 <p>Full disclosure: DinkyDash is our project, so treat this entry accordingly — the rest of the page is written to be useful whether or not you pick it.</p>
 <p>DinkyDash turns any TV, tablet, Raspberry Pi or spare monitor into a family calendar. It shows today's events from any iCal link, a chore chart that rotates between kids automatically, countdowns to birthdays and holidays, and <strong>a daily brief written by AI every morning</strong> — a fresh greeting written around your family's actual day. No other option on this page does that last one.</p>
@@ -496,7 +496,7 @@
 <p>One thing worth knowing before you sign up: <strong>the free plan does not include the calendar.</strong> It gives you two screens with a clock, weather, news headlines, background images and quotes. Calendars — along with chores, meal plan and photo widgets — start on Pro at $5.99/month, or $59.99/year.</p>
 <p><strong>Best for:</strong> people who want zero setup and are happy paying for it.</p>
 <h2>5. Skylight Calendar — buy the screen too</h2>
-<p>If the real answer is that you want a finished object on the wall rather than a project, Skylight sells the hardware: $329.99 for the 15″ Calendar 2, $599.99 for the 27″ Calendar Max, with an optional Plus subscription at $79/year for chore rewards and meal planning.</p>
+<p>If the real answer is that you want a finished object on the wall rather than a project, Skylight sells the hardware: $299.99 for the 15″ Calendar 2, $599.99 for the 27″ Calendar Max, with an optional Plus subscription at $79/year for chore rewards and meal planning.</p>
 <p>It is the opposite trade to DAKboard — you spend money instead of time, and you get a touchscreen your family can actually tap. See our <a href="/skylight-calendar-alternatives/">Skylight alternatives page</a> for the wider comparison, or the <a href="/skylight-calendar-subscription/">subscription breakdown</a> for what Plus actually costs.</p>
 <p><strong>Best for:</strong> people who would rather buy the problem away.</p>
 <h2>6. Hearth Display — routines rather than dashboards</h2>

--- a/docs/digital-calendar-and-chore-chart/index.html
+++ b/docs/digital-calendar-and-chore-chart/index.html
@@ -374,8 +374,13 @@
 <td>Automatic daily rotation</td>
 </tr>
 <tr>
+<td><strong>DAKboard</strong> (screen you own)</td>
+<td>Free tier; $6–10/mo</td>
+<td>Chore columns per child, points and rewards — paid plans only</td>
+</tr>
+<tr>
 <td><strong>Skylight Calendar</strong></td>
-<td>$329.99–$599.99</td>
+<td>$299.99–$599.99</td>
 <td>Chore chart free; rewards need Plus ($79/yr)</td>
 </tr>
 <tr>
@@ -385,8 +390,8 @@
 </tr>
 </tbody>
 </table>
-<p><em>Prices checked September 2026.</em></p>
-<p>Skylight and Hearth both do chores well — that's part of why families pay for them. But if the hardware price is the obstacle, the free route gets you the core loop (visible chores, fair rotation, zero nagging) on a screen you already own. Our <a href="/diy-skylight-calendar/">DIY guide</a> shows the whole build, and the <a href="/getting-started/">getting started guide</a> has the copy-paste setup.</p>
+<p><em>Prices checked 6 September 2026.</em></p>
+<p>Skylight, Hearth and DAKboard all do chores well — that's part of why families pay for them. But if the price is the obstacle, the free route gets you the core loop (visible chores, fair rotation, zero nagging) on a screen you already own. Our <a href="/diy-skylight-calendar/">DIY guide</a> shows the whole build, and the <a href="/getting-started/">getting started guide</a> has the copy-paste setup.</p>
 <h2>The countdown trick</h2>
 <p>One more thing that earns its place on the chore screen: countdowns. "8 days until your birthday" and "19 days until vacation" give kids a reason to look at the dashboard voluntarily every morning — and while they're there, they see whose turn the dishes are. That's the whole trick, honestly.</p>
 <p>You can see the effect without installing anything: our <a href="/birthday-countdown/">birthday countdown</a> is the same panel on its own, free and with no sign-up. Add the kids' birthdays and leave it open on a spare screen.</p>

--- a/docs/diy-skylight-calendar/index.html
+++ b/docs/diy-skylight-calendar/index.html
@@ -456,7 +456,7 @@
 </tr>
 </tbody>
 </table>
-<p><em>Prices checked September 2026.</em></p>
+<p><em>Skylight prices checked 6 September 2026; the Raspberry Pi part prices above are approximate and were last checked August 2026.</em></p>
 <h2>Questions people ask</h2>
 <p><strong>Is there a monthly fee for a DIY calendar?</strong>
 No subscription. The only running cost is the Anthropic API key for the daily brief, which comes to a few cents a month — roughly $0.20–0.40 for a typical family. Skip the AI brief and it's free. (For what Skylight itself charges, see our <a href="/skylight-calendar-subscription/">Skylight subscription breakdown</a>.)</p>

--- a/docs/hearth-vs-skylight/index.html
+++ b/docs/hearth-vs-skylight/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Hearth vs Skylight 2026: Prices, Subscriptions, Which to Buy</title>
-    <meta name="description" content="Hearth Display ($699 + $9/mo) vs Skylight Calendar ($329.99–$599.99 + optional $79/yr) compared honestly — plus the third option both companies would rather you didn&#39;t know about.">
+    <meta name="description" content="Hearth Display ($699 + $9/mo) vs Skylight Calendar ($299.99–$599.99 + optional $79/yr) compared honestly — plus the third option both companies would rather you didn&#39;t know about.">
     <link rel="canonical" href="https://dinkydash.co/hearth-vs-skylight/">
     
     <link rel="icon" href="/favicon.ico" sizes="any">
@@ -15,7 +15,7 @@
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://dinkydash.co/hearth-vs-skylight/">
     <meta property="og:image" content="https://dinkydash.co/images/og-hero.jpg">
-    <meta property="og:description" content="Hearth Display ($699 + $9/mo) vs Skylight Calendar ($329.99–$599.99 + optional $79/yr) compared honestly — plus the third option both companies would rather you didn&#39;t know about.">
+    <meta property="og:description" content="Hearth Display ($699 + $9/mo) vs Skylight Calendar ($299.99–$599.99 + optional $79/yr) compared honestly — plus the third option both companies would rather you didn&#39;t know about.">
     <meta name="twitter:card" content="summary_large_image">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -315,7 +315,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Hearth vs Skylight (2026): Prices, Subscriptions, and Which to Buy",
-  "description": "Hearth Display ($699 + $9/mo) vs Skylight Calendar ($329.99\u2013$599.99 + optional $79/yr) compared honestly \u2014 plus the third option both companies would rather you didn\u0027t know about.",
+  "description": "Hearth Display ($699 + $9/mo) vs Skylight Calendar ($299.99\u2013$599.99 + optional $79/yr) compared honestly \u2014 plus the third option both companies would rather you didn\u0027t know about.",
   "mainEntityOfPage": "https://dinkydash.co/hearth-vs-skylight/",
   "dateModified": "2026-09-06",
   "author": { "@type": "Person", "name": "Caspar Wrede", "url": "https://casparwre.de" },
@@ -361,7 +361,7 @@
 <tbody>
 <tr>
 <td>Price</td>
-<td>$329.99 (15″ Calendar 2) / $599.99 (27″ Max)</td>
+<td>$299.99 (15″ Calendar 2) / $599.99 (27″ Max)</td>
 <td>$699 (27″, often discounted)</td>
 </tr>
 <tr>
@@ -391,9 +391,10 @@
 </tr>
 </tbody>
 </table>
-<p><em>Prices checked September 2026.</em></p>
+<p><em>Prices checked 6 September 2026.</em></p>
+<p>Two footnotes on that last row, both in Hearth's favor: the $699 is a list price they discount often, and the membership gets cheaper if you commit — $155.52 for two years, or $207.36 for three, which brings the three-year total to about $906 rather than $958.</p>
 <h2>Where Skylight wins</h2>
-<p>Skylight nails the core job: your Google, Apple, or Outlook calendars merged into one big, color-coded family view. The interface is polished, the companion app is solid, and the 15″ model's $329.99 entry price is the lowest way into a premium dedicated display. Meal planning and its AI-powered "Magic Import" (photograph a school newsletter, get calendar events) are genuinely useful — but note they live behind the $79/year Plus plan. Read more on <a href="/skylight-calendar-subscription/">what Skylight's subscription does and doesn't cover</a>.</p>
+<p>Skylight nails the core job: your Google, Apple, or Outlook calendars merged into one big, color-coded family view. The interface is polished, the companion app is solid, and the 15″ model's $299.99 entry price is the lowest way into a premium dedicated display. Meal planning and its AI-powered "Magic Import" (photograph a school newsletter, get calendar events) are genuinely useful — but note they live behind the $79/year Plus plan. Read more on <a href="/skylight-calendar-subscription/">what Skylight's subscription does and doesn't cover</a>.</p>
 <h2>Where Hearth wins</h2>
 <p>Hearth is designed around <em>routines</em>, not just events: visual morning and evening checklists kids work through themselves, to-do assignments, and a portrait layout that reads like a poster. Families managing ADHD consistently praise it — that focus is real differentiation, and the build quality feels premium. The catch: it's the most expensive option in the category, and the membership isn't optional, which pushes the three-year cost to around $960.</p>
 <h2>The honest bottom line</h2>
@@ -403,7 +404,7 @@
 </ul>
 <h2>The third option: don't buy a screen at all</h2>
 <p>Both products are, at heart, a screen showing your family's day. If you have an old tablet, a TV, or $100 for a Raspberry Pi, free software gives you the same glanceable calendar — with chore rotations and countdowns — for no subscription at all.</p>
-<p>That's what <a href="/">DinkyDash</a> does (free, open source, and with an AI-written daily brief neither Skylight nor Hearth offers). See <a href="/diy-skylight-calendar/">how to build one in an afternoon</a>, or compare <a href="/skylight-calendar-alternatives/">all seven Skylight alternatives</a>.</p>
+<p>That's what <a href="/">DinkyDash</a> does (free, open source, and with an AI-written daily brief neither Skylight nor Hearth offers). See <a href="/diy-skylight-calendar/">how to build one in an afternoon</a>, or compare <a href="/skylight-calendar-alternatives/">all eight Skylight alternatives</a>.</p>
     <p class="page-updated">Last updated 2026-09-06.</p>
 </div>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -888,7 +888,7 @@
                 <div class="math-sub">$29/yr for the first 100 on the list</div>
             </div>
         </div>
-        <p class="math-note">Competitor prices checked September 2026. Skylight and Hearth are lovely products &mdash; you just might not need the hardware. Running DinkyDash on your own machine is free forever, and always will be.</p>
+        <p class="math-note">Competitor prices checked 6 September 2026. Skylight and Hearth are lovely products &mdash; you just might not need the hardware. Running DinkyDash on your own machine is free forever, and always will be.</p>
     </div>
 </section>
 
@@ -1073,7 +1073,7 @@
             </details>
             <details>
                 <summary>How is this different from a Skylight or Hearth?</summary>
-                <p>Skylight and Hearth sell you a dedicated touchscreen ($330–$699) with an optional or required subscription on top. DinkyDash is just the software, running on a screen you already own. It also does something they don't: a line written fresh every morning from your actual day. <a href="/skylight-calendar-alternatives/">See the full comparison</a>.</p>
+                <p>Skylight and Hearth sell you a dedicated touchscreen ($300–$699) with an optional or required subscription on top. DinkyDash is just the software, running on a screen you already own. It also does something they don't: a line written fresh every morning from your actual day. <a href="/skylight-calendar-alternatives/">See the full comparison</a>.</p>
             </details>
         </div>
     </div>
@@ -1168,7 +1168,7 @@
     {
       "@type": "Question",
       "name": "How is this different from a Skylight or Hearth?",
-      "acceptedAnswer": { "@type": "Answer", "text": "Skylight and Hearth sell you a dedicated touchscreen ($330–$699) with an optional or required subscription on top. DinkyDash is just the software, running on a screen you already own. It also does something they don't: a line written fresh every morning from your actual day." }
+      "acceptedAnswer": { "@type": "Answer", "text": "Skylight and Hearth sell you a dedicated touchscreen ($300–$699) with an optional or required subscription on top. DinkyDash is just the software, running on a screen you already own. It also does something they don't: a line written fresh every morning from your actual day." }
     }
   ]
 }

--- a/docs/skylight-calendar-alternatives/index.html
+++ b/docs/skylight-calendar-alternatives/index.html
@@ -3,19 +3,19 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>The 7 Best Skylight Calendar Alternatives in 2026 — DinkyDash</title>
-    <meta name="description" content="Looking for a Skylight Calendar alternative without the $329.99–$599.99 price tag or the $79/year subscription? Here are 7 options — including free ones that run on screens you already own.">
+    <title>The 8 Best Skylight Calendar Alternatives in 2026 — DinkyDash</title>
+    <meta name="description" content="Looking for a Skylight Calendar alternative without the $299.99–$599.99 price tag or the $79/year subscription? Here are 8 options — including free ones that run on screens you already own.">
     <link rel="canonical" href="https://dinkydash.co/skylight-calendar-alternatives/">
     
     <link rel="icon" href="/favicon.ico" sizes="any">
     <link rel="icon" href="/favicon.svg" type="image/svg+xml">
     <link rel="apple-touch-icon" href="/apple-touch-icon.png">
     <meta name="theme-color" content="#fffaf5">
-    <meta property="og:title" content="The 7 Best Skylight Calendar Alternatives in 2026 — DinkyDash">
+    <meta property="og:title" content="The 8 Best Skylight Calendar Alternatives in 2026 — DinkyDash">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://dinkydash.co/skylight-calendar-alternatives/">
     <meta property="og:image" content="https://dinkydash.co/images/og-hero.jpg">
-    <meta property="og:description" content="Looking for a Skylight Calendar alternative without the $329.99–$599.99 price tag or the $79/year subscription? Here are 7 options — including free ones that run on screens you already own.">
+    <meta property="og:description" content="Looking for a Skylight Calendar alternative without the $299.99–$599.99 price tag or the $79/year subscription? Here are 8 options — including free ones that run on screens you already own.">
     <meta name="twitter:card" content="summary_large_image">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -314,8 +314,8 @@
 {
   "@context": "https://schema.org",
   "@type": "Article",
-  "headline": "The 7 Best Skylight Calendar Alternatives in 2026",
-  "description": "Looking for a Skylight Calendar alternative without the $329.99\u2013$599.99 price tag or the $79/year subscription? Here are 7 options \u2014 including free ones that run on screens you already own.",
+  "headline": "The 8 Best Skylight Calendar Alternatives in 2026",
+  "description": "Looking for a Skylight Calendar alternative without the $299.99\u2013$599.99 price tag or the $79/year subscription? Here are 8 options \u2014 including free ones that run on screens you already own.",
   "mainEntityOfPage": "https://dinkydash.co/skylight-calendar-alternatives/",
   "dateModified": "2026-09-06",
   "author": { "@type": "Person", "name": "Caspar Wrede", "url": "https://casparwre.de" },
@@ -347,8 +347,8 @@
 <main>
     
 <div class="container page-content">
-    <h1>The 7 Best Skylight Calendar Alternatives in 2026</h1>
-    <p>The Skylight Calendar is a lovely idea: your family's schedule, big and glanceable, on the kitchen wall. But between the hardware ($329.99 for the 15″ Calendar 2, $599.99 for the 27″ Calendar Max) and the optional $79/year Plus subscription for features like meal planning and chore rewards, plenty of families go looking for alternatives before checking out.</p>
+    <h1>The 8 Best Skylight Calendar Alternatives in 2026</h1>
+    <p>The Skylight Calendar is a lovely idea: your family's schedule, big and glanceable, on the kitchen wall. But between the hardware ($299.99 for the 15″ Calendar 2, $599.99 for the 27″ Calendar Max) and the optional $79/year Plus subscription for features like meal planning and chore rewards, plenty of families go looking for alternatives before checking out.</p>
 <p>The good news: you have real options — including some that cost nothing because they run on a screen you already own.</p>
 <p><img alt="The same family calendar dashboard running on a TV, an old iPad, and a Raspberry Pi touchscreen" src="/images/any-screen-family-calendar.webp" width="1408" height="768" decoding="async" /></p>
 <h2>Quick comparison</h2>
@@ -371,7 +371,7 @@
 <tr>
 <td><strong>Mango Display</strong></td>
 <td>$0</td>
-<td>Free tier; Pro $5.99/mo</td>
+<td>Free tier (no calendar); Pro $5.99/mo</td>
 <td>Yes</td>
 </tr>
 <tr>
@@ -389,7 +389,13 @@
 <tr>
 <td><strong>Cozyla</strong></td>
 <td>From $169.99</td>
-<td>Advertises no monthly fees</td>
+<td>Core free; optional $79.99/yr</td>
+<td>No</td>
+</tr>
+<tr>
+<td><strong>Dæly</strong></td>
+<td>€299</td>
+<td>None</td>
 <td>No</td>
 </tr>
 <tr>
@@ -406,27 +412,31 @@
 </tr>
 </tbody>
 </table>
-<p><em>Prices checked September 2026 — always confirm current pricing before buying.</em></p>
+<p><em>Prices checked 6 September 2026 — always confirm current pricing before buying. Dæly is sold in euros and ships from Germany.</em></p>
 <h2>1. DinkyDash — free, open source, and AI-powered</h2>
 <p>Full disclosure: DinkyDash is our project, so we're biased — but it exists precisely because we wanted a Skylight without the hardware bill. DinkyDash turns any TV, tablet, Raspberry Pi, or spare monitor into a family calendar with a daily chore rotation, birthday countdowns, and something no other option here has: <strong>a daily brief written by AI every morning</strong>, personalized to your family's actual day.</p>
 <p>It's MIT-licensed and free. The trade-off: today you set it up yourself, which means being comfortable with a terminal for an afternoon. Our <a href="/getting-started/">getting started guide</a> walks you through it, and a zero-setup hosted version is in the works.</p>
 <p><strong>Best for:</strong> families with a tinkerer in the house who want $0 hardware and no subscription.</p>
 <h2>2. Mango Display — polished BYO-screen software</h2>
-<p>Mango Display is a commercial take on the same idea: install their app on a smart TV, Fire TV, or tablet and it renders a calendar-centric smart display with widgets for photos, weather, and to-dos. There's a free tier (two screens), and the Pro plan is $5.99/month, or $59.99 a year.</p>
+<p>Mango Display is a commercial take on the same idea: install their app on a smart TV, Fire TV, or tablet and it renders a calendar-centric smart display with widgets for photos, weather, and to-dos. There's a free tier, but read it before you rely on it: the free plan gives you two screens with a clock, weather, news headlines and background images, and <strong>no calendar at all</strong>. Calendars — along with chores, meal plans and photos — start on Pro, at $5.99/month or $59.99 a year.</p>
 <p><strong>Best for:</strong> families who want bring-your-own-screen without any DIY at all.</p>
 <h2>3. DAKboard — the customizable wall display veteran</h2>
-<p>DAKboard has been the DIY wall-display favorite for years — calendars, photos, weather, and news on any screen, with deep layout customization. Free for one predefined screen with two calendars; $6/month (or $5 billed annually) unlocks custom layouts, and $10/month adds unlimited calendars. It's more "information display" than "family organizer." If it's the one you're weighing up, we compared it properly on the <a href="/dakboard-alternatives/">DAKboard alternatives page</a>.</p>
+<p>DAKboard has been the DIY wall-display favorite for years — calendars, photos, weather, and news on any screen, with deep layout customization. Free for one predefined screen with two calendars; $6/month (or $5 billed annually) unlocks custom layouts, and $10/month adds unlimited calendars. It leans "information display" rather than "family organizer," though it now markets a chore chart with points and rewards on the paid plans. If it's the one you're weighing up, we compared it properly on the <a href="/dakboard-alternatives/">DAKboard alternatives page</a>.</p>
 <p><strong>Best for:</strong> data-dense household dashboards and tinkerers who want full layout control.</p>
 <h2>4. Hearth Display — the premium hardware rival</h2>
 <p>If what you actually want is <em>nicer</em> dedicated hardware, Hearth's 27″ portrait display ($699 + $9/month, or $86.40 a year) focuses on routines and visual schedules — it's especially popular with ADHD and neurodivergent families. It costs more than Skylight over time, but the routine-building features are genuinely different. See our full <a href="/hearth-vs-skylight/">Hearth vs Skylight comparison</a>.</p>
 <p><strong>Best for:</strong> families who want routines and to-dos front and center, and don't mind the price.</p>
 <h2>5. Cozyla — hardware without the monthly fee</h2>
-<p>Cozyla sells digital calendar displays from $169.99 that advertise no monthly fees — the feature set that Skylight puts behind Plus (like AI-assisted event import) is included. Build quality and app polish get mixed reviews compared to Skylight, but "pay once" is a compelling pitch.</p>
+<p>Cozyla sells digital calendar displays from $169.99 on a "no monthly fees" pitch, and the core really does work without one — calendar sync, chores, routines and notes are all free on the device. Read the checkout carefully, though: the Calendar Neo ships with a 30-day trial of an optional Calendar Essential plan that auto-renews at $79.99 a year, and that is where meal planning, custom screensavers and the AI voice agent live. Build quality and app polish get mixed reviews compared to Skylight, but "pay once" is still a compelling pitch.</p>
 <p><strong>Best for:</strong> families set on dedicated hardware who refuse subscriptions.</p>
-<h2>6. Cozi — the free app (no wall display)</h2>
+<h2>6. Dæly — the one-time purchase, if you're in Europe</h2>
+<p>Dæly is a 15.6″ touchscreen family calendar sold from Germany for <strong>€299</strong> (list price €349), with no subscription at all — the company's own line is that every feature you get on the day you buy stays free. It syncs with a free iOS and Android app, arrives with a stand and an integrated wall mount, and keeps your data on German servers under GDPR.</p>
+<p>The catch for most readers of this page: the shop, the app and the support are in German, prices are in euros, and it ships from Germany by DHL. In the US the options above are far easier to buy. In the German-speaking market it's the closest thing here to a Skylight without the subscription.</p>
+<p><strong>Best for:</strong> German-speaking families who want dedicated hardware, one payment, and their data held in the EU.</p>
+<h2>7. Cozi — the free app (no wall display)</h2>
 <p>Cozi is the most popular shared family calendar app: free, cross-platform, with shopping lists and meal planning. There's no wall-display product — it lives on phones. Some families genuinely don't need the wall screen; if that's you, start here before spending anything.</p>
 <p><strong>Best for:</strong> families who just need shared scheduling on phones.</p>
-<h2>7. Google Calendar on an old tablet — the zero-dollar DIY</h2>
+<h2>8. Google Calendar on an old tablet — the zero-dollar DIY</h2>
 <p>Mount an old tablet on the wall, open Google Calendar in kiosk/fullscreen mode, done. It's free and takes ten minutes. The downsides: no chore charts, no countdowns, no kid-friendly layout, and tablets sleeping or logging out at the worst moment. It's the baseline every option above is trying to beat — and why we built <a href="/diy-skylight-calendar/">a friendlier version of exactly this</a>.</p>
 <p><strong>Best for:</strong> testing whether your family will actually look at a wall calendar, before investing anything.</p>
 <h2>Which one should you pick?</h2>
@@ -435,7 +445,7 @@
 <li><strong>Want BYO screen with zero setup:</strong> Mango Display</li>
 <li><strong>Want maximum layout control:</strong> DAKboard</li>
 <li><strong>Want premium dedicated hardware:</strong> Hearth (routines) or stick with Skylight (calendar + meals)</li>
-<li><strong>Want hardware but no subscription:</strong> Cozyla</li>
+<li><strong>Want hardware but no subscription:</strong> Cozyla, or Dæly if you're buying in Europe</li>
 <li><strong>Not sure you need a wall display at all:</strong> Cozi on your phones, or the old-tablet test</li>
 </ul>
     <p class="page-updated">Last updated 2026-09-06.</p>

--- a/docs/skylight-calendar-subscription/index.html
+++ b/docs/skylight-calendar-subscription/index.html
@@ -357,7 +357,7 @@
       "name": "What does a Skylight Calendar cost in the first year with Plus?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "About $409 for the 15-inch Calendar 2 ($329.99 plus $79 a year) and about $679 for the 27-inch Calendar Max ($599.99 plus $79 a year). Over three years the Max works out at roughly $837."
+        "text": "About $379 for the 15-inch Calendar 2 ($299.99 plus $79 a year) and about $679 for the 27-inch Calendar Max ($599.99 plus $79 a year). Over three years the Max works out at roughly $837."
       }
     },
     {
@@ -365,7 +365,7 @@
       "name": "Is there a family calendar with no subscription at all?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Yes. You can keep a Skylight and skip Plus, buy hardware like Cozyla that advertises no monthly fees, or run free open-source software such as DinkyDash on a TV, tablet or Raspberry Pi you already own, which costs nothing per month."
+        "text": "Yes. You can keep a Skylight and skip Plus, buy hardware like Cozyla whose core calendar, chores and routines need no subscription, or run free open-source software such as DinkyDash on a TV, tablet or Raspberry Pi you already own, which costs nothing per month."
       }
     }
   ]
@@ -415,8 +415,8 @@
 <tbody>
 <tr>
 <td>Skylight Calendar 2 (15″)</td>
-<td>$329.99</td>
-<td>$329.99 + $79/yr → <strong>~$409 first year</strong></td>
+<td>$299.99</td>
+<td>$299.99 + $79/yr → <strong>~$379 first year</strong></td>
 </tr>
 <tr>
 <td>Skylight Calendar Max (27″)</td>
@@ -430,17 +430,17 @@
 </tr>
 </tbody>
 </table>
-<p><em>Prices checked September 2026 — Skylight adjusts pricing and bundles regularly (Costco bundles sometimes include a year of Plus).</em></p>
+<p><em>Prices checked 6 September 2026 — Skylight adjusts pricing and bundles regularly (Costco bundles sometimes include a year of Plus).</em></p>
 <h2>Is Plus worth $79 a year?</h2>
 <p>If Magic Import and meal planning would genuinely get used weekly in your house, most owners say yes. If you bought the calendar to <em>see the family calendar</em>, you can skip Plus entirely and lose nothing essential — just know that the chore-rewards and photo-frame features you may have seen in ads won't be there.</p>
 <h2>If subscriptions are the dealbreaker</h2>
 <p>You have three subscription-free routes:</p>
 <ol>
 <li><strong>Skylight without Plus</strong> — keep the core calendar, skip the extras.</li>
-<li><strong>Cozyla</strong> — dedicated hardware that advertises no monthly fees, with AI import included.</li>
+<li><strong>Cozyla</strong> — dedicated hardware whose core calendar, chores and routines need no subscription. An optional Calendar Essential plan auto-renews at $79.99/yr and covers meal planning, custom screensavers and the AI voice agent.</li>
 <li><strong>Free software on a screen you already own</strong> — <a href="/">DinkyDash</a> is open source and turns any TV, tablet, or Raspberry Pi into a family calendar with chore rotations, countdowns, and an AI-written daily brief. Hardware cost: $0 if you own a spare screen, <a href="/diy-skylight-calendar/">about $100 for a tidy Raspberry Pi build</a>. Subscription: none, ever.</li>
 </ol>
-<p>For the full field, see our guide to <a href="/skylight-calendar-alternatives/">the 7 best Skylight Calendar alternatives</a>.</p>
+<p>For the full field, see our guide to <a href="/skylight-calendar-alternatives/">the 8 best Skylight Calendar alternatives</a>.</p>
 <h2>Common questions</h2>
 <p><strong>Does the Skylight Calendar require a subscription?</strong>
 No. Calendar syncing, the shared family view, basic chore charts and lists all work on the device you bought, with no subscription. The extras — meal planning, Magic Import, chore rewards and the photo screensaver — need Skylight Plus at $79 per year.</p>
@@ -449,9 +449,9 @@ $79 per year as of September 2026, with the first month free. Skylight adjusts p
 <p><strong>What does Skylight Plus include?</strong>
 Meal planning with a recipe box and weekly dinner plan, Magic Import (photograph a school newsletter or forward an email and AI turns it into events), chore rewards with stars and tracking, and a photo screensaver for when the calendar is idle.</p>
 <p><strong>What does a Skylight Calendar cost in the first year with Plus?</strong>
-About $409 for the 15-inch Calendar 2 ($329.99 plus $79 a year) and about $679 for the 27-inch Calendar Max ($599.99 plus $79 a year). Over three years the Max works out at roughly $837.</p>
+About $379 for the 15-inch Calendar 2 ($299.99 plus $79 a year) and about $679 for the 27-inch Calendar Max ($599.99 plus $79 a year). Over three years the Max works out at roughly $837.</p>
 <p><strong>Is there a family calendar with no subscription at all?</strong>
-Yes. You can keep a Skylight and skip Plus, buy hardware like Cozyla that advertises no monthly fees, or run free open-source software such as <a href="/diy-skylight-calendar/">DinkyDash</a> on a TV, tablet or Raspberry Pi you already own, which costs nothing per month.</p>
+Yes. You can keep a Skylight and skip Plus, buy hardware like Cozyla whose core calendar, chores and routines need no subscription, or run free open-source software such as <a href="/diy-skylight-calendar/">DinkyDash</a> on a TV, tablet or Raspberry Pi you already own, which costs nothing per month.</p>
     <p class="page-updated">Last updated 2026-09-06.</p>
 </div>
 

--- a/website/content/best-digital-family-calendar.md
+++ b/website/content/best-digital-family-calendar.md
@@ -13,11 +13,13 @@ Every "best digital family calendar" list starts from the same assumption: that 
 
 You're paying for plug-and-play: unbox, connect Wi-Fi, done. As of September 2026:
 
-**Skylight Calendar 2 (15″, $329.99) / Calendar Max (27″, $599.99)** — the category leader and the safest pick. Best-in-class calendar view, meal planning and AI event import with the optional Plus plan ($79/yr). If you just want it to work, buy this. ([What the subscription does and doesn't cover →](/skylight-calendar-subscription/))
+**Skylight Calendar 2 (15″, $299.99) / Calendar Max (27″, $599.99)** — the category leader and the safest pick. Best-in-class calendar view, meal planning and AI event import with the optional Plus plan ($79/yr). If you just want it to work, buy this. ([What the subscription does and doesn't cover →](/skylight-calendar-subscription/))
 
 **Hearth Display (27″, $699 + $9/mo, or $86.40/yr billed annually)** — the routines specialist. Visual morning/evening checklists kids run themselves; a favorite with ADHD families. Priciest option in the category. ([Hearth vs Skylight compared →](/hearth-vs-skylight/))
 
-**Cozyla (from $169.99)** — dedicated hardware whose pitch is "no monthly fees" — features that cost extra elsewhere are included. Less polished than Skylight, but pay-once pricing.
+**Cozyla (from $169.99)** — dedicated hardware whose pitch is "no monthly fees," and the core calendar, chores and routines do work without one. Watch for the optional Calendar Essential plan, which auto-renews at $79.99/yr after a 30-day trial and covers meal planning and the AI voice agent. Less polished than Skylight, but pay-once pricing.
+
+**Dæly (€299)** — a 15.6″ German alternative with no subscription and EU data storage, sold in euros and shipped from Germany. Worth knowing if you are buying in the German-speaking market; awkward to buy from anywhere else.
 
 ## Path 2: Use a screen you already own
 
@@ -25,9 +27,9 @@ A family calendar display is, mechanically, a screen showing a web page. If a sp
 
 **DinkyDash (free, open source)** — our project, and the reason this site exists. Any screen with a browser becomes a family calendar with automatic chore rotation, birthday countdowns, and an AI-written daily brief — a fresh greeting and fun fact every morning, written around your own family, which no hardware calendar offers. Setup takes an afternoon and a bit of terminal comfort ([guide](/getting-started/)); a zero-setup hosted version is [in the works](https://fffwryhvses.typeform.com/to/yxMMhmFs).
 
-**Mango Display (free tier; Pro $5.99/mo or $59.99/yr)** — commercial BYO-screen software with polished apps for smart TVs and tablets. The no-DIY version of this path.
+**Mango Display (free tier; Pro $5.99/mo or $59.99/yr)** — commercial BYO-screen software with polished apps for smart TVs and tablets. The no-DIY version of this path — but budget for Pro, because the free plan has no calendar.
 
-**DAKboard (free tier; $5–10/mo)** — the veteran customizable wall display. Enormous flexibility, more "information dashboard" than "family organizer." The free tier is narrower than it looks — one predefined screen and two calendars — so see the [DAKboard alternatives comparison](/dakboard-alternatives/) before committing.
+**DAKboard (free tier; $5–10/mo)** — the veteran customizable wall display. Enormous flexibility, and a chore chart with points and rewards on the paid plans, though it is still a dashboard first. The free tier is narrower than it looks — one predefined screen and two calendars — so see the [DAKboard alternatives comparison](/dakboard-alternatives/) before committing.
 
 ## How to decide
 
@@ -40,13 +42,13 @@ A family calendar display is, mechanically, a screen showing a web page. If a sp
 
 | | Hardware | Ongoing cost | Standout feature |
 |---|---|---|---|
-| Skylight Cal 2 / Max | $329.99 / $599.99 | $0–79/yr | Best plug-and-play calendar |
+| Skylight Cal 2 / Max | $299.99 / $599.99 | $0–79/yr | Best plug-and-play calendar |
 | Hearth | $699 | $86.40/yr | Visual routines for kids |
-| Cozyla | From $169.99 | $0 | Pay-once hardware |
+| Cozyla | From $169.99 | $0, or $79.99/yr optional | Pay-once hardware |
 | DinkyDash | $0 (your screen) | $0 | AI daily brief, open source |
 | Mango Display | $0 (your screen) | $0–60/yr | Easiest BYO-screen |
 | DAKboard | $0 (your screen) | $0–120/yr | Deep customization |
 
-*Prices checked September 2026.*
+*Prices checked 6 September 2026.*
 
 Whichever path you take: the win isn't the gadget, it's the behavior change — the family checking one shared screen instead of asking one exhausted parent. The cheapest way to test whether that works in your house is [the free one](/getting-started/).

--- a/website/content/dakboard-alternatives.md
+++ b/website/content/dakboard-alternatives.md
@@ -32,7 +32,7 @@ This page compares six alternatives on the things that actually decide it: what 
 | **MagicMirror²** | $0 | Bring your own | Yes | Yes (MIT) |
 | **Home Assistant** | $0 | Bring your own | Yes | Yes (Apache 2.0) |
 | **Mango Display** | Free tier; Pro $5.99/mo | Bring your own | No | No |
-| **Skylight Calendar** | Optional $79/yr | $329.99–$599.99 | No | No |
+| **Skylight Calendar** | Optional $79/yr | $299.99–$599.99 | No | No |
 | **Hearth Display** | $86.40/yr required | $699 | No | No |
 | *DAKboard, for reference* | *Free tier; $5–10/mo* | *Bring your own, or ~$80 CPU* | *No* | *No* |
 
@@ -46,7 +46,7 @@ Three reasons come up repeatedly, and they point at different replacements.
 
 **It is not open source.** You can run the display on your own Raspberry Pi, which reads like self-hosting, but the service runs on DAKboard's servers and the source is not published. If your reason for building a wall display was keeping the family's schedule on your own hardware, that is the wrong shape.
 
-**It is a dashboard, not a family organizer.** DAKboard's strength is arranging many data sources on one screen. If what you wanted was "whose turn is it to feed the dog", you are configuring a general tool into a specific one.
+**It is a dashboard first, a family organizer second.** DAKboard does now market a chore chart — a column per family member, one tap to check something off, points that convert into rewards you set, and a child lock so siblings can't clear each other's lists. It is on Essential and Plus, not the free tier. But the product underneath is still a way of arranging many data sources on one screen, so "whose turn is it to feed the dog" means pointing a general tool at a specific job.
 
 ## 1. DinkyDash — free, open source, family-shaped
 
@@ -90,7 +90,7 @@ One thing worth knowing before you sign up: **the free plan does not include the
 
 ## 5. Skylight Calendar — buy the screen too
 
-If the real answer is that you want a finished object on the wall rather than a project, Skylight sells the hardware: $329.99 for the 15″ Calendar 2, $599.99 for the 27″ Calendar Max, with an optional Plus subscription at $79/year for chore rewards and meal planning.
+If the real answer is that you want a finished object on the wall rather than a project, Skylight sells the hardware: $299.99 for the 15″ Calendar 2, $599.99 for the 27″ Calendar Max, with an optional Plus subscription at $79/year for chore rewards and meal planning.
 
 It is the opposite trade to DAKboard — you spend money instead of time, and you get a touchscreen your family can actually tap. See our [Skylight alternatives page](/skylight-calendar-alternatives/) for the wider comparison, or the [subscription breakdown](/skylight-calendar-subscription/) for what Plus actually costs.
 

--- a/website/content/digital-calendar-and-chore-chart.md
+++ b/website/content/digital-calendar-and-chore-chart.md
@@ -25,12 +25,13 @@ Nobody negotiates with a screen. The rotation is provably fair (it cycles throug
 | Option | Cost | Chore features |
 |---|---|---|
 | **DinkyDash** (screen you own) | Free, open source | Automatic daily rotation |
-| **Skylight Calendar** | $329.99–$599.99 | Chore chart free; rewards need Plus ($79/yr) |
+| **DAKboard** (screen you own) | Free tier; $6–10/mo | Chore columns per child, points and rewards — paid plans only |
+| **Skylight Calendar** | $299.99–$599.99 | Chore chart free; rewards need Plus ($79/yr) |
 | **Hearth Display** | $699 + $9/mo ($86.40/yr) | Routines and task assignments |
 
-*Prices checked September 2026.*
+*Prices checked 6 September 2026.*
 
-Skylight and Hearth both do chores well — that's part of why families pay for them. But if the hardware price is the obstacle, the free route gets you the core loop (visible chores, fair rotation, zero nagging) on a screen you already own. Our [DIY guide](/diy-skylight-calendar/) shows the whole build, and the [getting started guide](/getting-started/) has the copy-paste setup.
+Skylight, Hearth and DAKboard all do chores well — that's part of why families pay for them. But if the price is the obstacle, the free route gets you the core loop (visible chores, fair rotation, zero nagging) on a screen you already own. Our [DIY guide](/diy-skylight-calendar/) shows the whole build, and the [getting started guide](/getting-started/) has the copy-paste setup.
 
 ## The countdown trick
 

--- a/website/content/diy-skylight-calendar.md
+++ b/website/content/diy-skylight-calendar.md
@@ -81,7 +81,7 @@ A cheap tablet wall mount, a picture ledge, or a small easel stand all work. Non
 | AI daily brief | No | Yes |
 | Fixable/customizable | No | It's your code |
 
-*Prices checked September 2026.*
+*Skylight prices checked 6 September 2026; the Raspberry Pi part prices above are approximate and were last checked August 2026.*
 
 ## Questions people ask
 

--- a/website/content/hearth-vs-skylight.md
+++ b/website/content/hearth-vs-skylight.md
@@ -2,7 +2,7 @@
 title: "Hearth vs Skylight (2026): Prices, Subscriptions, and Which to Buy"
 seo_title: "Hearth vs Skylight 2026: Prices, Subscriptions, Which to Buy"
 template: page.html
-description: Hearth Display ($699 + $9/mo) vs Skylight Calendar ($329.99–$599.99 + optional $79/yr) compared honestly — plus the third option both companies would rather you didn't know about.
+description: Hearth Display ($699 + $9/mo) vs Skylight Calendar ($299.99–$599.99 + optional $79/yr) compared honestly — plus the third option both companies would rather you didn't know about.
 ---
 
 Comparing the two big family-calendar displays? Here's the short version: **Skylight** is the calendar-first option with a lower entry price and an optional subscription. **Hearth** is the routines-first option — beloved by families managing ADHD and complex mornings — with a higher price and a required membership. And there's a third path that costs almost nothing, which we'll get to.
@@ -11,18 +11,20 @@ Comparing the two big family-calendar displays? Here's the short version: **Skyl
 
 | | Skylight Calendar | Hearth Display |
 |---|---|---|
-| Price | $329.99 (15″ Calendar 2) / $599.99 (27″ Max) | $699 (27″, often discounted) |
+| Price | $299.99 (15″ Calendar 2) / $599.99 (27″ Max) | $699 (27″, often discounted) |
 | Subscription | Optional Plus, $79/yr | Required: $9/mo, or $86.40/yr billed annually |
 | Orientation | Landscape or portrait | Portrait |
 | Core strength | Shared calendar, meal planning | Routines, to-dos, visual schedules |
 | Chores | Chore chart; rewards need Plus | Routine and task system built in |
 | Realistic 3-year cost | $599.99 + $237 ≈ **$837** (Max with Plus) | $699 + $259 ≈ **$958** (annual membership) |
 
-*Prices checked September 2026.*
+*Prices checked 6 September 2026.*
+
+Two footnotes on that last row, both in Hearth's favor: the $699 is a list price they discount often, and the membership gets cheaper if you commit — $155.52 for two years, or $207.36 for three, which brings the three-year total to about $906 rather than $958.
 
 ## Where Skylight wins
 
-Skylight nails the core job: your Google, Apple, or Outlook calendars merged into one big, color-coded family view. The interface is polished, the companion app is solid, and the 15″ model's $329.99 entry price is the lowest way into a premium dedicated display. Meal planning and its AI-powered "Magic Import" (photograph a school newsletter, get calendar events) are genuinely useful — but note they live behind the $79/year Plus plan. Read more on [what Skylight's subscription does and doesn't cover](/skylight-calendar-subscription/).
+Skylight nails the core job: your Google, Apple, or Outlook calendars merged into one big, color-coded family view. The interface is polished, the companion app is solid, and the 15″ model's $299.99 entry price is the lowest way into a premium dedicated display. Meal planning and its AI-powered "Magic Import" (photograph a school newsletter, get calendar events) are genuinely useful — but note they live behind the $79/year Plus plan. Read more on [what Skylight's subscription does and doesn't cover](/skylight-calendar-subscription/).
 
 ## Where Hearth wins
 
@@ -37,4 +39,4 @@ Hearth is designed around *routines*, not just events: visual morning and evenin
 
 Both products are, at heart, a screen showing your family's day. If you have an old tablet, a TV, or $100 for a Raspberry Pi, free software gives you the same glanceable calendar — with chore rotations and countdowns — for no subscription at all.
 
-That's what [DinkyDash](/) does (free, open source, and with an AI-written daily brief neither Skylight nor Hearth offers). See [how to build one in an afternoon](/diy-skylight-calendar/), or compare [all seven Skylight alternatives](/skylight-calendar-alternatives/).
+That's what [DinkyDash](/) does (free, open source, and with an AI-written daily brief neither Skylight nor Hearth offers). See [how to build one in an afternoon](/diy-skylight-calendar/), or compare [all eight Skylight alternatives](/skylight-calendar-alternatives/).

--- a/website/content/skylight-calendar-alternatives.md
+++ b/website/content/skylight-calendar-alternatives.md
@@ -1,10 +1,10 @@
 ---
-title: The 7 Best Skylight Calendar Alternatives in 2026
+title: The 8 Best Skylight Calendar Alternatives in 2026
 template: page.html
-description: Looking for a Skylight Calendar alternative without the $329.99–$599.99 price tag or the $79/year subscription? Here are 7 options — including free ones that run on screens you already own.
+description: Looking for a Skylight Calendar alternative without the $299.99–$599.99 price tag or the $79/year subscription? Here are 8 options — including free ones that run on screens you already own.
 ---
 
-The Skylight Calendar is a lovely idea: your family's schedule, big and glanceable, on the kitchen wall. But between the hardware ($329.99 for the 15″ Calendar 2, $599.99 for the 27″ Calendar Max) and the optional $79/year Plus subscription for features like meal planning and chore rewards, plenty of families go looking for alternatives before checking out.
+The Skylight Calendar is a lovely idea: your family's schedule, big and glanceable, on the kitchen wall. But between the hardware ($299.99 for the 15″ Calendar 2, $599.99 for the 27″ Calendar Max) and the optional $79/year Plus subscription for features like meal planning and chore rewards, plenty of families go looking for alternatives before checking out.
 
 The good news: you have real options — including some that cost nothing because they run on a screen you already own.
 
@@ -15,14 +15,15 @@ The good news: you have real options — including some that cost nothing becaus
 | Alternative | Hardware cost | Subscription | Bring your own screen? |
 |---|---|---|---|
 | **DinkyDash** | $0 | None — open source | Yes |
-| **Mango Display** | $0 | Free tier; Pro $5.99/mo | Yes |
+| **Mango Display** | $0 | Free tier (no calendar); Pro $5.99/mo | Yes |
 | **DAKboard** | $0 | Free tier; $5–10/mo | Yes |
 | **Hearth Display** | $699 | $9/mo ($86.40/yr) | No |
-| **Cozyla** | From $169.99 | Advertises no monthly fees | No |
+| **Cozyla** | From $169.99 | Core free; optional $79.99/yr | No |
+| **Dæly** | €299 | None | No |
 | **Cozi** | $0 (phone app) | Free with ads | No wall display |
 | **Google Calendar on an old tablet** | $0 | None | Yes |
 
-*Prices checked September 2026 — always confirm current pricing before buying.*
+*Prices checked 6 September 2026 — always confirm current pricing before buying. Dæly is sold in euros and ships from Germany.*
 
 ## 1. DinkyDash — free, open source, and AI-powered
 
@@ -34,13 +35,13 @@ It's MIT-licensed and free. The trade-off: today you set it up yourself, which m
 
 ## 2. Mango Display — polished BYO-screen software
 
-Mango Display is a commercial take on the same idea: install their app on a smart TV, Fire TV, or tablet and it renders a calendar-centric smart display with widgets for photos, weather, and to-dos. There's a free tier (two screens), and the Pro plan is $5.99/month, or $59.99 a year.
+Mango Display is a commercial take on the same idea: install their app on a smart TV, Fire TV, or tablet and it renders a calendar-centric smart display with widgets for photos, weather, and to-dos. There's a free tier, but read it before you rely on it: the free plan gives you two screens with a clock, weather, news headlines and background images, and **no calendar at all**. Calendars — along with chores, meal plans and photos — start on Pro, at $5.99/month or $59.99 a year.
 
 **Best for:** families who want bring-your-own-screen without any DIY at all.
 
 ## 3. DAKboard — the customizable wall display veteran
 
-DAKboard has been the DIY wall-display favorite for years — calendars, photos, weather, and news on any screen, with deep layout customization. Free for one predefined screen with two calendars; $6/month (or $5 billed annually) unlocks custom layouts, and $10/month adds unlimited calendars. It's more "information display" than "family organizer." If it's the one you're weighing up, we compared it properly on the [DAKboard alternatives page](/dakboard-alternatives/).
+DAKboard has been the DIY wall-display favorite for years — calendars, photos, weather, and news on any screen, with deep layout customization. Free for one predefined screen with two calendars; $6/month (or $5 billed annually) unlocks custom layouts, and $10/month adds unlimited calendars. It leans "information display" rather than "family organizer," though it now markets a chore chart with points and rewards on the paid plans. If it's the one you're weighing up, we compared it properly on the [DAKboard alternatives page](/dakboard-alternatives/).
 
 **Best for:** data-dense household dashboards and tinkerers who want full layout control.
 
@@ -52,17 +53,25 @@ If what you actually want is *nicer* dedicated hardware, Hearth's 27″ portrait
 
 ## 5. Cozyla — hardware without the monthly fee
 
-Cozyla sells digital calendar displays from $169.99 that advertise no monthly fees — the feature set that Skylight puts behind Plus (like AI-assisted event import) is included. Build quality and app polish get mixed reviews compared to Skylight, but "pay once" is a compelling pitch.
+Cozyla sells digital calendar displays from $169.99 on a "no monthly fees" pitch, and the core really does work without one — calendar sync, chores, routines and notes are all free on the device. Read the checkout carefully, though: the Calendar Neo ships with a 30-day trial of an optional Calendar Essential plan that auto-renews at $79.99 a year, and that is where meal planning, custom screensavers and the AI voice agent live. Build quality and app polish get mixed reviews compared to Skylight, but "pay once" is still a compelling pitch.
 
 **Best for:** families set on dedicated hardware who refuse subscriptions.
 
-## 6. Cozi — the free app (no wall display)
+## 6. Dæly — the one-time purchase, if you're in Europe
+
+Dæly is a 15.6″ touchscreen family calendar sold from Germany for **€299** (list price €349), with no subscription at all — the company's own line is that every feature you get on the day you buy stays free. It syncs with a free iOS and Android app, arrives with a stand and an integrated wall mount, and keeps your data on German servers under GDPR.
+
+The catch for most readers of this page: the shop, the app and the support are in German, prices are in euros, and it ships from Germany by DHL. In the US the options above are far easier to buy. In the German-speaking market it's the closest thing here to a Skylight without the subscription.
+
+**Best for:** German-speaking families who want dedicated hardware, one payment, and their data held in the EU.
+
+## 7. Cozi — the free app (no wall display)
 
 Cozi is the most popular shared family calendar app: free, cross-platform, with shopping lists and meal planning. There's no wall-display product — it lives on phones. Some families genuinely don't need the wall screen; if that's you, start here before spending anything.
 
 **Best for:** families who just need shared scheduling on phones.
 
-## 7. Google Calendar on an old tablet — the zero-dollar DIY
+## 8. Google Calendar on an old tablet — the zero-dollar DIY
 
 Mount an old tablet on the wall, open Google Calendar in kiosk/fullscreen mode, done. It's free and takes ten minutes. The downsides: no chore charts, no countdowns, no kid-friendly layout, and tablets sleeping or logging out at the worst moment. It's the baseline every option above is trying to beat — and why we built [a friendlier version of exactly this](/diy-skylight-calendar/).
 
@@ -74,5 +83,5 @@ Mount an old tablet on the wall, open Google Calendar in kiosk/fullscreen mode, 
 - **Want BYO screen with zero setup:** Mango Display
 - **Want maximum layout control:** DAKboard
 - **Want premium dedicated hardware:** Hearth (routines) or stick with Skylight (calendar + meals)
-- **Want hardware but no subscription:** Cozyla
+- **Want hardware but no subscription:** Cozyla, or Dæly if you're buying in Europe
 - **Not sure you need a wall display at all:** Cozi on your phones, or the old-tablet test

--- a/website/content/skylight-calendar-subscription.md
+++ b/website/content/skylight-calendar-subscription.md
@@ -11,9 +11,9 @@ faq:
   - q: "What does Skylight Plus include?"
     a: "Meal planning with a recipe box and weekly dinner plan, Magic Import (photograph a school newsletter or forward an email and AI turns it into events), chore rewards with stars and tracking, and a photo screensaver for when the calendar is idle."
   - q: "What does a Skylight Calendar cost in the first year with Plus?"
-    a: "About $409 for the 15-inch Calendar 2 ($329.99 plus $79 a year) and about $679 for the 27-inch Calendar Max ($599.99 plus $79 a year). Over three years the Max works out at roughly $837."
+    a: "About $379 for the 15-inch Calendar 2 ($299.99 plus $79 a year) and about $679 for the 27-inch Calendar Max ($599.99 plus $79 a year). Over three years the Max works out at roughly $837."
   - q: "Is there a family calendar with no subscription at all?"
-    a: "Yes. You can keep a Skylight and skip Plus, buy hardware like Cozyla that advertises no monthly fees, or run free open-source software such as DinkyDash on a TV, tablet or Raspberry Pi you already own, which costs nothing per month."
+    a: "Yes. You can keep a Skylight and skip Plus, buy hardware like Cozyla whose core calendar, chores and routines need no subscription, or run free open-source software such as DinkyDash on a TV, tablet or Raspberry Pi you already own, which costs nothing per month."
 ---
 
 **Short answer: no — the Skylight Calendar works without a subscription.** Calendar syncing, the shared family view, basic chore charts, and lists all work on the device you bought, forever.
@@ -29,11 +29,11 @@ faq:
 
 | | Without Plus | With Plus |
 |---|---|---|
-| Skylight Calendar 2 (15″) | $329.99 | $329.99 + $79/yr → **~$409 first year** |
+| Skylight Calendar 2 (15″) | $299.99 | $299.99 + $79/yr → **~$379 first year** |
 | Skylight Calendar Max (27″) | $599.99 | $599.99 + $79/yr → **~$679 first year** |
 | Cost over 3 years (Max) | $599.99 | **~$837** |
 
-*Prices checked September 2026 — Skylight adjusts pricing and bundles regularly (Costco bundles sometimes include a year of Plus).*
+*Prices checked 6 September 2026 — Skylight adjusts pricing and bundles regularly (Costco bundles sometimes include a year of Plus).*
 
 ## Is Plus worth $79 a year?
 
@@ -44,10 +44,10 @@ If Magic Import and meal planning would genuinely get used weekly in your house,
 You have three subscription-free routes:
 
 1. **Skylight without Plus** — keep the core calendar, skip the extras.
-2. **Cozyla** — dedicated hardware that advertises no monthly fees, with AI import included.
+2. **Cozyla** — dedicated hardware whose core calendar, chores and routines need no subscription. An optional Calendar Essential plan auto-renews at $79.99/yr and covers meal planning, custom screensavers and the AI voice agent.
 3. **Free software on a screen you already own** — [DinkyDash](/) is open source and turns any TV, tablet, or Raspberry Pi into a family calendar with chore rotations, countdowns, and an AI-written daily brief. Hardware cost: $0 if you own a spare screen, [about $100 for a tidy Raspberry Pi build](/diy-skylight-calendar/). Subscription: none, ever.
 
-For the full field, see our guide to [the 7 best Skylight Calendar alternatives](/skylight-calendar-alternatives/).
+For the full field, see our guide to [the 8 best Skylight Calendar alternatives](/skylight-calendar-alternatives/).
 
 ## Common questions
 
@@ -61,7 +61,7 @@ $79 per year as of September 2026, with the first month free. Skylight adjusts p
 Meal planning with a recipe box and weekly dinner plan, Magic Import (photograph a school newsletter or forward an email and AI turns it into events), chore rewards with stars and tracking, and a photo screensaver for when the calendar is idle.
 
 **What does a Skylight Calendar cost in the first year with Plus?**
-About $409 for the 15-inch Calendar 2 ($329.99 plus $79 a year) and about $679 for the 27-inch Calendar Max ($599.99 plus $79 a year). Over three years the Max works out at roughly $837.
+About $379 for the 15-inch Calendar 2 ($299.99 plus $79 a year) and about $679 for the 27-inch Calendar Max ($599.99 plus $79 a year). Over three years the Max works out at roughly $837.
 
 **Is there a family calendar with no subscription at all?**
-Yes. You can keep a Skylight and skip Plus, buy hardware like Cozyla that advertises no monthly fees, or run free open-source software such as [DinkyDash](/diy-skylight-calendar/) on a TV, tablet or Raspberry Pi you already own, which costs nothing per month.
+Yes. You can keep a Skylight and skip Plus, buy hardware like Cozyla whose core calendar, chores and routines need no subscription, or run free open-source software such as [DinkyDash](/diy-skylight-calendar/) on a TV, tablet or Raspberry Pi you already own, which costs nothing per month.

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -565,7 +565,7 @@
                 <div class="math-sub">$29/yr for the first 100 on the list</div>
             </div>
         </div>
-        <p class="math-note">Competitor prices checked September 2026. Skylight and Hearth are lovely products &mdash; you just might not need the hardware. Running DinkyDash on your own machine is free forever, and always will be.</p>
+        <p class="math-note">Competitor prices checked 6 September 2026. Skylight and Hearth are lovely products &mdash; you just might not need the hardware. Running DinkyDash on your own machine is free forever, and always will be.</p>
     </div>
 </section>
 
@@ -750,7 +750,7 @@
             </details>
             <details>
                 <summary>How is this different from a Skylight or Hearth?</summary>
-                <p>Skylight and Hearth sell you a dedicated touchscreen ($330–$699) with an optional or required subscription on top. DinkyDash is just the software, running on a screen you already own. It also does something they don't: a line written fresh every morning from your actual day. <a href="/skylight-calendar-alternatives/">See the full comparison</a>.</p>
+                <p>Skylight and Hearth sell you a dedicated touchscreen ($300–$699) with an optional or required subscription on top. DinkyDash is just the software, running on a screen you already own. It also does something they don't: a line written fresh every morning from your actual day. <a href="/skylight-calendar-alternatives/">See the full comparison</a>.</p>
             </details>
         </div>
     </div>
@@ -813,7 +813,7 @@
     {
       "@type": "Question",
       "name": "How is this different from a Skylight or Hearth?",
-      "acceptedAnswer": { "@type": "Answer", "text": "Skylight and Hearth sell you a dedicated touchscreen ($330–$699) with an optional or required subscription on top. DinkyDash is just the software, running on a screen you already own. It also does something they don't: a line written fresh every morning from your actual day." }
+      "acceptedAnswer": { "@type": "Answer", "text": "Skylight and Hearth sell you a dedicated touchscreen ($300–$699) with an optional or required subscription on top. DinkyDash is just the software, running on a screen you already own. It also does something they don't: a line written fresh every morning from your actual day." }
     }
   ]
 }


### PR DESCRIPTION
Closes [DIN-4](https://linear.app/keepthescore/issue/DIN-4).

Every competitor price on the comparison pages was re-fetched from the vendor's own pricing page on
6 September 2026. One published figure was wrong in the direction that costs us trust.

## The correction that matters

We listed the 15" Skylight Calendar 2 at **$329.99**. Skylight sells it at **$299.99**, in every
style (Classic, Wood, Shadow Box) and every colour. $329.99 is a retailer listing, not Skylight's
own price. The $30 also inflated our first-year-with-Plus figure to $409 where the real number is
$379. Both are fixed everywhere they appear, including the page descriptions and the FAQ JSON-LD.

This is the same class of mistake as the Hearth `$9 × 12 = $108` error fixed last week, and it
points at one rule worth keeping: **the vendor's own product page is the source, and a retailer
listing is not a substitute for it.**

## Verified unchanged

| Product | Verified 6 Sep 2026 |
| --- | --- |
| Skylight Calendar Max (27") | $599.99, Plus $79/yr optional |
| Hearth Display | $699 list, required membership $9/mo or $86.40/yr |
| DAKboard | Free; Essential $6/mo ($5 annually); Plus $10/mo ($8 annually) |
| Mango Display | Free; Pro $5.99/mo or $59.99/yr |
| Cozyla Calendar Neo | from $169.99 |

## Three things the re-check found that are not prices

**DAKboard has shipped a chore chart.** A column per family member, one tap to complete, points
converting into rewards you set, and a child lock so siblings can't clear each other's lists. It is
on Essential and Plus, not the free tier. Three pages said or implied DAKboard had nothing for kids'
chores. Corrected — and **DAKboard now has a row in the chore-chart comparison table**, which is
where the missing row DIN-4 asks for actually was. It was already present on the two pages the issue
named.

**Mango Display's free plan has no calendar at all.** Two screens with a clock, weather, news
headlines and background images; calendars, chores, meal plans and photos are all Pro. Now said
wherever we list that tier, not just on the new DAKboard page.

**Cozyla's "no monthly fees" needs a footnote.** The core — calendar sync, chores, routines, notes —
really is free on the device, but the Calendar Neo ships with a 30-day trial of a Calendar Essential
plan that auto-renews at $79.99/yr and carries meal planning, custom screensavers and the AI voice
agent.

## Also in here

- **Dæly added** as a genuine eighth entry on the alternatives page: 15.6" touchscreen, €299 (list
  €349), no subscription, EU data storage, shipped from Germany. Marked plainly as euro-priced and
  German-language, because it is awkward to buy from the US. The page is now "The 8 Best…" and the
  two pages that linked to "all seven" follow.
- **Hearth's multi-year membership noted** beside the three-year total. We quote $958 on annual
  billing; their three-year plan is $207.36, which would make it about $906. Quoting only the dearer
  option on a page about honest pricing is the same error as the $30, in a smaller size.
- **Checked dates tightened** from "September 2026" to "6 September 2026" across the price tables.
  The DIY page's caption now separates the Skylight column (re-checked) from the Raspberry Pi part
  prices (August 2026, not re-checked), which it was quietly covering with one stamp.

## Not in this PR

Per repo policy, the strategy side of DIN-4 was written to Linear, not here: the pricing-anchor
table in [DinkyDash Strategy](https://linear.app/keepthescore/document/dinkydash-strategy-8f4bb9166693)
and the field list in [Competitor and alternative product list](https://linear.app/keepthescore/document/competitor-and-alternative-product-list-f36cf2a7b640)
both carried the $329.99 and are now corrected, with the next quarterly re-check dated December 2026.

`docs/` is the rebuilt output of `website/`, no hand edits. 157 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)