### PR TITLE
Say in the README that self-hosted mode has no login (DIN-22)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -489,7 +489,10 @@ written steps are what people see.
   there is no JSON-repair retry loop. Do not add one back.
 - Self-hosted mode has **no authentication**. Anyone who can reach the port can edit the config.
   That is the same trust model as the file it writes, but keep the port off the public internet.
-  Cloud mode cannot inherit this — see [Hosted mode raises the stakes](#hosted-mode-raises-the-stakes).
+  The README now says so too, in a callout under **Getting started** and a pointer from the Pi
+  section — it used to be written down only here and in the `app.py` docstring, neither of which a
+  user reads. Cloud mode cannot inherit this — see
+  [Hosted mode raises the stakes](#hosted-mode-raises-the-stakes).
 - **A failed calendar fetch puts the secret URL in the error text.** `requests` formats both
   `raise_for_status()` and connection errors with the full URL (`404 Client Error: ... for url:
   https://.../private-REALSECRET/basic.ics`), and `fetch_feed` wraps `{exc}` straight into

--- a/README.md
+++ b/README.md
@@ -49,6 +49,20 @@ are still today's — the board just labels the written line as older.
 
 ## Getting started
 
+> **There is no login.** The board and the settings UI are both served without authentication, so
+> anyone who can reach the port can read your family's agenda and rewrite `config.yaml` — names,
+> birthdays, and every calendar link in it.
+>
+> That is deliberate rather than unfinished: DinkyDash is a config file with a web form on it, and
+> the file has no login either. It assumes it is on your home network, the same as a printer.
+>
+> **So keep the port off the public internet.** Do not forward port 5000 on your router. If you need
+> it from outside the house, reach it over a VPN such as [Tailscale](https://tailscale.com) or
+> [WireGuard](https://www.wireguard.com), or put a reverse proxy with basic auth in front of it.
+>
+> Hosted mode is a different matter — it authenticates every request and is scoped per family. See
+> [PLAN.md](PLAN.md).
+
 ### Prerequisites
 
 - Python 3.11+
@@ -340,6 +354,10 @@ feed per person instead.
 ## Raspberry Pi deployment
 
 This section covers setting up DinkyDash on a Raspberry Pi with a small display so it runs as a permanent family dashboard.
+
+The Pi serves the board and the settings UI to your whole network with no login — see the warning
+under [Getting started](#getting-started). On a home network that is the intended setup. Do not
+forward the port to the internet.
 
 ### What you need
 


### PR DESCRIPTION
`app.py` binds `0.0.0.0` and `/settings` rewrites `config.yaml` — names, birthdays and every calendar link — for anyone who can reach the port, but that was written down only in the `app.py` docstring and CLAUDE.md, neither of which a user reads. This adds a callout under **Getting started** saying it plainly, saying why it is a deliberate trust model rather than an omission, and giving the two safe ways to reach the board from outside the house: a VPN, or a reverse proxy with basic auth. The Raspberry Pi section points back at it, since that is the install that actually ends up on a network. CLAUDE.md's known-issues entry records that the README now covers it, so it does not get re-filed.

Docs only — no code paths change, and all 227 tests pass.

Closes #34.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
