### PR TITLE
Split the daily run into a calendar refresh and a brief, on a tick (DIN-17)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ __pycache__/
 dashboard_data.json
 content_history.json
 generate.log
+.tick.lock
 
 # Personal data (not for public repo)
 config.yaml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -229,6 +229,7 @@ dinkydash/
 ├── board.py           payload + config -> what the template renders
 ├── config.py          config.yaml load/save (ruamel round-trip), item ids
 ├── history.py         rolling record of recent notes, to avoid repeats
+├── schedule.py        due(config, payload, now) -> what a tick owes (pure)
 └── runner.py          the one place that does I/O around the engine
 
 web/
@@ -252,18 +253,71 @@ can be actively wrong.
 
 That same 14-day window is where **tomorrow's** agenda comes from, so it survives a failed run too.
 
-### The daily cycle
+The payload carries two stamps, **both in UTC**: `generated_at` (when the brief was written) and
+`calendars_fetched_at` (when the feeds were last fetched, and what `schedule.due` reads). UTC
+because the server is routinely not on the family's clock — a Pi is often left on UTC, and hosted
+the server is nowhere near them. They are rendered in the family's timezone at the point of display,
+which on the settings home is `_clock(stamp, tzinfo)`. It used to slice the characters out of the
+ISO string, which showed the server's hour (PLAN.md bug 9).
+
+### Two cadences, one tick
+
+The fetch and the model call ran together only because history put them there, and it meant an
+appointment added at 09:00 was not on the wall until the next morning. They now run on their own
+clocks, chosen by the family (PLAN.md decision 11, single-mode half):
 
 ```
-[cron @ 6am] -> generate.py -> dinkydash.runner.run()
-                                 fetch every enabled iCal feed, merge, sort
-                                 build the prompt, call Claude
-                                 write dashboard_data.json atomically
-                                 append to content_history.json
+[cron */5m] -> generate.py --tick -> schedule.due(config, payload, now)
+                                       refresh? -> runner.refresh_calendars()
+                                                     fetch every enabled feed, merge, sort
+                                                     write events + calendars_fetched_at
+                                       brief?   -> runner.write_brief()
+                                                     build the prompt, call Claude
+                                                     write headline + note, append to history
+                                       neither  -> exit 0, silently
 
-[browser]    -> app.py       -> board.build_view(config, payload, today)
-                                 renders web/templates/board.html
+[browser]   -> app.py             -> board.build_view(config, payload, today)
+                                       renders web/templates/board.html
 ```
+
+`refresh_minutes` (default 60) and `brief_time` (default `"06:00"`, on the family's clock) are
+ordinary config keys, so they migrate through `with_defaults` and will survive as a `jsonb` column.
+`runner.run` is still both halves in order, which is what a plain `python generate.py` and the
+settings page's **Rewrite now** do — the old `0 6 * * *` line keeps working, it just never sees a
+same-day change.
+
+Three rules hold this together:
+
+- **`due()` is pure and takes `now` as an aware datetime.** No clock, no I/O. That is what lets the
+  same function drive a Pi's cron tick and, later, a worker loop walking every family. A brief is
+  due when `generated_for_date` is not today *in the family's timezone* and the local clock has
+  passed `brief_time`; a refresh is due when `calendars_fetched_at` is missing or older than
+  `refresh_minutes`.
+- **A refresh must not touch `headline`, `note` or `generated_for_date`.** `runner.REFRESH_KEYS`
+  names the three keys it owns. A fresh agenda under yesterday's brief is exactly the amber-banner
+  state `board.build_view` already handles, and the whole point of the split.
+- **A failure is not handled, it is simply due again.** Nothing is written, so the next tick asks
+  the same question and gets the same answer. That is the retry, and it is why there is no backoff
+  or attempt counter anywhere.
+
+Two consequences worth knowing.
+
+**A feed that does not answer keeps its own last-known events**, because a missing event is
+invisible while a stale one is still on the right day. The keeping is per feed, not per fetch: the
+feeds that answered are always fresh, or one dead URL would freeze the whole board for as long as
+nobody fixed it. `runner._with_last_known` does the merge, keyed on the `calendar` label each event
+carries, and only inside the current window — so a permanently broken feed empties out over a
+fortnight instead of growing a tail of appointments that already happened. A *paused* feed keeps
+nothing: switching a calendar off means switching it off. The failure is recorded in
+`calendar_statuses` and shown on the settings page, and the stamp is written either way, so a broken
+feed is retried on the configured cadence rather than every tick.
+
+**A tick takes an exclusive `flock` on `.tick.lock` and skips itself if another holds it**
+(`generate.only_one_tick`). A tick can outlive its five-minute slot — several feeds timing out, then
+a slow model call — and the next one would find the brief still unwritten, pay for it a second time,
+write a second history entry, and race the first over the payload. The overlapping tick exits 0
+instead: whatever is owed is still owed five minutes later. It is deliberately only around the tick.
+**Rewrite now** is a person asking for something, and should do it.
 
 ### Config
 
@@ -304,9 +358,13 @@ venv/bin/python -m pytest tests/ -q
 
 **Generate a board** (needs `ANTHROPIC_API_KEY` in `.env`)
 ```bash
-python generate.py                  # today
+python generate.py                  # today: fetch the calendars and write the brief
+python generate.py --tick           # only what is due now — what cron runs
 python generate.py --date 2026-12-24  # any date, for testing
 ```
+`--tick` and `--date` are mutually exclusive: a tick works from the real clock. `--config` now also
+decides where `dashboard_data.json` and `content_history.json` live, so a scratch config keeps its
+generated files beside it.
 
 **Run the app**
 ```bash
@@ -352,7 +410,9 @@ no changes.
 
 **Changing the payload shape.** Ask first whether the value can be recomputed from config + date.
 If it can, it belongs in `board.build_view`, not the payload — that is what keeps the stale state
-honest. The payload is for things only the generator can know.
+honest. The payload is for things only the generator can know. Then ask which half owns it: a key a
+refresh writes goes in `runner.REFRESH_KEYS` so `write_brief` carries it forward, and a key the
+brief writes must be one a refresh never touches.
 
 **Changing the board layout.** Everything is sized in `rem` off one root value, so check all three
 sizes at `/preview` rather than just the one you are looking at.
@@ -463,9 +523,14 @@ it is missing, installs dependencies, and restarts the `dinkydash.service` syste
 installed. Host, user and target directory are overridable with the `PI_HOST`, `PI_USER` and
 `PI_DIR` environment variables; `--dry-run` shows what a deploy would change without touching the Pi.
 
-Daily generation runs via cron:
+Generation runs via cron:
 ```
-0 6 * * * cd /home/pi/dinkydash && venv/bin/python generate.py >> generate.log 2>&1
+*/5 * * * * cd /home/pi/dinkydash && venv/bin/python generate.py --tick >> generate.log 2>&1
 ```
-A failed run leaves the previous board in place rather than blanking the screen, and the board
-labels itself stale.
+Each tick does only what `config.yaml` says is owed, and logs nothing when that is nothing — "not
+due" is at DEBUG precisely because it is the answer to roughly 260 of the day's 288 ticks. A tick
+that overruns its slot makes the next one skip rather than double up, so the interval is a floor and
+never a guarantee. The old
+`0 6 * * * generate.py` line still works and does both halves at once; use one or the other, not
+both. A failed run leaves the previous board in place rather than blanking the screen, the board
+labels itself stale, and the next tick tries again.

--- a/README.md
+++ b/README.md
@@ -32,12 +32,12 @@ the same file, and the UI keeps your comments.
 ## How it works
 
 ```
-[cron @ 6am] → generate.py         → merges every enabled iCal feed, in time order
-                                   → builds the prompt, calls Claude
-                                   → saves dashboard_data.json
+[cron every 5m] → generate.py --tick → every hour: re-fetches every iCal feed, in time order
+                                     → once a day at 06:00: builds the prompt, calls Claude
+                                     → saves dashboard_data.json
 
-[browser]    → web/routes/board.py → recomputes chores, countdowns and today's agenda
-                                   → renders the board
+[browser]       → web/routes/board.py → recomputes chores, countdowns and today's agenda
+                                      → renders the board
 ```
 
 Only the headline and the written line come from the model. Ages, countdowns, chore turns and the
@@ -158,7 +158,7 @@ pip install -r requirements-dev.txt   # adds pytest and the website build; not n
 python -m pytest tests/ -q
 ```
 
-157 tests, well under a second. They cover leap years, timezone conversion, event ordering, chore
+227 tests, well under a second. They cover leap years, timezone conversion, event ordering, chore
 rotation, the stale-board logic, the config round-trip, and the settings routes that write it.
 
 GitHub Actions runs the same command on every push and pull request, on Python 3.11
@@ -170,11 +170,21 @@ versions CI passed on. A pull request that fails either check shows a red X.
 
 ## Running it day to day
 
-### What happens each morning
+### What happens each day
 
-At 6am cron runs `generate.py`. It fetches every enabled calendar, merges them into one
-time-ordered agenda for the next 14 days, works out whose turn each chore is, and asks Claude for a
-headline and one line of copy. The result is written atomically to `dashboard_data.json`.
+Cron runs `generate.py --tick` every five minutes, and the tick does only what is owed.
+
+**Every hour**, it re-fetches every enabled calendar and merges them into one time-ordered agenda
+for the next 14 days. This costs nothing but a few HTTP requests, and it is what puts an
+appointment added at 09:00 for 15:00 onto the board the same afternoon. Change `refresh_minutes` in
+`config.yaml` to make that 15 minutes or once a day. Fetching faster than the provider updates buys
+nothing: Google's secret `.ics` link is cached at their end and can lag by hours.
+
+**Once a day at 06:00**, on your own clock, it asks Claude for a headline and one line of copy —
+the only part that costs money. Change the hour with `brief_time`. A brief that fails is simply
+owed again five minutes later, so a network blip at dawn no longer means a day-old line.
+
+Both write atomically to `dashboard_data.json`, and a refresh never touches the written line.
 
 The browser does the rest of the work on every render: ages, countdowns, whose turn it is, and
 today's slice of the agenda are all recomputed from `config.yaml` and the current date. Only the
@@ -188,7 +198,7 @@ so today's times are still there and still right.
 | What you see | What it means | What to do |
 |---|---|---|
 | The board, no banner | Today's run succeeded | Nothing |
-| An amber banner across the top | Today's run failed or hasn't happened yet. Times, turns and countdowns are still today's; only the written line is older, and it is labelled | Check `generate.log`. Press **Rewrite now** in settings to retry |
+| An amber banner across the top | Today's brief failed or hasn't happened yet. Times, turns and countdowns are still today's; only the written line is older, and it is labelled | Nothing — the next tick retries. Check `generate.log` if it stays. Press **Rewrite now** in settings to force it |
 | "Writing … first board" | Nothing has ever been generated | Press **Rewrite now**, or run `python generate.py` |
 
 The board never blanks itself. A failed run leaves the previous one up rather than clearing the
@@ -232,8 +242,18 @@ Settings → Family & system. **Rewrite now** costs the same as a scheduled run,
 
 ### When something looks wrong
 
-**The board is a day behind.** Look at `generate.log`. The commonest causes are an expired API key,
-no network at 6am, or a calendar that now 404s. Fix and press **Rewrite now**.
+**The board is a day behind.** Look at `generate.log`. The commonest causes are an expired API key
+or no network. With the `--tick` cron line a single failure fixes itself five minutes later, so a
+banner that is still there an hour on is a real fault. Fix it and press **Rewrite now**.
+
+**An event I just added is not on the board.** Give it up to `refresh_minutes` (an hour by
+default), plus your provider's own lag — Google's secret `.ics` link is cached at their end and can
+take hours to show a change. Press **Rewrite now** if you cannot wait.
+
+**One calendar is broken and its events are still showing.** That is deliberate. A feed that stops
+answering keeps whatever it last gave us, because an event that vanishes is one nobody notices,
+while a stale one is at least on the right day. Your other calendars carry on updating normally.
+Fix or delete the feed under Settings → Calendars, where it is flagged.
 
 **Times are off by an hour, or "today" rolls over at the wrong moment.** The timezone under
 Settings → Family & system is what the engine works from, not the machine's clock. Set it even on a
@@ -290,6 +310,8 @@ Nothing to do to your config — it is migrated on load. But be aware:
 | `max_tokens` | Max response length |
 | `calendar_days_ahead` | How far ahead to fetch (default 14) |
 | `history_days` | Days of past notes sent back so the model doesn't repeat itself |
+| `refresh_minutes` | How often `--tick` re-fetches the calendars (default 60). Costs nothing but HTTP requests |
+| `brief_time` | When `--tick` writes the daily brief, on your own clock (default `"06:00"`). Quote it |
 | `data_file` | Path for the generated JSON |
 | `content_history_file` | Path for the rolling note history |
 | `id` | Added to each `people[]`, `pets[]`, `recurring[]`, `special_dates[]` and `calendars[]` entry the first time you open `/settings`. Leave it alone — it is how the settings UI tells one entry from another, so deleting somebody does not renumber everyone below onto the wrong edit form |
@@ -405,18 +427,29 @@ sudo systemctl enable dinkydash.service
 sudo systemctl start dinkydash.service
 ```
 
-### Step 4: Set up daily generation
+### Step 4: Set up the tick
 
 ```bash
 crontab -e
 ```
 
-Add this line to write a fresh board every morning at 6am. If a run fails, the previous board
-stays up and labels itself — the screen never goes blank:
+Add this line. It runs every five minutes, and each run does only what `config.yaml` says is
+owed — nothing at all, most of the time. Runs never pile up: if one is still going when the next is
+due, the next skips itself. If a run fails, the previous board stays up and labels itself; the
+screen never goes blank:
 
 ```cron
-0 6 * * * cd /home/pi/dinkydash && source venv/bin/activate && python generate.py >> generate.log 2>&1
+*/5 * * * * cd /home/pi/dinkydash && venv/bin/python generate.py --tick >> generate.log 2>&1
 ```
+
+The old daily line still works, and does the fetch and the brief together:
+
+```cron
+0 6 * * * cd /home/pi/dinkydash && venv/bin/python generate.py >> generate.log 2>&1
+```
+
+It just never sees a change you make to your calendar during the day. Use one line or the other,
+not both.
 
 ### Step 5: Set up kiosk mode
 
@@ -530,6 +563,7 @@ getting the Pi to boot into it.
 # Local development
 source venv/bin/activate
 python -m pytest tests/ -q           # run the tests
+python generate.py --tick            # do only what is due now (what cron runs)
 python generate.py                   # write today's board (costs a few cents)
 python generate.py --date 2026-12-24 # any date, for checking a countdown
 python app.py                        # board at /, settings at /settings
@@ -551,14 +585,15 @@ tail -f /home/pi/dinkydash/generate.log   # last night's generation
 | `dinkydash/context.py` | Ages, birthdays, countdowns, chore rotation |
 | `dinkydash/calendars.py` | iCal fetch, parse, recurrence, merging feeds |
 | `dinkydash/board.py` | Turns config + payload into what the board renders |
-| `dinkydash/runner.py` | The daily cycle: fetch, generate, write. Used by cron and the UI |
+| `dinkydash/runner.py` | The two halves of the cycle: `refresh_calendars` and `write_brief` |
+| `dinkydash/schedule.py` | `due()` — which of the two the clock and the config owe right now |
 | `web/` | Flask app — board, settings UI, templates |
 | `web/templates/board.html` | The board itself, light and dark, all screen sizes |
-| `generate.py` | Command-line skin over `runner.run` — this is what cron calls |
+| `generate.py` | Command-line skin over `dinkydash.runner` — this is what cron calls |
 | `app.py` | Flask entry point |
 | `config.yaml` | All configuration. The settings UI writes this same file |
 | `config.example.yaml` | Template config, documenting every key |
-| `tests/` | 157 tests. Run them before committing |
+| `tests/` | 227 tests. Run them before committing |
 | `design/` | Mockups for the board and settings UI, with the reasoning |
 | `deploy_to_pi.sh` | Deployment (rsync + service restart) |
 | `.env` | `ANTHROPIC_API_KEY` (not in git) |

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -73,5 +73,18 @@ calendar_days_ahead: 14
 # How many days of past notes to send back to the model so it doesn't repeat itself.
 history_days: 30
 
+# The two cadences, read by `generate.py --tick` (the */5 cron line). A plain
+# `generate.py` ignores them and does both at once, as it always has.
+#
+# How often the calendars are re-fetched. This is what puts an appointment added
+# at 09:00 onto the board the same day. Fetching costs nothing, but Google's
+# secret .ics feed is cached at their end and can lag by hours, so asking more
+# often than every 15 minutes buys nothing.
+refresh_minutes: 60
+
+# When the daily brief is written, on your own clock. Quote it — an unquoted
+# 06:00 is a number in older YAML. One brief a day; "Rewrite now" covers the rest.
+brief_time: "06:00"
+
 data_file: "dashboard_data.json"
 content_history_file: "content_history.json"

--- a/deploy_to_pi.sh
+++ b/deploy_to_pi.sh
@@ -45,6 +45,7 @@ rsync -az --info=stats1 --delete $DRY_RUN \
     --exclude='config.yaml' \
     --exclude='dashboard_data.json' \
     --exclude='content_history.json' \
+    --exclude='.tick.lock' \
     --exclude='*.log' \
     --exclude='website/' \
     --exclude='docs/' \

--- a/dinkydash/config.py
+++ b/dinkydash/config.py
@@ -31,6 +31,9 @@ DEFAULTS = {
     "max_tokens": 1024,
     "calendar_days_ahead": 14,
     "history_days": 30,
+    # Read only by `generate.py --tick`. A plain run still does both at once.
+    "refresh_minutes": 60,
+    "brief_time": "06:00",
     "data_file": "dashboard_data.json",
     "content_history_file": "content_history.json",
 }

--- a/dinkydash/generate.py
+++ b/dinkydash/generate.py
@@ -13,7 +13,7 @@ render time and stays correct on a day when generation failed.
 """
 
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 
 from .claude_client import call_claude
 from .context import build_countdowns, compute_chore_assignments
@@ -51,7 +51,9 @@ def generate(config, today, events, recent_notes=(), client=None, rng=None,
     ai = call_claude(user_prompt, config, client=client)
 
     return {
-        "generated_at": datetime.now().astimezone().isoformat(),
+        # UTC, not the server's clock: the Pi is often not set to the family's
+        # timezone, and hosted the server is nowhere near them. Rendered local.
+        "generated_at": datetime.now(timezone.utc).isoformat(),
         "generated_for_date": today.isoformat(),
         "family_name": config.get("family_name", ""),
         "timezone": config.get("timezone", "UTC"),

--- a/dinkydash/runner.py
+++ b/dinkydash/runner.py
@@ -1,22 +1,46 @@
-"""The full daily cycle: fetch calendars, ask Claude, write the payload.
+"""The two halves of the daily cycle, and the one place that does I/O.
 
-This is the one place that does I/O around the engine, shared by the cron
-script and the settings page's "Rewrite now" button.
+`refresh_calendars` re-fetches the feeds and costs a few HTTP requests.
+`write_brief` asks Claude for the headline and note and costs money. They were
+one function only because history put them there; splitting them lets the
+calendars run on their own cadence, so an appointment added at 09:00 reaches
+the wall the same day (`generate.py --tick`, and `dinkydash.schedule.due`).
+
+`run` is still both, in order, which is what `python generate.py` has always
+meant and what the settings page's "Rewrite now" does.
 """
 
 import json
 import logging
 import os
 import tempfile
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 
 from . import config as config_module
 from . import history as history_module
-from .calendars import fetch_events
+from .calendars import fetch_events, sort_key
 from .claude_client import GenerationError
 from .generate import generate
 
 log = logging.getLogger(__name__)
+
+# What a refresh owns. Everything else in the payload belongs to the brief, and
+# a refresh must not touch it: a fresh agenda under yesterday's headline is
+# exactly the amber-banner state `board.build_view` already handles.
+REFRESH_KEYS = ("events", "calendar_statuses", "calendars_fetched_at")
+
+
+def read_payload(path):
+    """The stored payload, or None when there isn't a usable one."""
+    try:
+        with open(path) as f:
+            data = json.load(f)
+    except FileNotFoundError:
+        return None
+    except (OSError, json.JSONDecodeError) as exc:
+        log.warning("Dashboard data is not readable (%s); treating it as no board yet", exc)
+        return None
+    return data if isinstance(data, dict) else None
 
 
 def write_payload(payload, path):
@@ -32,36 +56,98 @@ def write_payload(payload, path):
         raise
 
 
-def run(config, today=None, client=None, base=None):
-    """Generate today's board and save it. Returns the payload.
+def refresh_calendars(config, now=None, base=None, today=None):
+    """Re-fetch every enabled feed and store the merged agenda. No model call.
+
+    `now` is when this is happening and becomes the `calendars_fetched_at`
+    stamp. `today` is the day the fourteen-day window starts on, and defaults
+    to today on the family's clock — they are the same thing except under
+    `generate.py --date`, where the window is moved but the stamp is not.
+    """
+    now = now or datetime.now(timezone.utc)
+    tzinfo = config_module.tzinfo_for(config)
+    today = today or now.astimezone(tzinfo).date()
+
+    days_ahead = int(config.get("calendar_days_ahead") or 14)
+    events, statuses = fetch_events(
+        config.get("calendars"), today, tzinfo, days_ahead=days_ahead,
+    )
+
+    path = config_module.data_path(config, base=base)
+    payload = read_payload(path) or {}
+
+    failed = {s["label"] for s in statuses if s["ok"] is False}
+    if failed:
+        log.warning("Calendars that did not answer: %s", ", ".join(sorted(failed)))
+        events = _with_last_known(events, payload.get("events"), failed,
+                                  today, today + timedelta(days=days_ahead))
+
+    payload["events"] = events
+    payload["calendar_statuses"] = statuses
+    payload["calendars_fetched_at"] = now.astimezone(timezone.utc).isoformat()
+    write_payload(payload, path)
+    log.info("Calendars refreshed: %d events stored", len(payload["events"]))
+    return payload
+
+
+def _with_last_known(fresh, previous, failed_labels, start, end):
+    """Fresh events, plus the last-known events of the feeds that did not answer.
+
+    A missing event is invisible while a stale one is still on the right day —
+    the previous fetch reached the same fourteen days ahead — so a feed that
+    fails holds its last agenda rather than emptying it. Only that feed does:
+    the ones that answered are always fresh, or a single dead URL would freeze
+    the whole board for as long as nobody fixed it.
+
+    Events are kept only inside the current window, so a permanently broken feed
+    empties out as the days pass instead of accumulating a tail of past events.
+    """
+    window = (start.isoformat(), end.isoformat())
+    seen = {(e.get("calendar"), e.get("title"), e.get("start")) for e in fresh}
+    kept = []
+    for event in previous or []:
+        if event.get("calendar") not in failed_labels:
+            continue
+        if not window[0] <= str(event.get("date")) <= window[1]:
+            continue
+        key = (event.get("calendar"), event.get("title"), event.get("start"))
+        if key in seen:  # two feeds sharing one label
+            continue
+        seen.add(key)
+        kept.append(event)
+    if kept:
+        log.info("Kept %d event(s) from the feeds that did not answer", len(kept))
+    return sorted(fresh + kept, key=sort_key)
+
+
+def write_brief(config, today=None, base=None, client=None):
+    """Ask Claude for today's headline and note, and store them. Costs one call.
+
+    The events come from the stored payload rather than a second fetch, so the
+    brief always describes the agenda the board is showing, and a tick that
+    owes both does one fetch rather than two.
 
     Raises GenerationError if the model call fails — the caller decides what to
     do, and the previous payload is left untouched either way.
     """
-    if not os.environ.get("ANTHROPIC_API_KEY"):
-        raise GenerationError(
-            "ANTHROPIC_API_KEY is not set. Put it in .env as ANTHROPIC_API_KEY=sk-ant-..."
-        )
-
+    require_api_key()
     today = today or config_module.today_for(config)
-    tzinfo = config_module.tzinfo_for(config)
 
-    events, statuses = fetch_events(
-        config.get("calendars"), today, tzinfo,
-        days_ahead=int(config.get("calendar_days_ahead") or 14),
-    )
-    failed = [s["label"] for s in statuses if s["ok"] is False]
-    if failed:
-        log.warning("Calendars that did not answer: %s", ", ".join(failed))
+    path = config_module.data_path(config, base=base)
+    stored = read_payload(path) or {}
 
     history_file = config_module.history_path(config, base=base)
     keep = int(config.get("history_days") or 30)
     recent = history_module.recent_notes(history_module.load_history(history_file), keep)
 
-    payload = generate(config, today, events, recent_notes=recent, client=client)
-    payload["calendar_statuses"] = statuses
+    payload = generate(
+        config, today, stored.get("events") or [], recent_notes=recent, client=client
+    )
+    for key in REFRESH_KEYS:
+        if key in stored:
+            payload[key] = stored[key]
 
-    write_payload(payload, config_module.data_path(config, base=base))
+    write_payload(payload, path)
     history_module.record(
         history_file,
         {
@@ -77,3 +163,17 @@ def run(config, today=None, client=None, base=None):
         today, payload.get("input_tokens"), payload.get("output_tokens"),
     )
     return payload
+
+
+def run(config, today=None, client=None, base=None):
+    """Both halves: fetch the calendars, then write the brief. Returns the payload."""
+    require_api_key()  # before the fetch, so a missing key fails in a second
+    refresh_calendars(config, base=base, today=today)
+    return write_brief(config, today=today, base=base, client=client)
+
+
+def require_api_key():
+    if not os.environ.get("ANTHROPIC_API_KEY"):
+        raise GenerationError(
+            "ANTHROPIC_API_KEY is not set. Put it in .env as ANTHROPIC_API_KEY=sk-ant-..."
+        )

--- a/dinkydash/schedule.py
+++ b/dinkydash/schedule.py
@@ -1,0 +1,99 @@
+"""What is owed right now: a calendar refresh, a brief, both, or nothing.
+
+Pure — no clock, no file, no network. The caller passes `now` as an aware
+datetime and gets back a dict of two booleans, so the same function serves a
+Pi's cron tick and (later) a worker loop walking every family.
+
+The two cadences differ because their costs do. Re-fetching the calendars is a
+few HTTP requests and happens every `refresh_minutes`, which is what puts an
+appointment added at 09:00 onto the wall the same day. The brief is an API
+call and happens once a day, after `brief_time` on the family's own clock.
+
+A brief that fails is simply due again on the next tick. That is the retry.
+"""
+
+import logging
+from datetime import datetime, time, timedelta, timezone
+
+from .config import tzinfo_for
+
+log = logging.getLogger(__name__)
+
+DEFAULT_REFRESH_MINUTES = 60
+DEFAULT_BRIEF_TIME = "06:00"
+
+# Below a minute the tick interval is the real limit anyway, and zero would
+# mean "fetch on every tick, forever".
+MIN_REFRESH_MINUTES = 1
+
+
+def due(config, payload, now):
+    """`{"refresh": bool, "brief": bool}` for this moment.
+
+    `now` must be an aware datetime; the caller owns the clock.
+    """
+    payload = payload or {}
+    return {
+        "refresh": refresh_due(config, payload, now),
+        "brief": brief_due(config, payload, now),
+    }
+
+
+def refresh_due(config, payload, now):
+    """True when the stored agenda is older than `refresh_minutes`."""
+    fetched = parse_stamp(payload.get("calendars_fetched_at"))
+    if fetched is None:
+        return True
+    if fetched > now:
+        # A stamp from the future means the clock moved, not that the fetch is
+        # fresh. Fetching is free, so believe the clock rather than the file.
+        return True
+    return now - fetched >= refresh_interval(config)
+
+
+def brief_due(config, payload, now):
+    """True when today has no brief yet and the family's clock has passed `brief_time`."""
+    local = now.astimezone(tzinfo_for(config))
+    if payload.get("generated_for_date") == local.date().isoformat():
+        return False
+    return local.time() >= brief_time(config)
+
+
+def refresh_interval(config):
+    """`refresh_minutes` as a timedelta, falling back to the default."""
+    raw = config.get("refresh_minutes")
+    try:
+        minutes = int(raw) if raw is not None else DEFAULT_REFRESH_MINUTES
+    except (TypeError, ValueError):
+        log.warning("refresh_minutes is not a number (%r); using %d", raw, DEFAULT_REFRESH_MINUTES)
+        minutes = DEFAULT_REFRESH_MINUTES
+    return timedelta(minutes=max(minutes, MIN_REFRESH_MINUTES))
+
+
+def brief_time(config):
+    """`brief_time` as a `time` on the family's clock, falling back to the default."""
+    raw = config.get("brief_time")
+    if raw is None:
+        return time.fromisoformat(DEFAULT_BRIEF_TIME)
+    try:
+        return time.fromisoformat(str(raw).strip())
+    except ValueError:
+        log.warning("brief_time is not a time (%r); using %s", raw, DEFAULT_BRIEF_TIME)
+        return time.fromisoformat(DEFAULT_BRIEF_TIME)
+
+
+def parse_stamp(value):
+    """A payload timestamp as an aware datetime, or None if there isn't one.
+
+    Stamps are written in UTC. A naive one comes from an older payload, and is
+    read as UTC rather than as the server's clock — which on a Pi is often not
+    the family's clock at all.
+    """
+    if not value:
+        return None
+    try:
+        moment = datetime.fromisoformat(str(value))
+    except (TypeError, ValueError):
+        log.warning("Unreadable timestamp in the payload (%r); treating it as absent", value)
+        return None
+    return moment if moment.tzinfo else moment.replace(tzinfo=timezone.utc)

--- a/generate.py
+++ b/generate.py
@@ -1,33 +1,51 @@
 #!/usr/bin/env python3
-"""Write today's board. Run once a day from cron.
+"""Write the board. Run from cron.
 
-    0 6 * * * cd /home/pi/dinkydash && venv/bin/python generate.py >> generate.log 2>&1
+    */5 * * * * cd /home/pi/dinkydash && venv/bin/python generate.py --tick >> generate.log 2>&1
+
+`--tick` does only what the config says is owed: re-fetch the calendars every
+`refresh_minutes`, write the brief once a day after `brief_time`, and exit
+quietly when neither is due. Without it, a plain run does both at once, which
+is what the old `0 6 * * *` line has always meant.
 
 Everything interesting lives in the dinkydash package; this is the command-line
-skin around dinkydash.runner.run.
+skin around dinkydash.runner.
 """
 
 import argparse
 import logging
 import sys
-from datetime import date
+from contextlib import contextmanager
+from datetime import date, datetime, timezone
+from pathlib import Path
+
+try:
+    import fcntl  # POSIX only; the board runs on a Pi
+except ImportError:  # pragma: no cover - Windows has no flock
+    fcntl = None
 
 from dotenv import load_dotenv
 
 from dinkydash import config as config_module
 from dinkydash.claude_client import GenerationError
-from dinkydash.runner import run
+from dinkydash.runner import read_payload, refresh_calendars, run, write_brief
+from dinkydash.schedule import due
 
 load_dotenv()
 log = logging.getLogger("dinkydash")
 
 
 def main(argv=None):
-    parser = argparse.ArgumentParser(description="Generate today's DinkyDash board.")
+    parser = argparse.ArgumentParser(description="Generate the DinkyDash board.")
     parser.add_argument("--config", help="path to config.yaml")
     parser.add_argument("--date", help="generate for this date (YYYY-MM-DD) instead of today")
+    parser.add_argument("--tick", action="store_true",
+                        help="do only what is due now, and nothing when nothing is")
     parser.add_argument("--quiet", action="store_true", help="only log warnings and errors")
     args = parser.parse_args(argv)
+
+    if args.tick and args.date:
+        parser.error("--tick works from the real clock; --date is for one-off runs")
 
     logging.basicConfig(
         level=logging.WARNING if args.quiet else logging.INFO,
@@ -42,19 +60,87 @@ def main(argv=None):
         log.error("No config found at %s. Copy config.example.yaml to config.yaml.", path)
         return 1
 
-    today = date.fromisoformat(args.date) if args.date else config_module.today_for(config)
+    # Generated data sits beside the config it was generated from, so --config
+    # moves the payload and the history with it.
+    base = Path(path).expanduser().parent
+    if args.tick:
+        with only_one_tick(base / LOCK_FILE) as mine:
+            if not mine:
+                log.warning("A previous tick is still running; skipping this one.")
+                return 0
+            return tick(config, base)
 
+    today = date.fromisoformat(args.date) if args.date else config_module.today_for(config)
     try:
-        payload = run(config, today=today, base=config_module.config_path().parent)
+        payload = run(config, today=today, base=base)
     except GenerationError as exc:
         # The previous board is left in place rather than blanking the screen.
         log.error("%s", exc)
         log.error("Keeping the previous board.")
         return 1
 
+    report(payload)
+    return 0
+
+
+LOCK_FILE = ".tick.lock"
+
+
+@contextmanager
+def only_one_tick(path):
+    """Hold an exclusive lock for the tick, or yield False and let it be skipped.
+
+    A tick can outlive its five-minute slot — several feeds timing out, then a
+    slow model call — and the next one would find the brief still unwritten and
+    pay for it a second time, with two history entries and a last-writer-wins
+    race over the payload. The overlapping tick gives up instead: whatever is
+    owed is still owed five minutes later.
+    """
+    if fcntl is None:
+        yield True
+        return
+    handle = open(path, "a")
+    try:
+        try:
+            fcntl.flock(handle, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError:
+            yield False
+            return
+        yield True
+    finally:
+        handle.close()  # releases the lock, and so does the process exiting
+
+
+def tick(config, base):
+    """Do what the clock and the config say is owed, and no more."""
+    now = datetime.now(timezone.utc)
+    payload = read_payload(config_module.data_path(config, base=base))
+    owed = due(config, payload, now)
+
+    if not any(owed.values()):
+        # With a */5 cron line this is the normal case, so it is logged below
+        # the default level — otherwise it would be the whole of generate.log.
+        log.debug("Nothing due")
+        return 0
+
+    if owed["refresh"]:
+        refresh_calendars(config, now=now, base=base)
+
+    if owed["brief"]:
+        today = now.astimezone(config_module.tzinfo_for(config)).date()
+        try:
+            report(write_brief(config, today=today, base=base))
+        except GenerationError as exc:
+            # Not fatal: the brief is simply due again on the next tick.
+            log.error("%s", exc)
+            log.error("Keeping the previous board; the next tick will try again.")
+            return 1
+    return 0
+
+
+def report(payload):
     log.info("Headline: %s", payload["headline"])
     log.info("Note: %s", payload["note"])
-    return 0
 
 
 if __name__ == "__main__":

--- a/sample_board.py
+++ b/sample_board.py
@@ -14,7 +14,7 @@ in the current schema is already here, this leaves it alone.
 
 import json
 import sys
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from dinkydash import config as config_module
 
@@ -72,7 +72,7 @@ def build_payload(config, today, tzinfo):
         })
 
     return {
-        "generated_at": datetime.now(tzinfo).isoformat(),
+        "generated_at": datetime.now(timezone.utc).isoformat(),
         "generated_for_date": today.isoformat(),
         "family_name": config.get("family_name", ""),
         "timezone": config.get("timezone", "UTC"),

--- a/tests/test_board.py
+++ b/tests/test_board.py
@@ -192,6 +192,20 @@ class TestEmptyStates:
         assert view["state"] == "ready"
         assert view["chores"]
 
+    def test_an_agenda_with_no_brief_yet_still_shows_the_day(self):
+        # A `--tick` that refreshed the calendars before brief_time leaves a
+        # payload with events and no words. Reachable only since the split, and
+        # the right answer is today's agenda under the amber banner rather than
+        # the first-run screen.
+        agenda = {"events": [event("2026-09-03", "08:20", "School run")],
+                  "calendars_fetched_at": "2026-09-03T03:00:00+00:00"}
+        view = build_view(CONFIG, agenda, TODAY)
+        assert view["state"] == "stale"
+        assert [e["title"] for e in view["events"]] == ["School run"]
+        assert view["headline"] == "1 thing on today, starting at 08:20."
+        assert view["note"] == ""
+        assert view["stale_days"] is None
+
 
 class TestTheme:
     def test_dark_is_carried_through(self):

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,0 +1,396 @@
+"""The two halves of the run, and the tick that decides between them.
+
+Nothing here touches the network or the API: `fetch_events` is replaced with a
+recorder, and the model call goes through the same fake client the generator
+tests use. What is being asserted is the division of labour — a refresh must
+not rewrite the brief, and a tick that owes nothing must do nothing.
+"""
+
+import json
+from datetime import date, datetime, timezone
+
+import pytest
+
+import generate as cli
+from dinkydash import runner
+from dinkydash.claude_client import GenerationError
+
+from test_generate import FakeClient  # the same stand-in the generator tests use
+
+CONFIG_YAML = """\
+family_name: "The Wilsons"
+timezone: "Europe/Berlin"
+theme: light
+refresh_minutes: 60
+brief_time: "06:00"
+calendars: []
+people:
+  - name: "Mia"
+    date_of_birth: "2017-03-15"
+recurring: []
+special_dates: []
+data_file: "dashboard_data.json"
+content_history_file: "content_history.json"
+"""
+
+EVENTS = [
+    {"title": "Swimming", "date": "2026-09-03", "time": "15:45", "all_day": False,
+     "start": "2026-09-03T15:45:00+02:00", "location": None, "calendar": "Family"},
+]
+SCHOOL = [
+    {"title": "Sports day", "date": "2026-09-04", "time": "09:00", "all_day": False,
+     "start": "2026-09-04T09:00:00+02:00", "location": None, "calendar": "School"},
+]
+OK_STATUS = [{"label": "Family", "ok": True, "detail": "", "count": 1}]
+FAILED_STATUS = [{"label": "Family", "ok": False, "detail": "could not fetch", "count": 0}]
+# One feed answered, the other did not — the case a single dead URL must not freeze.
+MIXED_STATUS = [{"label": "Family", "ok": False, "detail": "could not fetch", "count": 0},
+                {"label": "School", "ok": True, "detail": "", "count": 1}]
+
+# Pinned, because the window a refresh keeps is measured from `today`: a test
+# that let the real clock decide would pass in September and fail in November.
+NOW = datetime(2026, 9, 3, 8, tzinfo=timezone.utc)
+
+
+@pytest.fixture
+def home(tmp_path):
+    """A config file and an empty data directory, together, as on a Pi."""
+    (tmp_path / "config.yaml").write_text(CONFIG_YAML)
+    return tmp_path
+
+
+@pytest.fixture
+def config(home):
+    from dinkydash import config as config_module
+    return config_module.load_config(home / "config.yaml")
+
+
+@pytest.fixture
+def api_key(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-not-a-real-key")
+
+
+def stored(home):
+    return json.loads((home / "dashboard_data.json").read_text())
+
+
+def write_stored(home, payload):
+    (home / "dashboard_data.json").write_text(json.dumps(payload))
+
+
+def fake_fetch(events, statuses, seen=None):
+    def _fetch(calendars, today, tzinfo, days_ahead=14, timeout=30):
+        if seen is not None:
+            seen.append({"calendars": calendars, "today": today, "days_ahead": days_ahead})
+        return list(events), list(statuses)
+    return _fetch
+
+
+class TestRefreshCalendars:
+    def test_stores_the_events_and_stamps_the_fetch(self, home, config, monkeypatch):
+        monkeypatch.setattr(runner, "fetch_events", fake_fetch(EVENTS, OK_STATUS))
+        runner.refresh_calendars(config, now=datetime(2026, 9, 3, 8, tzinfo=timezone.utc),
+                                 base=home)
+        payload = stored(home)
+        assert payload["events"] == EVENTS
+        assert payload["calendar_statuses"] == OK_STATUS
+        assert payload["calendars_fetched_at"] == "2026-09-03T08:00:00+00:00"
+
+    def test_the_stamp_is_utc_whatever_the_clock_was(self, home, config, monkeypatch):
+        monkeypatch.setattr(runner, "fetch_events", fake_fetch(EVENTS, OK_STATUS))
+        local = datetime.fromisoformat("2026-09-03T10:00:00+02:00")
+        runner.refresh_calendars(config, now=local, base=home)
+        assert stored(home)["calendars_fetched_at"] == "2026-09-03T08:00:00+00:00"
+
+    def test_the_window_starts_on_the_familys_today(self, home, config, monkeypatch):
+        seen = []
+        monkeypatch.setattr(runner, "fetch_events", fake_fetch(EVENTS, OK_STATUS, seen))
+        # 23:30 UTC is already the 4th in Berlin.
+        runner.refresh_calendars(config, now=datetime(2026, 9, 3, 23, 30, tzinfo=timezone.utc),
+                                 base=home)
+        assert seen[0]["today"] == date(2026, 9, 4)
+        assert seen[0]["days_ahead"] == 14
+
+    def test_it_leaves_the_brief_alone(self, home, config, monkeypatch):
+        # The state the board labels amber: today's times under yesterday's words.
+        write_stored(home, {
+            "generated_for_date": "2026-09-02", "generated_at": "2026-09-02T04:00:00+00:00",
+            "headline": "Yesterday's headline", "note": "Yesterday's note",
+            "note_kind": "fact", "events": [], "model": "claude-haiku-4-5",
+        })
+        monkeypatch.setattr(runner, "fetch_events", fake_fetch(EVENTS, OK_STATUS))
+        runner.refresh_calendars(config, base=home)
+        payload = stored(home)
+        assert payload["generated_for_date"] == "2026-09-02"
+        assert payload["generated_at"] == "2026-09-02T04:00:00+00:00"
+        assert payload["headline"] == "Yesterday's headline"
+        assert payload["note"] == "Yesterday's note"
+        assert payload["events"] == EVENTS
+
+    def test_a_failed_feed_leaves_its_own_events_up(self, home, config, monkeypatch):
+        # A missing event is invisible; a stale one is at least on the wall.
+        write_stored(home, {"generated_for_date": "2026-09-03", "headline": "Hi",
+                            "note": "There", "events": EVENTS})
+        monkeypatch.setattr(runner, "fetch_events", fake_fetch([], FAILED_STATUS))
+        runner.refresh_calendars(config, now=NOW, base=home)
+        payload = stored(home)
+        assert payload["events"] == EVENTS
+        assert payload["calendar_statuses"] == FAILED_STATUS
+
+    def test_one_dead_feed_does_not_freeze_the_healthy_ones(self, home, config,
+                                                            monkeypatch):
+        # The whole point of merging per feed: School answered, so School is
+        # fresh, while Family holds what it last gave us. Freezing everything
+        # would hide a new event behind somebody else's broken URL for as long
+        # as nobody fixed it.
+        write_stored(home, {"generated_for_date": "2026-09-03", "headline": "Hi",
+                            "note": "There", "events": EVENTS})
+        monkeypatch.setattr(runner, "fetch_events", fake_fetch(SCHOOL, MIXED_STATUS))
+        runner.refresh_calendars(config, now=NOW, base=home)
+        titles = [(e["calendar"], e["title"]) for e in stored(home)["events"]]
+        assert titles == [("Family", "Swimming"), ("School", "Sports day")]
+
+    def test_a_healthy_feed_that_dropped_an_event_really_drops_it(self, home, config,
+                                                                  monkeypatch):
+        # Nothing stale is kept for a feed that answered, or a deleted
+        # appointment would live on the board for ever.
+        write_stored(home, {"events": EVENTS + SCHOOL})
+        monkeypatch.setattr(runner, "fetch_events", fake_fetch(SCHOOL, MIXED_STATUS))
+        runner.refresh_calendars(config, now=NOW, base=home)
+        assert [e["title"] for e in stored(home)["events"]] == ["Swimming", "Sports day"]
+
+        # Now Family answers too, with nothing in it. Swimming is gone.
+        monkeypatch.setattr(runner, "fetch_events", fake_fetch(SCHOOL, [
+            {"label": "Family", "ok": True, "detail": "", "count": 0},
+            {"label": "School", "ok": True, "detail": "", "count": 1}]))
+        runner.refresh_calendars(config, now=NOW, base=home)
+        assert [e["title"] for e in stored(home)["events"]] == ["Sports day"]
+
+    def test_stale_events_outside_the_window_are_dropped(self, home, config, monkeypatch):
+        # A permanently broken feed empties out as the days pass rather than
+        # keeping a growing tail of appointments that already happened.
+        write_stored(home, {"events": EVENTS})
+        monkeypatch.setattr(runner, "fetch_events", fake_fetch([], FAILED_STATUS))
+        # A month on, 2026-09-03 is behind the fourteen-day window.
+        runner.refresh_calendars(config, now=datetime(2026, 10, 3, 8, tzinfo=timezone.utc),
+                                 base=home)
+        assert stored(home)["events"] == []
+
+    def test_a_paused_feed_does_not_keep_its_old_events(self, home, config, monkeypatch):
+        # Switching a calendar off means switching it off.
+        write_stored(home, {"events": EVENTS})
+        paused = [{"label": "Family", "ok": None, "detail": "paused", "count": 0}]
+        monkeypatch.setattr(runner, "fetch_events", fake_fetch([], paused))
+        runner.refresh_calendars(config, now=NOW, base=home)
+        assert stored(home)["events"] == []
+
+    def test_two_feeds_sharing_a_label_are_not_doubled(self, home, config, monkeypatch):
+        # Labels are the only identity an event carries, so a duplicate label
+        # must degrade to one copy rather than two.
+        write_stored(home, {"events": EVENTS})
+        both = [{"label": "Family", "ok": False, "detail": "could not fetch", "count": 0},
+                {"label": "Family", "ok": True, "detail": "", "count": 1}]
+        monkeypatch.setattr(runner, "fetch_events", fake_fetch(EVENTS, both))
+        runner.refresh_calendars(config, now=NOW, base=home)
+        assert stored(home)["events"] == EVENTS
+
+    def test_a_failed_feed_on_the_first_run_stores_what_there_is(self, home, config,
+                                                                 monkeypatch):
+        monkeypatch.setattr(runner, "fetch_events", fake_fetch([], FAILED_STATUS))
+        runner.refresh_calendars(config, now=NOW, base=home)
+        assert stored(home)["events"] == []
+
+    def test_no_calendars_configured_touches_nothing_but_the_stamp(self, home, config):
+        # fetch_events is the real one here: with an empty list it must not
+        # reach the network at all.
+        config["calendars"] = []
+        payload = runner.refresh_calendars(config, base=home)
+        assert payload["events"] == []
+        assert payload["calendar_statuses"] == []
+        assert payload["calendars_fetched_at"]
+
+    def test_it_needs_no_api_key(self, home, config, monkeypatch):
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.setattr(runner, "fetch_events", fake_fetch(EVENTS, OK_STATUS))
+        runner.refresh_calendars(config, base=home)  # a fetch costs nothing
+        assert stored(home)["events"] == EVENTS
+
+
+class TestWriteBrief:
+    def test_it_uses_the_stored_events_rather_than_fetching_again(self, home, config,
+                                                                 api_key, monkeypatch):
+        monkeypatch.setattr(runner, "fetch_events",
+                            lambda *a, **k: pytest.fail("write_brief must not fetch"))
+        write_stored(home, {"events": EVENTS, "calendar_statuses": OK_STATUS,
+                            "calendars_fetched_at": "2026-09-03T05:00:00+00:00"})
+        client = FakeClient()
+        runner.write_brief(config, today=date(2026, 9, 3), base=home, client=client)
+        payload = stored(home)
+        assert payload["headline"] == "Big morning"
+        assert payload["events"] == EVENTS
+        assert "Swimming" in client.messages.calls[0]["messages"][0]["content"]
+
+    def test_it_carries_the_refresh_keys_forward(self, home, config, api_key):
+        write_stored(home, {"events": EVENTS, "calendar_statuses": FAILED_STATUS,
+                            "calendars_fetched_at": "2026-09-03T05:00:00+00:00"})
+        runner.write_brief(config, today=date(2026, 9, 3), base=home, client=FakeClient())
+        payload = stored(home)
+        assert payload["calendars_fetched_at"] == "2026-09-03T05:00:00+00:00"
+        assert payload["calendar_statuses"] == FAILED_STATUS
+
+    def test_it_records_the_note_in_the_history(self, home, config, api_key):
+        runner.write_brief(config, today=date(2026, 9, 3), base=home, client=FakeClient())
+        history = json.loads((home / "content_history.json").read_text())
+        assert history[-1]["note"] == "An octopus fact."
+        assert history[-1]["date"] == "2026-09-03"
+
+    def test_it_works_with_no_payload_at_all(self, home, config, api_key):
+        payload = runner.write_brief(config, today=date(2026, 9, 3), base=home,
+                                     client=FakeClient())
+        assert payload["events"] == []
+        assert payload["generated_for_date"] == "2026-09-03"
+
+    def test_a_failure_leaves_the_previous_board_untouched(self, home, config, api_key):
+        write_stored(home, {"generated_for_date": "2026-09-02", "headline": "Kept",
+                            "note": "Kept", "events": EVENTS})
+        client = FakeClient(raises=RuntimeError("the API is down"))
+        with pytest.raises(GenerationError):
+            runner.write_brief(config, today=date(2026, 9, 3), base=home, client=client)
+        assert stored(home)["headline"] == "Kept"
+
+    def test_it_refuses_without_an_api_key(self, home, config, monkeypatch):
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        with pytest.raises(GenerationError, match="ANTHROPIC_API_KEY"):
+            runner.write_brief(config, today=date(2026, 9, 3), base=home, client=FakeClient())
+
+
+class TestRun:
+    def test_it_still_does_both(self, home, config, api_key, monkeypatch):
+        monkeypatch.setattr(runner, "fetch_events", fake_fetch(EVENTS, OK_STATUS))
+        runner.run(config, today=date(2026, 9, 3), base=home, client=FakeClient())
+        payload = stored(home)
+        assert payload["events"] == EVENTS
+        assert payload["headline"] == "Big morning"
+        assert payload["generated_for_date"] == "2026-09-03"
+        assert payload["calendars_fetched_at"]
+
+    def test_the_date_override_moves_the_fetch_window(self, home, config, api_key,
+                                                      monkeypatch):
+        seen = []
+        monkeypatch.setattr(runner, "fetch_events", fake_fetch(EVENTS, OK_STATUS, seen))
+        runner.run(config, today=date(2026, 12, 24), base=home, client=FakeClient())
+        assert seen[0]["today"] == date(2026, 12, 24)
+
+    def test_a_missing_key_fails_before_the_fetch(self, home, config, monkeypatch):
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.setattr(runner, "fetch_events",
+                            lambda *a, **k: pytest.fail("should not have fetched"))
+        with pytest.raises(GenerationError, match="ANTHROPIC_API_KEY"):
+            runner.run(config, today=date(2026, 9, 3), base=home)
+
+
+def refuse(what):
+    def _refuse(*args, **kwargs):
+        pytest.fail(f"{what} should not have run")
+    return _refuse
+
+
+class TestTick:
+    def run_tick(self, home, monkeypatch, now):
+        """`generate.py --tick` with the clock pinned."""
+        class Clock(datetime):
+            @classmethod
+            def now(cls, tz=None):
+                return now if tz is None else now.astimezone(tz)
+        monkeypatch.setattr(cli, "datetime", Clock)
+        return cli.main(["--tick", "--config", str(home / "config.yaml")])
+
+    def test_nothing_due_calls_nothing(self, home, monkeypatch):
+        # Fetched ten minutes ago, brief written for today: the normal case on
+        # a five-minute cron line, and it must cost nothing at all.
+        write_stored(home, {"generated_for_date": "2026-09-03",
+                            "calendars_fetched_at": "2026-09-03T05:50:00+00:00",
+                            "headline": "Kept", "note": "Kept", "events": EVENTS})
+        monkeypatch.setattr(cli, "refresh_calendars", refuse("the fetch"))
+        monkeypatch.setattr(cli, "write_brief", refuse("the model call"))
+        # 08:00 Berlin.
+        assert self.run_tick(home, monkeypatch, datetime(2026, 9, 3, 6, tzinfo=timezone.utc)) == 0
+        assert stored(home)["headline"] == "Kept"
+
+    def test_a_due_refresh_runs_without_the_model(self, home, monkeypatch):
+        write_stored(home, {"generated_for_date": "2026-09-03",
+                            "calendars_fetched_at": "2026-09-03T04:00:00+00:00",
+                            "headline": "Kept", "note": "Kept", "events": []})
+        monkeypatch.setattr(runner, "fetch_events", fake_fetch(EVENTS, OK_STATUS))
+        monkeypatch.setattr(cli, "write_brief", refuse("the model call"))
+        assert self.run_tick(home, monkeypatch, datetime(2026, 9, 3, 6, tzinfo=timezone.utc)) == 0
+        payload = stored(home)
+        assert payload["events"] == EVENTS
+        assert payload["headline"] == "Kept"
+
+    def test_a_due_brief_is_written_once(self, home, monkeypatch, api_key):
+        write_stored(home, {"generated_for_date": "2026-09-02",
+                            "calendars_fetched_at": "2026-09-03T05:50:00+00:00",
+                            "headline": "Yesterday", "note": "Yesterday", "events": EVENTS})
+        client = FakeClient()
+        monkeypatch.setattr(cli, "write_brief",
+                            lambda config, **kw: runner.write_brief(config, client=client, **kw))
+        # 08:00 Berlin, so the brief is owed and the fetch is not.
+        assert self.run_tick(home, monkeypatch, datetime(2026, 9, 3, 6, tzinfo=timezone.utc)) == 0
+        payload = stored(home)
+        assert payload["headline"] == "Big morning"
+        assert payload["generated_for_date"] == "2026-09-03"
+        assert len(client.messages.calls) == 1
+
+    def test_a_failed_brief_reports_but_keeps_the_board(self, home, monkeypatch, api_key):
+        write_stored(home, {"generated_for_date": "2026-09-02",
+                            "calendars_fetched_at": "2026-09-03T05:50:00+00:00",
+                            "headline": "Yesterday", "note": "Yesterday", "events": EVENTS})
+        client = FakeClient(raises=RuntimeError("the API is down"))
+        monkeypatch.setattr(cli, "write_brief",
+                            lambda config, **kw: runner.write_brief(config, client=client, **kw))
+        assert self.run_tick(home, monkeypatch, datetime(2026, 9, 3, 6, tzinfo=timezone.utc)) == 1
+        # Untouched, so the next tick five minutes later asks again.
+        assert stored(home)["headline"] == "Yesterday"
+
+    def test_the_first_tick_of_a_new_pi_fetches_and_writes(self, home, monkeypatch, api_key):
+        monkeypatch.setattr(runner, "fetch_events", fake_fetch(EVENTS, OK_STATUS))
+        client = FakeClient()
+        monkeypatch.setattr(cli, "write_brief",
+                            lambda config, **kw: runner.write_brief(config, client=client, **kw))
+        assert self.run_tick(home, monkeypatch, datetime(2026, 9, 3, 6, tzinfo=timezone.utc)) == 0
+        payload = stored(home)
+        assert payload["events"] == EVENTS
+        assert payload["headline"] == "Big morning"
+
+    def test_tick_and_date_are_refused(self, home):
+        with pytest.raises(SystemExit):
+            cli.main(["--tick", "--date", "2026-12-24", "--config", str(home / "config.yaml")])
+
+
+class TestOnlyOneTickAtATime:
+    """A tick can outlive its five-minute slot; the next one must not pay twice."""
+
+    def test_the_second_holder_is_turned_away(self, tmp_path):
+        lock = tmp_path / ".tick.lock"
+        with cli.only_one_tick(lock) as first:
+            assert first is True
+            # A second process, same file. flock is per open file description,
+            # so this is what a second cron run would see.
+            with cli.only_one_tick(lock) as second:
+                assert second is False
+
+    def test_the_lock_is_released_when_the_tick_finishes(self, tmp_path):
+        lock = tmp_path / ".tick.lock"
+        with cli.only_one_tick(lock) as first:
+            assert first is True
+        with cli.only_one_tick(lock) as again:
+            assert again is True
+
+    def test_an_overlapping_tick_does_nothing_and_does_not_fail(self, home, monkeypatch):
+        monkeypatch.setattr(runner, "fetch_events", refuse("the fetch"))
+        monkeypatch.setattr(cli, "write_brief", refuse("the model call"))
+        with cli.only_one_tick(home / cli.LOCK_FILE):
+            # Nothing has ever been generated, so everything would be owed.
+            assert cli.main(["--tick", "--config", str(home / "config.yaml")]) == 0
+        assert not (home / "dashboard_data.json").exists()

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -1,0 +1,213 @@
+"""What is owed, and when.
+
+`due` is the whole of the tick's decision-making and it is pure, so these are
+the tests that stop a family in Auckland getting yesterday's brief and a Pi
+left on UTC writing at the wrong hour. Every `now` here is UTC, deliberately:
+the server's clock is never the family's.
+"""
+
+from datetime import datetime, time, timedelta, timezone
+
+import pytest
+
+from dinkydash.schedule import (DEFAULT_BRIEF_TIME, DEFAULT_REFRESH_MINUTES,
+                                brief_due, brief_time, due, parse_stamp,
+                                refresh_due, refresh_interval)
+
+BERLIN = {"timezone": "Europe/Berlin", "refresh_minutes": 60, "brief_time": "06:00"}
+AUCKLAND = {"timezone": "Pacific/Auckland", "refresh_minutes": 60, "brief_time": "06:00"}
+
+
+def utc(text):
+    """An aware UTC datetime from '2026-09-03 04:05'."""
+    return datetime.fromisoformat(text).replace(tzinfo=timezone.utc)
+
+
+def payload(fetched=None, generated_for=None):
+    stored = {}
+    if fetched:
+        stored["calendars_fetched_at"] = fetched
+    if generated_for:
+        stored["generated_for_date"] = generated_for
+    return stored
+
+
+class TestFirstRun:
+    def test_no_payload_owes_a_fetch(self):
+        # Nothing has ever been stored, so there is nothing to be stale.
+        assert due(BERLIN, None, utc("2026-09-03 01:00"))["refresh"] is True
+
+    def test_no_payload_before_the_brief_time_owes_only_the_fetch(self):
+        # 03:00 Berlin. The agenda can be fetched now; the brief waits for 06:00
+        # rather than landing on the wall in the middle of the night.
+        owed = due(BERLIN, None, utc("2026-09-03 01:00"))
+        assert owed == {"refresh": True, "brief": False}
+
+    def test_no_payload_after_the_brief_time_owes_both(self):
+        assert due(BERLIN, None, utc("2026-09-03 07:00")) == {"refresh": True, "brief": True}
+
+    def test_an_empty_payload_is_the_same_as_none(self):
+        assert due(BERLIN, {}, utc("2026-09-03 07:00")) == {"refresh": True, "brief": True}
+
+
+class TestRefresh:
+    def test_not_due_inside_the_interval(self):
+        stored = payload(fetched="2026-09-03T10:00:00+00:00")
+        assert refresh_due(BERLIN, stored, utc("2026-09-03 10:59")) is False
+
+    def test_due_on_the_interval(self):
+        stored = payload(fetched="2026-09-03T10:00:00+00:00")
+        assert refresh_due(BERLIN, stored, utc("2026-09-03 11:00")) is True
+
+    def test_a_shorter_interval_is_obeyed(self):
+        stored = payload(fetched="2026-09-03T10:00:00+00:00")
+        config = dict(BERLIN, refresh_minutes=15)
+        assert refresh_due(config, stored, utc("2026-09-03 10:14")) is False
+        assert refresh_due(config, stored, utc("2026-09-03 10:15")) is True
+
+    def test_a_daily_interval_is_obeyed(self):
+        stored = payload(fetched="2026-09-03T10:00:00+00:00")
+        config = dict(BERLIN, refresh_minutes=1440)
+        assert refresh_due(config, stored, utc("2026-09-03 23:00")) is False
+        assert refresh_due(config, stored, utc("2026-09-04 10:00")) is True
+
+    def test_a_stamp_from_the_future_forces_a_fetch(self):
+        # The Pi's clock was wrong and has just been corrected. Believe the
+        # clock rather than the file — a fetch costs nothing.
+        stored = payload(fetched="2027-01-01T00:00:00+00:00")
+        assert refresh_due(BERLIN, stored, utc("2026-09-03 10:00")) is True
+
+    def test_a_naive_stamp_is_read_as_utc(self):
+        # An older payload, written before the stamp carried an offset.
+        stored = payload(fetched="2026-09-03T10:00:00")
+        assert refresh_due(BERLIN, stored, utc("2026-09-03 10:30")) is False
+        assert refresh_due(BERLIN, stored, utc("2026-09-03 11:30")) is True
+
+    def test_an_unreadable_stamp_is_treated_as_absent(self):
+        assert refresh_due(BERLIN, payload(fetched="soon"), utc("2026-09-03 10:00")) is True
+
+    def test_a_stale_brief_does_not_make_a_fetch_due(self):
+        # The two clocks are independent: yesterday's headline over a
+        # ten-minute-old agenda is a state the board already handles.
+        stored = payload(fetched="2026-09-03T10:00:00+00:00", generated_for="2026-09-02")
+        assert refresh_due(BERLIN, stored, utc("2026-09-03 10:10")) is False
+
+
+class TestBriefTimeCrossing:
+    @pytest.mark.parametrize("moment, expected", [
+        ("2026-09-03 03:00", False),  # 05:00 Berlin
+        ("2026-09-03 03:58", False),  # 05:58
+        ("2026-09-03 03:59", False),  # 05:59
+        ("2026-09-03 04:00", True),   # 06:00 — on the minute
+        ("2026-09-03 04:01", True),   # 06:01
+        ("2026-09-03 20:00", True),   # 22:00, still owed if the day was missed
+    ])
+    def test_the_brief_waits_for_the_family_clock(self, moment, expected):
+        stored = payload(generated_for="2026-09-02")
+        assert brief_due(BERLIN, stored, utc(moment)) is expected
+
+    def test_once_written_it_is_not_owed_again(self):
+        stored = payload(generated_for="2026-09-03")
+        assert brief_due(BERLIN, stored, utc("2026-09-03 04:00")) is False
+        assert brief_due(BERLIN, stored, utc("2026-09-03 21:59")) is False
+
+    def test_it_is_owed_again_after_midnight_and_the_brief_time(self):
+        stored = payload(generated_for="2026-09-03")
+        # 00:30 Berlin on the 4th: a new day, but too early.
+        assert brief_due(BERLIN, stored, utc("2026-09-03 22:30")) is False
+        # 06:00 Berlin on the 4th.
+        assert brief_due(BERLIN, stored, utc("2026-09-04 04:00")) is True
+
+    def test_a_failed_brief_is_owed_again_on_the_next_tick(self):
+        # A failure writes nothing, so generated_for_date still says yesterday
+        # and five minutes later the answer is still yes. That is the retry.
+        stored = payload(generated_for="2026-09-02")
+        assert brief_due(BERLIN, stored, utc("2026-09-03 04:00")) is True
+        assert brief_due(BERLIN, stored, utc("2026-09-03 04:05")) is True
+
+    def test_a_later_brief_time_is_obeyed(self):
+        stored = payload(generated_for="2026-09-02")
+        config = dict(BERLIN, brief_time="07:30")
+        assert brief_due(config, stored, utc("2026-09-03 05:29")) is False  # 07:29
+        assert brief_due(config, stored, utc("2026-09-03 05:30")) is True   # 07:30
+
+
+class TestTheOtherSideOfTheWorld:
+    """Auckland is twelve hours from UTC, so the local date is often not the server's."""
+
+    def test_the_day_is_the_familys_day_not_the_servers(self):
+        # 2026-06-14 18:00 UTC is 2026-06-15 06:00 in Auckland.
+        moment = utc("2026-06-14 18:00")
+        assert brief_due(AUCKLAND, payload(generated_for="2026-06-14"), moment) is True
+        assert brief_due(AUCKLAND, payload(generated_for="2026-06-15"), moment) is False
+
+    def test_the_brief_time_is_the_familys_clock(self):
+        stored = payload(generated_for="2026-06-14")
+        assert brief_due(AUCKLAND, stored, utc("2026-06-14 17:59")) is False  # 05:59 local
+        assert brief_due(AUCKLAND, stored, utc("2026-06-14 18:00")) is True   # 06:00 local
+
+    def test_a_server_at_utc_midnight_is_mid_afternoon_there(self):
+        # A board written at 18:00 local looks, from UTC, like it was written
+        # "tomorrow". It is still today's, and must not be rewritten.
+        assert brief_due(AUCKLAND, payload(generated_for="2026-06-15"),
+                         utc("2026-06-15 06:00")) is False
+
+
+class TestDaylightSaving:
+    """Berlin, 29 March 2026: 02:00 becomes 03:00. Wall times 02:00-02:59 never happen."""
+
+    def test_a_brief_time_inside_the_lost_hour_is_not_skipped(self):
+        config = dict(BERLIN, brief_time="02:30")
+        stored = payload(generated_for="2026-03-28")
+        # 01:30 local, before the jump.
+        assert brief_due(config, stored, utc("2026-03-29 00:30")) is False
+        # The clock goes straight to 03:00, which is past 02:30, so it is owed.
+        assert brief_due(config, stored, utc("2026-03-29 01:00")) is True
+
+    def test_the_refresh_interval_counts_real_minutes_not_wall_clock(self):
+        # Fetched at 01:30 local. At 03:05 local the wall clock has moved 95
+        # minutes but only 35 have passed, so an hourly refresh is not owed.
+        stored = payload(fetched="2026-03-29T00:30:00+00:00")
+        assert refresh_due(BERLIN, stored, utc("2026-03-29 01:05")) is False
+        assert refresh_due(BERLIN, stored, utc("2026-03-29 01:30")) is True
+
+    def test_the_repeated_hour_does_not_write_a_second_brief(self):
+        # 25 October 2026: 02:00-02:59 happens twice. The first pass writes the
+        # brief; the second must find it already written for the day.
+        config = dict(BERLIN, brief_time="02:30")
+        assert brief_due(config, payload(generated_for="2026-10-24"),
+                         utc("2026-10-25 00:30")) is True   # 02:30 CEST
+        assert brief_due(config, payload(generated_for="2026-10-25"),
+                         utc("2026-10-25 01:30")) is False  # 02:30 CET, again
+
+    def test_auckland_gains_an_hour_without_losing_the_brief(self):
+        # 27 September 2026: 02:00 becomes 03:00 in Auckland too.
+        config = dict(AUCKLAND, brief_time="02:30")
+        stored = payload(generated_for="2026-09-26")
+        assert brief_due(config, stored, utc("2026-09-26 13:30")) is False  # 01:30 local
+        assert brief_due(config, stored, utc("2026-09-26 14:00")) is True   # 03:00 local
+
+
+class TestSettings:
+    def test_defaults_when_the_keys_are_missing(self):
+        assert refresh_interval({}) == timedelta(minutes=DEFAULT_REFRESH_MINUTES)
+        assert brief_time({}) == time.fromisoformat(DEFAULT_BRIEF_TIME)
+
+    def test_nonsense_falls_back_rather_than_raising(self):
+        assert refresh_interval({"refresh_minutes": "hourly"}) == timedelta(minutes=60)
+        assert brief_time({"brief_time": "breakfast"}) == time(6, 0)
+        # YAML 1.1 would read an unquoted 06:00 as the number 360.
+        assert brief_time({"brief_time": 360}) == time(6, 0)
+
+    def test_a_zero_interval_still_leaves_a_gap(self):
+        # Otherwise every tick fetches, for ever.
+        assert refresh_interval({"refresh_minutes": 0}) == timedelta(minutes=1)
+        assert refresh_interval({"refresh_minutes": -5}) == timedelta(minutes=1)
+
+    def test_seconds_in_a_brief_time_are_accepted(self):
+        assert brief_time({"brief_time": "06:30:00"}) == time(6, 30)
+
+    def test_parse_stamp_round_trips_an_offset(self):
+        assert parse_stamp("2026-09-03T10:00:00+02:00") == utc("2026-09-03 08:00")
+        assert parse_stamp(None) is None
+        assert parse_stamp("") is None

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -5,6 +5,8 @@ when the page was rendered. It used to be a list position, so deleting anyone
 above shifted everybody below onto somebody else's edit form.
 """
 
+import json
+
 import pytest
 
 from dinkydash import config as config_module
@@ -189,3 +191,55 @@ class TestHomeScreen:
         assert 'rel="apple-touch-icon"' in page
         assert '<meta name="apple-mobile-web-app-title" content="DinkyDash">' in page
         assert client.get("/static/apple-touch-icon.png").status_code == 200
+
+
+class TestTheClockOnTheStatusLine:
+    """Stamps are stored in UTC; the family reads their own clock (PLAN bug 9)."""
+
+    @pytest.fixture
+    def config_path(self, tmp_path, monkeypatch):
+        # Kolkata is UTC+05:30 in every month of the year. Berlin would make
+        # these assertions pass in summer and fail in winter, and the half hour
+        # means no accidental slice of the ISO string can look like a pass.
+        path = tmp_path / "config.yaml"
+        path.write_text(CONFIG.replace('timezone: "Europe/Berlin"',
+                                       'timezone: "Asia/Kolkata"'))
+        monkeypatch.setenv("DINKYDASH_CONFIG", str(path))
+        return path
+
+    @pytest.fixture
+    def board(self, tmp_path, config_path):
+        def _write(payload):
+            (tmp_path / "dashboard_data.json").write_text(json.dumps(payload))
+        return _write
+
+    @pytest.fixture
+    def today(self, config_path):
+        """Today on the family's clock — the same question the page asks."""
+        return config_module.today_for(config_module.load_config(config_path)).isoformat()
+
+    def test_a_utc_stamp_is_shown_in_the_familys_timezone(self, client, board, today):
+        board({"generated_for_date": today, "generated_at": f"{today}T04:07:00+00:00",
+               "headline": "Hi", "note": "There", "events": []})
+        page = client.get("/settings/").get_data(as_text=True)
+        # 04:07 UTC is 09:37 in Kolkata, whatever the server thinks the time is.
+        assert "written 09:37" in page
+
+    def test_the_calendar_refresh_is_shown_too(self, client, board, today):
+        board({"generated_for_date": today, "generated_at": f"{today}T04:00:00+00:00",
+               "calendars_fetched_at": f"{today}T12:30:00+00:00",
+               "headline": "Hi", "note": "There", "events": []})
+        assert "Calendars refreshed 18:00" in client.get("/settings/").get_data(as_text=True)
+
+    def test_an_agenda_with_no_brief_yet_is_still_waiting(self, client, board, today):
+        # The state after a first `--tick` before brief_time: events, no words.
+        board({"calendars_fetched_at": f"{today}T05:00:00+00:00", "events": []})
+        page = client.get("/settings/").get_data(as_text=True)
+        assert "No board has been generated yet." in page
+        assert "Calendars refreshed 10:30" in page
+        assert "from None" not in page
+
+    def test_an_unreadable_stamp_does_not_break_the_page(self, client, board, today):
+        board({"generated_for_date": today, "generated_at": "who knows",
+               "headline": "Hi", "note": "There", "events": []})
+        assert "written earlier" in client.get("/settings/").get_data(as_text=True)

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -5,28 +5,18 @@ network. Anyone who can reach the port can edit the config, which is the same
 trust model as the config file it writes.
 """
 
-import json
-import logging
 import os
 from pathlib import Path
 
 from flask import Flask
 
 from dinkydash import config as config_module
-
-log = logging.getLogger(__name__)
+from dinkydash import runner
 
 
 def load_payload(config):
     """The last generated payload, or None if nothing has been generated yet."""
-    try:
-        with open(config_module.data_path(config)) as f:
-            return json.load(f)
-    except FileNotFoundError:
-        return None
-    except json.JSONDecodeError as exc:
-        log.warning("Dashboard data is not valid JSON (%s); showing the waiting screen", exc)
-        return None
+    return runner.read_payload(config_module.data_path(config))
 
 
 def create_app():

--- a/web/routes/settings.py
+++ b/web/routes/settings.py
@@ -9,7 +9,7 @@ comments in the file survive being edited from a phone.
 """
 
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 
 from flask import (Blueprint, abort, current_app, flash, redirect,
                    render_template, request, url_for)
@@ -170,13 +170,21 @@ def home():
     today = config_module.today_for(config)
     payload = load_payload(config)
 
+    tzinfo = config_module.tzinfo_for(config)
     status = {"state": "waiting", "detail": "No board has been generated yet."}
     if payload:
         generated_for = payload.get("generated_for_date")
+        written = _clock(payload.get("generated_at"), tzinfo)
         if generated_for == today.isoformat():
-            status = {"state": "ready", "detail": f"Today's board is up — written {_clock(payload)}."}
-        else:
+            status = {"state": "ready",
+                      "detail": f"Today's board is up — written {written or 'earlier'}."}
+        elif generated_for:
             status = {"state": "stale", "detail": f"Showing the board from {generated_for}."}
+        # A refresh with no brief yet leaves a payload holding only the agenda,
+        # so an unwritten board stays "waiting" rather than claiming a date.
+        fetched = _clock(payload.get("calendars_fetched_at"), tzinfo)
+        if fetched:
+            status["detail"] += f" Calendars refreshed {fetched}."
 
     calendars = config.get("calendars") or []
     broken = [c for c in (payload or {}).get("calendar_statuses", []) if c.get("ok") is False]
@@ -194,9 +202,22 @@ def home():
     )
 
 
-def _clock(payload):
-    stamp = payload.get("generated_at", "")
-    return stamp[11:16] if len(stamp) >= 16 else "earlier"
+def _clock(stamp, tzinfo):
+    """An ISO timestamp as the time on the family's own clock, or None.
+
+    Stamps are written in UTC. The server is often not in the family's timezone
+    — a Pi is frequently left on UTC, and hosted the server is nowhere near
+    them — so reading the characters out of the string showed the wrong time.
+    """
+    if not stamp:
+        return None
+    try:
+        moment = datetime.fromisoformat(str(stamp))
+    except (TypeError, ValueError):
+        return None
+    if moment.tzinfo is None:
+        moment = moment.replace(tzinfo=timezone.utc)
+    return moment.astimezone(tzinfo).strftime("%H:%M")
 
 
 @bp.route("/manifest.webmanifest")


### PR DESCRIPTION
The agenda was a slice of a fourteen-day window fetched once at 6am, so an appointment added at 09:00 for 15:00 did not reach the board until the next morning; `runner.run` now splits into `refresh_calendars` and `write_brief`, driven by a pure `due(config, payload, now)` in the new `dinkydash/schedule.py` and two ordinary config keys — `refresh_minutes` (60) and `brief_time` (`"06:00"`, on the family's clock). Cron changes to `*/5 * * * * generate.py --tick`, which does only what is owed and exits silently when nothing is; the old `0 6 * * *` line keeps working, and a refresh never touches `headline`, `note` or `generated_for_date`, so a fresh agenda under yesterday's brief is the amber-banner state the board already handles. A failure is not handled but simply due again next tick, which is the retry — and a feed that stops answering keeps its own last-known events, merged per feed so one dead URL cannot freeze every healthy calendar. A tick takes a non-blocking `flock` and skips itself if one is still running, so an overrun cannot buy the same brief twice. PLAN.md bug 9 rides along: `generated_at` is stamped in UTC and the settings home renders both stamps in the family's timezone.

227 tests pass, up from 157, and green under server timezones from UTC+14 to UTC−11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)