### PR TITLE
Put the two cadences on a settings page, and derive the board's reload (DIN-18)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -284,7 +284,21 @@ clocks, chosen by the family (PLAN.md decision 11, single-mode half):
 ordinary config keys, so they migrate through `with_defaults` and will survive as a `jsonb` column.
 `runner.run` is still both halves in order, which is what a plain `python generate.py` and the
 settings page's **Rewrite now** do — the old `0 6 * * *` line keeps working, it just never sees a
-same-day change.
+same-day change. **Refresh calendars**, beside it, is `refresh_calendars` alone: no key needed, no
+money spent, and the thing most people pressing the other button actually wanted.
+
+Both keys are edited at `/settings/refresh` rather than in YAML. The select offers five intervals
+and nothing else, but it also offers **whatever the file already says** — a hand-edited
+`refresh_minutes: 45` has to survive somebody opening the page and pressing Save, or the UI quietly
+overrules the file. `brief_time` is written back through `config.quoted()`: bare `06:00` is a string
+to ruamel and a sexagesimal integer to a YAML 1.1 parser, and this file is meant to be hand-editable
+with either.
+
+**The board's own reload is derived, not stored** (`board.reload_seconds`). Five minutes is the
+ceiling; only a `refresh_minutes` shorter than that lowers it, because reloading faster than the
+calendars are fetched just redraws the same thing. A parent picks "how soon does a change show up",
+not a browser knob — so there is no separate setting for it and the template reads
+`view.reload_seconds` rather than deciding.
 
 Three rules hold this together:
 
@@ -515,8 +529,8 @@ written steps are what people see.
   and `--dump-dom` both hang until the timeout, though they do write their output first. Strip the
   tag when rendering a copy for measurement, and wrap the call in `timeout` regardless.
 - The honest check is `scrot` over SSH on the Pi itself: a real 800x480 panel, a real kiosk browser,
-  no capture artifacts. The board refreshes itself every 5 minutes, so a change takes one refresh to
-  appear.
+  no capture artifacts. The board reloads itself every 5 minutes on a default config, so a change
+  takes one reload to appear — check `refresh_minutes` before concluding it did not work.
 
 ## Raspberry Pi Deployment
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -457,7 +457,7 @@ Critical path is 0 → 1 → 2 → 3. Phases 4–6 can run alongside 3. Nothing 
 - [x] Fix the five issues listed above; add tests around date/timezone, calendar parsing, chore rotation *(#28, #29)*
 - [x] Update the Claude model; switch to structured outputs *(#28 — `claude-haiku-4-5` takes no `thinking` parameter, so leaving it unset is the explicit choice)*
 - [ ] The small jobs above: CI, `gitleaks`, push protection, `.env.example`, pinned requirements, key rotation *(DIN-16)*; self-hosted font, URL scrub, referrer policy, `/healthz`, Dockerfile
-- [ ] **Decision 11, single-mode half:** `refresh_minutes` and `brief_time` in `DEFAULTS`; `runner.run` split into `refresh_calendars` and `write_brief`; a pure `due()`; `generate.py --tick`; the settings page under *This screen*; the board's reload derived from the interval; README cron line updated. Ships to the Pi at once and needs no database. *(DIN-17 for the engine and cron, DIN-18 for the page)*
+- [x] **Decision 11, single-mode half:** `refresh_minutes` and `brief_time` in `DEFAULTS`; `runner.run` split into `refresh_calendars` and `write_brief`; a pure `due()`; `generate.py --tick`; the settings page under *This screen*; the board's reload derived from the interval; README cron line updated. Ships to the Pi at once and needs no database. *(DIN-17 for the engine and cron, DIN-18 for the page)*
 - [ ] Name the storage seam: `FileStore` gathering the six operations that exist today, and the settings routes, runner and board taking a store *(DIN-19)*
 - [ ] `docker-compose.yml` for single mode (`web` only) — the self-host path is real from here on, and every later phase reuses the file
 - [ ] Postgres + plain-SQL migrations; CI running the suite against a Postgres service container

--- a/README.md
+++ b/README.md
@@ -193,12 +193,12 @@ Cron runs `generate.py --tick` every five minutes, and the tick does only what i
 
 **Every hour**, it re-fetches every enabled calendar and merges them into one time-ordered agenda
 for the next 14 days. This costs nothing but a few HTTP requests, and it is what puts an
-appointment added at 09:00 for 15:00 onto the board the same afternoon. Change `refresh_minutes` in
-`config.yaml` to make that 15 minutes or once a day. Fetching faster than the provider updates buys
-nothing: Google's secret `.ics` link is cached at their end and can lag by hours.
+appointment added at 09:00 for 15:00 onto the board the same afternoon. Make that 15 minutes or
+once a day under **Settings → How often it updates**. Fetching faster than the provider updates
+buys nothing: Google's secret `.ics` link is cached at their end and can lag by hours.
 
 **Once a day at 06:00**, on your own clock, it asks Claude for a headline and one line of copy —
-the only part that costs money. Change the hour with `brief_time`. A brief that fails is simply
+the only part that costs money. The same page changes the hour. A brief that fails is simply
 owed again five minutes later, so a network blip at dawn no longer means a day-old line.
 
 Both write atomically to `dashboard_data.json`, and a refresh never touches the written line.
@@ -229,8 +229,19 @@ your comments and formatting, so editing the file by hand and editing through th
 interchangeable.
 
 Config changes show up on the next page load. They do **not** re-run generation: the headline and
-note are from this morning. Press **Rewrite now** if you want fresh copy immediately — each press is
-one API call.
+note are from this morning.
+
+Two buttons on the settings home force the point:
+
+- **Refresh calendars** re-fetches the feeds and nothing else. Free, and usually what you want
+  after adding something to a calendar you don't want to wait for.
+- **Rewrite now** does that *and* asks Claude for a new headline and line. One API call per press.
+
+**How often it updates** sets both cadences — how often the calendars are fetched, and what time
+the daily line is written, on your own clock. They are the `refresh_minutes` and `brief_time` keys,
+so editing them by hand still works; the page is just the version you can reach from a phone. The
+board's own reload follows: it redraws every five minutes, or every `refresh_minutes` if you set
+something shorter than that.
 
 ### Keeping settings on your phone
 
@@ -338,8 +349,8 @@ Nothing to do to your config — it is migrated on load. But be aware:
 | `max_tokens` | Max response length |
 | `calendar_days_ahead` | How far ahead to fetch (default 14) |
 | `history_days` | Days of past notes sent back so the model doesn't repeat itself |
-| `refresh_minutes` | How often `--tick` re-fetches the calendars (default 60). Costs nothing but HTTP requests |
-| `brief_time` | When `--tick` writes the daily brief, on your own clock (default `"06:00"`). Quote it |
+| `refresh_minutes` | How often `--tick` re-fetches the calendars (default 60). Costs nothing but HTTP requests. Also sets the board's own reload, when it is under five minutes. Editable at **Settings → How often it updates** |
+| `brief_time` | When `--tick` writes the daily brief, on your own clock (default `"06:00"`). Quote it. Same settings page |
 | `data_file` | Path for the generated JSON |
 | `content_history_file` | Path for the rolling note history |
 | `id` | Added to each `people[]`, `pets[]`, `recurring[]`, `special_dates[]` and `calendars[]` entry the first time you open `/settings`. Leave it alone — it is how the settings UI tells one entry from another, so deleting somebody does not renumber everyone below onto the wrong edit form |

--- a/dinkydash/board.py
+++ b/dinkydash/board.py
@@ -11,6 +11,7 @@ from datetime import datetime, timedelta
 
 from .calendars import events_on
 from .context import build_countdowns, compute_chore_assignments
+from .schedule import refresh_interval
 
 # The agenda's row budget, not just today's cap. Today fills it first and
 # tomorrow tops up whatever is left, so a quiet day stops leaving the column
@@ -20,6 +21,15 @@ MAX_EVENTS = 5
 # reads as today's first.
 MAX_TOMORROW = 3
 MAX_COUNTDOWNS = 3
+
+# Nothing pushes to the board, so it reloads itself on a timer. Five minutes is
+# the ceiling — it is a panel on a wall, not a page anyone is watching — and
+# reloading faster than the calendars are fetched only shows the same thing
+# again, so a shorter `refresh_minutes` is the only thing that lowers it.
+MAX_RELOAD_SECONDS = 300
+# Before the first run there is nothing to show, so ask more often: the screen
+# then fills itself in a minute after the board is written rather than five.
+WAITING_RELOAD_SECONDS = 60
 
 
 def computed_headline(events):
@@ -32,6 +42,16 @@ def computed_headline(events):
     if timed:
         return f"{count} {noun} on today, starting at {timed[0]['time']}."
     return f"{count} {noun} on today."
+
+
+def reload_seconds(config):
+    """How long the board waits before rendering itself again.
+
+    Config-derived, so it is computed here rather than written into the
+    template: a family that fetches every 15 minutes still reloads every 5, and
+    only an interval shorter than that pulls it down.
+    """
+    return min(MAX_RELOAD_SECONDS, int(refresh_interval(config).total_seconds()))
 
 
 def build_view(config, payload, today):
@@ -57,10 +77,13 @@ def build_view(config, payload, today):
         "note": "",
         "stale": False,
         "state": "waiting",
+        "reload_seconds": WAITING_RELOAD_SECONDS,
     }
 
     if not payload:
         return view
+
+    view["reload_seconds"] = reload_seconds(config)
 
     fetched = payload.get("events") or []
     events = events_on(fetched, today)[:MAX_EVENTS]

--- a/dinkydash/config.py
+++ b/dinkydash/config.py
@@ -12,6 +12,7 @@ from datetime import datetime
 from pathlib import Path
 
 from ruamel.yaml import YAML
+from ruamel.yaml.scalarstring import DoubleQuotedScalarString
 
 from .calendars import zone
 
@@ -51,6 +52,17 @@ LIST_KEYS = ("people", "pets", "recurring", "special_dates", "calendars")
 # when something goes wrong, so leave out the characters that look like others.
 ID_ALPHABET = "23456789abcdefghjkmnpqrstuvwxyz"
 ID_LENGTH = 8
+
+
+def quoted(value):
+    """A string that stays quoted when the file is written back.
+
+    `06:00` is a plain string to ruamel's resolver but a sexagesimal integer to
+    a YAML 1.1 one, and config.yaml is meant to be editable by hand with
+    whatever parser the reader has. So `brief_time` is written the way
+    config.example.yaml documents it — in quotes.
+    """
+    return DoubleQuotedScalarString(str(value))
 
 
 def _yaml():

--- a/docs/best-digital-family-calendar/index.html
+++ b/docs/best-digital-family-calendar/index.html
@@ -326,7 +326,7 @@
   "headline": "The Best Digital Family Calendar in 2026: Buy One, or Use a Screen You Own",
   "description": "An honest guide to choosing a digital family calendar in 2026 \u2014 dedicated displays like Skylight and Hearth vs free software on a screen you already own.",
   "mainEntityOfPage": "https://dinkydash.co/best-digital-family-calendar/",
-  "dateModified": "2026-09-06",
+  "dateModified": "2026-09-07",
   "author": { "@type": "Person", "name": "Caspar Wrede", "url": "https://casparwre.de" },
   "publisher": { "@id": "https://dinkydash.co/#org" }
 }
@@ -428,7 +428,7 @@
 </table>
 <p><em>Prices checked 6 September 2026.</em></p>
 <p>Whichever path you take: the win isn't the gadget, it's the behavior change — the family checking one shared screen instead of asking one exhausted parent. The cheapest way to test whether that works in your house is <a href="/getting-started/">the free one</a>.</p>
-    <p class="page-updated">Last updated 2026-09-06.</p>
+    <p class="page-updated">Last updated 2026-09-07.</p>
 </div>
 
 </main>

--- a/docs/dakboard-alternatives/index.html
+++ b/docs/dakboard-alternatives/index.html
@@ -326,7 +326,7 @@
   "headline": "DAKboard Alternatives in 2026: 6 Options, Including a Free Open-Source One",
   "description": "Looking for a DAKboard alternative? Here are 6 options compared on price, screens, and whether you can self-host \u2014 including a free, MIT-licensed one that runs on a screen you already own.",
   "mainEntityOfPage": "https://dinkydash.co/dakboard-alternatives/",
-  "dateModified": "2026-09-06",
+  "dateModified": "2026-09-07",
   "author": { "@type": "Person", "name": "Caspar Wrede", "url": "https://casparwre.de" },
   "publisher": { "@id": "https://dinkydash.co/#org" }
 }
@@ -576,7 +576,7 @@
 <li><strong>Want maximum layout control with support behind it:</strong> stay on DAKboard</li>
 </ul>
 <p>Not sure a wall display is worth it at all? Prop an old tablet on the counter for two weeks first — our <a href="/diy-skylight-calendar/">DIY guide</a> explains why that test is worth more than the hardware decision.</p>
-    <p class="page-updated">Last updated 2026-09-06.</p>
+    <p class="page-updated">Last updated 2026-09-07.</p>
 </div>
 
 </main>

--- a/docs/dakboard-vs-skylight/index.html
+++ b/docs/dakboard-vs-skylight/index.html
@@ -326,7 +326,7 @@
   "headline": "DAKboard vs Skylight vs DinkyDash (2026): Prices, Setup, and Which to Pick",
   "description": "DAKboard ($0\u201310/mo, bring your own screen) vs Skylight ($299.99\u2013$599.99 plus optional $79/yr) vs DinkyDash (free and open source) \u2014 compared on hardware, subscription, setup effort, and what happens when it breaks.",
   "mainEntityOfPage": "https://dinkydash.co/dakboard-vs-skylight/",
-  "dateModified": "2026-09-06",
+  "dateModified": "2026-09-07",
   "author": { "@type": "Person", "name": "Caspar Wrede", "url": "https://casparwre.de" },
   "publisher": { "@id": "https://dinkydash.co/#org" }
 }
@@ -600,7 +600,7 @@
 <li><strong>Mornings are the actual problem, not the calendar:</strong> neither of these. See <a href="/hearth-vs-skylight/">Hearth vs Skylight</a>.</li>
 </ul>
 <p>Still deciding whether a wall display is worth it at all? Prop an old tablet on the kitchen counter for two weeks first. Our <a href="/diy-skylight-calendar/">DIY guide</a> explains why that test tells you more than the hardware decision does. Or compare the wider field on the <a href="/skylight-calendar-alternatives/">Skylight alternatives</a> and <a href="/dakboard-alternatives/">DAKboard alternatives</a> pages.</p>
-    <p class="page-updated">Last updated 2026-09-06.</p>
+    <p class="page-updated">Last updated 2026-09-07.</p>
 </div>
 
 </main>

--- a/docs/getting-started/index.html
+++ b/docs/getting-started/index.html
@@ -326,7 +326,7 @@
   "headline": "Getting Started with DinkyDash",
   "description": "Set up DinkyDash from scratch \u2014 first on your computer, then as a permanent wall dashboard on a Raspberry Pi running the current Raspberry Pi OS.",
   "mainEntityOfPage": "https://dinkydash.co/getting-started/",
-  "dateModified": "2026-09-06",
+  "dateModified": "2026-09-07",
   "author": { "@type": "Person", "name": "Caspar Wrede", "url": "https://casparwre.de" },
   "publisher": { "@id": "https://dinkydash.co/#org" }
 }
@@ -598,13 +598,24 @@ sudo systemctl daemon-reload
 sudo systemctl enable dinkydash.service
 sudo systemctl start dinkydash.service
 </code></pre>
-<h3>Step 6: Generate a fresh board every morning</h3>
-<p>A cron job writes a new board at 6am. If a run fails, the previous board stays up and labels itself stale — the screen never goes blank.</p>
+<h3>Step 6: Keep the board up to date</h3>
+<p>A cron job ticks every five minutes, and each tick does only what your settings say is owed —
+nothing at all, most of the time. Calendars are re-fetched every hour, so an appointment added at
+09:00 for 15:00 reaches the board the same afternoon. The daily line is written once, at 6am. Both
+are yours to change under <strong>Settings → How often it updates</strong>.</p>
 <pre><code class="language-bash">crontab -e
 </code></pre>
 <p>Add this line:</p>
+<pre><code class="language-cron">*/5 * * * * cd /home/pi/dinkydash &amp;&amp; venv/bin/python generate.py --tick &gt;&gt; generate.log 2&gt;&amp;1
+</code></pre>
+<p>Runs never pile up: if one is still going when the next is due, the next skips itself. If a run
+fails, the previous board stays up and labels itself stale — the screen never goes blank, and the
+next tick tries again.</p>
+<p>The old daily line still works, and does the fetch and the line together:</p>
 <pre><code class="language-cron">0 6 * * * cd /home/pi/dinkydash &amp;&amp; venv/bin/python generate.py &gt;&gt; generate.log 2&gt;&amp;1
 </code></pre>
+<p>It just never sees a change you make to your calendar during the day, and the settings above have
+no effect on it. Use one line or the other, not both.</p>
 <h3>Step 7: Show the board full screen at boot (kiosk)</h3>
 <p>Kiosk mode launches Chromium full screen with nothing around it. Current Raspberry Pi OS uses the Wayland desktop by default, so that is the main path. A classic X11 alternative follows for people who want the older, simpler tools.</p>
 <p>First, save this launcher as <code>/home/pi/run.sh</code>. It waits for the board to answer before opening the browser, which avoids the "localhost refused to connect" screen at boot:</p>
@@ -724,7 +735,7 @@ tail -f /home/pi/dinkydash/generate.log   # last night's generation
 /home/pi/screen_control.sh on         # screen on
 </code></pre>
 <p>Once it is set up, the family gets a fresh dashboard every morning, and there is nothing to tap and nothing to maintain.</p>
-    <p class="page-updated">Last updated 2026-09-06.</p>
+    <p class="page-updated">Last updated 2026-09-07.</p>
 </div>
 
 </main>

--- a/docs/hearth-vs-skylight/index.html
+++ b/docs/hearth-vs-skylight/index.html
@@ -326,7 +326,7 @@
   "headline": "Hearth vs Skylight (2026): Prices, Subscriptions, and Which to Buy",
   "description": "Hearth Display ($699 + $9/mo) vs Skylight Calendar ($299.99\u2013$599.99 + optional $79/yr) compared honestly \u2014 plus the third option both companies would rather you didn\u0027t know about.",
   "mainEntityOfPage": "https://dinkydash.co/hearth-vs-skylight/",
-  "dateModified": "2026-09-06",
+  "dateModified": "2026-09-07",
   "author": { "@type": "Person", "name": "Caspar Wrede", "url": "https://casparwre.de" },
   "publisher": { "@id": "https://dinkydash.co/#org" }
 }
@@ -415,7 +415,7 @@
 <p>Both products are, at heart, a screen showing your family's day. If you have an old tablet, a TV, or $100 for a Raspberry Pi, free software gives you the same glanceable calendar — with chore rotations and countdowns — for no subscription at all.</p>
 <p>That's what <a href="/">DinkyDash</a> does (free, open source, and with an AI-written daily brief neither Skylight nor Hearth offers). See <a href="/diy-skylight-calendar/">how to build one in an afternoon</a>, or compare <a href="/skylight-calendar-alternatives/">all eight Skylight alternatives</a>.</p>
 <p>If the bring-your-own-screen route is the one that interests you, <a href="/dakboard-vs-skylight/">DAKboard vs Skylight vs DinkyDash</a> compares the three on hardware cost, subscription, setup effort, and what happens when it breaks.</p>
-    <p class="page-updated">Last updated 2026-09-06.</p>
+    <p class="page-updated">Last updated 2026-09-07.</p>
 </div>
 
 </main>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -10,7 +10,7 @@
   </url>
   <url>
     <loc>https://dinkydash.co/best-digital-family-calendar/</loc>
-    <lastmod>2026-09-06</lastmod>
+    <lastmod>2026-09-07</lastmod>
   </url>
   <url>
     <loc>https://dinkydash.co/birthday-countdown/</loc>
@@ -18,11 +18,11 @@
   </url>
   <url>
     <loc>https://dinkydash.co/dakboard-alternatives/</loc>
-    <lastmod>2026-09-06</lastmod>
+    <lastmod>2026-09-07</lastmod>
   </url>
   <url>
     <loc>https://dinkydash.co/dakboard-vs-skylight/</loc>
-    <lastmod>2026-09-06</lastmod>
+    <lastmod>2026-09-07</lastmod>
   </url>
   <url>
     <loc>https://dinkydash.co/digital-calendar-and-chore-chart/</loc>
@@ -38,11 +38,11 @@
   </url>
   <url>
     <loc>https://dinkydash.co/getting-started/</loc>
-    <lastmod>2026-09-06</lastmod>
+    <lastmod>2026-09-07</lastmod>
   </url>
   <url>
     <loc>https://dinkydash.co/hearth-vs-skylight/</loc>
-    <lastmod>2026-09-06</lastmod>
+    <lastmod>2026-09-07</lastmod>
   </url>
   <url>
     <loc>https://dinkydash.co/morning-routine/</loc>
@@ -58,7 +58,7 @@
   </url>
   <url>
     <loc>https://dinkydash.co/skylight-calendar-alternatives/</loc>
-    <lastmod>2026-09-06</lastmod>
+    <lastmod>2026-09-07</lastmod>
   </url>
   <url>
     <loc>https://dinkydash.co/skylight-calendar-subscription/</loc>

--- a/docs/skylight-calendar-alternatives/index.html
+++ b/docs/skylight-calendar-alternatives/index.html
@@ -326,7 +326,7 @@
   "headline": "The 8 Best Skylight Calendar Alternatives in 2026",
   "description": "Looking for a Skylight Calendar alternative without the $299.99\u2013$599.99 price tag or the $79/year subscription? Here are 8 options \u2014 including free ones that run on screens you already own.",
   "mainEntityOfPage": "https://dinkydash.co/skylight-calendar-alternatives/",
-  "dateModified": "2026-09-06",
+  "dateModified": "2026-09-07",
   "author": { "@type": "Person", "name": "Caspar Wrede", "url": "https://casparwre.de" },
   "publisher": { "@id": "https://dinkydash.co/#org" }
 }
@@ -458,7 +458,7 @@
 <li><strong>Want hardware but no subscription:</strong> Cozyla, or Dæly if you're buying in Europe</li>
 <li><strong>Not sure you need a wall display at all:</strong> Cozi on your phones, or the old-tablet test</li>
 </ul>
-    <p class="page-updated">Last updated 2026-09-06.</p>
+    <p class="page-updated">Last updated 2026-09-07.</p>
 </div>
 
 </main>

--- a/tests/test_board.py
+++ b/tests/test_board.py
@@ -215,3 +215,34 @@ class TestTheme:
     def test_an_unknown_theme_falls_back_to_light(self):
         view = build_view(dict(CONFIG, theme="neon"), payload("2026-09-03"), TODAY)
         assert view["theme"] == "light"
+
+
+class TestReloadInterval:
+    """The board reloads itself on a timer, derived from `refresh_minutes`.
+
+    Five minutes is the ceiling, so the four longer intervals all render the
+    same value the template used to hard-code. Only a shorter one moves it.
+    """
+
+    def test_the_default_is_five_minutes(self):
+        assert build_view(CONFIG, payload("2026-09-03"), TODAY)["reload_seconds"] == 300
+
+    def test_a_longer_fetch_interval_does_not_slow_the_reload(self):
+        config = dict(CONFIG, refresh_minutes=1440)
+        assert build_view(config, payload("2026-09-03"), TODAY)["reload_seconds"] == 300
+
+    def test_a_quarter_hourly_fetch_still_reloads_every_five_minutes(self):
+        config = dict(CONFIG, refresh_minutes=15)
+        assert build_view(config, payload("2026-09-03"), TODAY)["reload_seconds"] == 300
+
+    def test_only_an_interval_under_five_minutes_pulls_it_down(self):
+        config = dict(CONFIG, refresh_minutes=2)
+        assert build_view(config, payload("2026-09-03"), TODAY)["reload_seconds"] == 120
+
+    def test_the_waiting_screen_asks_more_often(self):
+        # Nothing to show yet, so fill the screen in a minute rather than five.
+        assert build_view(CONFIG, None, TODAY)["reload_seconds"] == 60
+
+    def test_an_unreadable_interval_falls_back_to_five_minutes(self):
+        config = dict(CONFIG, refresh_minutes="hourly")
+        assert build_view(config, payload("2026-09-03"), TODAY)["reload_seconds"] == 300

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -243,3 +243,176 @@ class TestTheClockOnTheStatusLine:
         board({"generated_for_date": today, "generated_at": "who knows",
                "headline": "Hi", "note": "There", "events": []})
         assert "written earlier" in client.get("/settings/").get_data(as_text=True)
+
+
+CADENCE_CONFIG = """\
+# What the family is called.
+family_name: "The Wilsons"
+timezone: "Europe/Berlin"
+
+# How often --tick re-fetches the calendars.
+refresh_minutes: 60
+
+# When --tick writes the daily brief, on your own clock.
+brief_time: "06:00"
+
+people:
+  - id: mia12345
+    name: "Mia"
+    date_of_birth: "2017-03-15"
+"""
+
+
+class TestTheCadencePage:
+    """The two keys decision 11 added, edited from a phone rather than in YAML."""
+
+    @pytest.fixture
+    def config_path(self, tmp_path, monkeypatch):
+        path = tmp_path / "config.yaml"
+        path.write_text(CADENCE_CONFIG)
+        monkeypatch.setenv("DINKYDASH_CONFIG", str(path))
+        return path
+
+    def test_the_page_is_not_swallowed_by_the_section_routes(self, client):
+        # `/settings/<section_name>` would match "refresh" too.
+        assert client.get("/settings/refresh").status_code == 200
+
+    def test_it_opens_on_what_the_file_says(self, client):
+        page = client.get("/settings/refresh").get_data(as_text=True)
+        assert '<option value="60" selected>Every hour</option>' in page
+        assert 'value="06:00"' in page
+
+    def test_it_offers_the_five_intervals(self, client):
+        page = client.get("/settings/refresh").get_data(as_text=True)
+        for label in ("Every 15 minutes", "Every 30 minutes", "Every hour",
+                      "Every 6 hours", "Once a day"):
+            assert f">{label}</option>" in page
+
+    def test_saving_both_writes_them_back(self, client, config_path):
+        client.post("/settings/refresh",
+                    data={"refresh_minutes": "15", "brief_time": "07:30"})
+        config = config_module.load_config(config_path)
+        assert config["refresh_minutes"] == 15
+        assert config["brief_time"] == "07:30"
+
+    def test_a_save_changes_exactly_the_two_lines_it_means_to(self, client, config_path):
+        before = config_path.read_text().splitlines()
+        client.post("/settings/refresh",
+                    data={"refresh_minutes": "1440", "brief_time": "07:30"})
+        after = config_path.read_text().splitlines()
+
+        changed = [(a, b) for a, b in zip(before, after) if a != b]
+        assert changed == [
+            ("refresh_minutes: 60", "refresh_minutes: 1440"),
+            ('brief_time: "06:00"', 'brief_time: "07:30"'),
+        ]
+        # The comments introducing them are what a self-hoster reads.
+        assert "# How often --tick re-fetches the calendars." in "\n".join(after)
+        assert "# When --tick writes the daily brief, on your own clock." in "\n".join(after)
+
+    def test_the_brief_time_stays_quoted(self, config_path, client):
+        # Bare 07:30 is a string to ruamel and a sexagesimal integer to a YAML
+        # 1.1 parser. The file is edited by hand, so it keeps its quotes.
+        client.post("/settings/refresh",
+                    data={"refresh_minutes": "60", "brief_time": "07:30"})
+        assert 'brief_time: "07:30"' in config_path.read_text()
+
+    def test_seconds_from_a_time_input_are_trimmed(self, client, config_path):
+        client.post("/settings/refresh",
+                    data={"refresh_minutes": "60", "brief_time": "07:30:00"})
+        assert config_module.load_config(config_path)["brief_time"] == "07:30"
+
+    def test_an_interval_that_was_not_offered_is_refused(self, client, config_path):
+        page = client.post("/settings/refresh",
+                           data={"refresh_minutes": "7", "brief_time": "07:30"})
+        assert "Pick one of the calendar intervals offered." in page.get_data(as_text=True)
+        assert config_module.load_config(config_path)["refresh_minutes"] == 60
+
+    def test_a_time_that_is_not_a_time_is_refused(self, client, config_path):
+        page = client.post("/settings/refresh",
+                           data={"refresh_minutes": "15", "brief_time": "breakfast"})
+        assert "should look like 06:00" in page.get_data(as_text=True)
+        # Neither key is written when either is wrong.
+        config = config_module.load_config(config_path)
+        assert (config["refresh_minutes"], config["brief_time"]) == (60, "06:00")
+
+    def test_a_rejected_form_shows_back_what_was_typed(self, client):
+        page = client.post("/settings/refresh",
+                           data={"refresh_minutes": "15", "brief_time": "breakfast"})
+        assert 'value="breakfast"' in page.get_data(as_text=True)
+
+    def test_a_hand_edited_interval_is_offered_rather_than_overwritten(self, client, config_path):
+        config_path.write_text(CADENCE_CONFIG.replace("refresh_minutes: 60",
+                                                      "refresh_minutes: 45"))
+        page = client.get("/settings/refresh").get_data(as_text=True)
+        assert '<option value="45" selected>Every 45 minutes</option>' in page
+        # And saving it back keeps it, rather than snapping to the nearest offer.
+        client.post("/settings/refresh", data={"refresh_minutes": "45", "brief_time": "06:00"})
+        assert config_module.load_config(config_path)["refresh_minutes"] == 45
+
+
+class TestTheCadenceOnTheHomePage:
+    @pytest.fixture
+    def config_path(self, tmp_path, monkeypatch):
+        path = tmp_path / "config.yaml"
+        path.write_text(CADENCE_CONFIG)
+        monkeypatch.setenv("DINKYDASH_CONFIG", str(path))
+        return path
+
+    def test_the_row_says_both_cadences(self, client):
+        page = client.get("/settings/").get_data(as_text=True)
+        assert "Calendars every hour · brief at 06:00" in page
+        assert 'href="/settings/refresh"' in page
+
+    def test_it_follows_what_was_saved(self, client):
+        client.post("/settings/refresh", data={"refresh_minutes": "1440", "brief_time": "07:30"})
+        page = client.get("/settings/").get_data(as_text=True)
+        assert "Calendars once a day · brief at 07:30" in page
+
+
+class TestRefreshingTheCalendarsByHand:
+    """The cheap half of "Rewrite now": fetch the feeds, ask Claude nothing."""
+
+    @pytest.fixture
+    def refreshed(self, monkeypatch):
+        """Stub the runner, so the test touches neither the network nor a key."""
+        calls = []
+
+        def fake(config, base=None, **kwargs):
+            calls.append(config)
+            return {"events": [1, 2, 3], "calendar_statuses": [{"label": "Family", "ok": True}]}
+
+        monkeypatch.setattr("web.routes.settings.refresh_calendars", fake)
+        return calls
+
+    def test_the_button_posts_to_the_refresh_route(self, client):
+        page = client.get("/settings/").get_data(as_text=True)
+        assert 'action="/settings/refresh-now"' in page
+        assert "Refresh calendars" in page
+
+    def test_it_reports_what_it_found(self, client, refreshed):
+        page = client.post("/settings/refresh-now", follow_redirects=True)
+        assert "Calendars refreshed — 3 events over the next 14 days." in \
+            page.get_data(as_text=True)
+        assert len(refreshed) == 1
+
+    def test_a_broken_feed_is_named_without_its_url(self, client, monkeypatch):
+        secret = "https://calendar.google.com/calendar/ical/private-abc123/basic.ics"
+
+        def fake(config, base=None, **kwargs):
+            return {"events": [],
+                    "calendar_statuses": [{"label": "Dad's", "ok": False, "error": secret}]}
+
+        monkeypatch.setattr("web.routes.settings.refresh_calendars", fake)
+        page = client.post("/settings/refresh-now", follow_redirects=True).get_data(as_text=True)
+        assert "1 didn&#39;t answer: Dad&#39;s." in page
+        assert "private-abc123" not in page
+
+    def test_a_failure_flashes_rather_than_500s(self, client, monkeypatch):
+        def explode(config, base=None, **kwargs):
+            raise OSError("the disk is full")
+
+        monkeypatch.setattr("web.routes.settings.refresh_calendars", explode)
+        page = client.post("/settings/refresh-now", follow_redirects=True)
+        assert page.status_code == 200
+        assert "Could not refresh the calendars: the disk is full" in page.get_data(as_text=True)

--- a/web/routes/settings.py
+++ b/web/routes/settings.py
@@ -9,15 +9,17 @@ comments in the file survive being edited from a phone.
 """
 
 import logging
-from datetime import datetime, timezone
+from datetime import datetime, time, timezone
 
 from flask import (Blueprint, abort, current_app, flash, redirect,
                    render_template, request, url_for)
 
 from dinkydash import config as config_module
+from dinkydash import schedule
 from dinkydash.calendars import FeedError, describe_feed
 from dinkydash.claude_client import GenerationError
 from dinkydash.context import compute_birthday_info, upcoming_for
+from dinkydash.runner import refresh_calendars
 from dinkydash.runner import run as run_generation
 from web import manifest as manifest_module
 
@@ -108,6 +110,12 @@ EMOJI_SUGGESTIONS = {
 
 MONTHS = ["January", "February", "March", "April", "May", "June", "July",
           "August", "September", "October", "November", "December"]
+
+# How often the calendars are re-fetched. A short list rather than a free
+# number: the useful range is bounded at both ends, and Google's own feed is
+# cached, so anything under a quarter of an hour would be a promise we cannot
+# keep. The engine takes any integer — these are what the page offers.
+REFRESH_CHOICES = (15, 30, 60, 360, 1440)
 
 
 def current_config():
@@ -201,7 +209,7 @@ def home():
     }
     return render_template(
         "settings/home.html", config=config, status=status, counts=counts,
-        broken=broken, sections=SECTIONS,
+        broken=broken, sections=SECTIONS, cadence=cadence_summary(config),
     )
 
 
@@ -394,6 +402,107 @@ def screen():
             flash(f"Board set to {theme}.", "ok")
         return redirect(url_for("settings.screen"))
     return render_template("settings/screen.html", config=config, themes=config_module.THEMES)
+
+
+def describe_minutes(minutes):
+    """An interval as the page says it — "Every hour", not "60"."""
+    if minutes == 1440:
+        return "Once a day"
+    if minutes >= 60 and minutes % 60 == 0:
+        hours = minutes // 60
+        return "Every hour" if hours == 1 else f"Every {hours} hours"
+    return "Every minute" if minutes == 1 else f"Every {minutes} minutes"
+
+
+def cadence_choices(current):
+    """The offered intervals, plus whatever the file already says if it differs.
+
+    A hand-edited `refresh_minutes: 45` is a real setting, and a select that
+    could not show it would silently rewrite it the first time anyone saved.
+    """
+    minutes = sorted(set(REFRESH_CHOICES) | {current})
+    return [(m, describe_minutes(m)) for m in minutes]
+
+
+def cadence_values(config):
+    """The two keys as the form wants them — an int and an "HH:MM" string."""
+    return {
+        "refresh_minutes": int(schedule.refresh_interval(config).total_seconds() // 60),
+        "brief_time": schedule.brief_time(config).strftime("%H:%M"),
+    }
+
+
+def cadence_summary(config):
+    """The one line the settings home shows: "Calendars every hour · brief at 06:00"."""
+    values = cadence_values(config)
+    cadence = describe_minutes(values["refresh_minutes"])
+    return (f"Calendars {cadence[:1].lower()}{cadence[1:]} · "
+            f"brief at {values['brief_time']}")
+
+
+@bp.route("/refresh", methods=["GET", "POST"])
+def refresh():
+    """The two cadences: how often the calendars are fetched, and when the brief is written."""
+    config = current_config()
+    stored = cadence_values(config)
+    choices = cadence_choices(stored["refresh_minutes"])
+    allowed = {m for m, _ in choices}
+    values, problems = stored, []
+
+    if request.method == "POST":
+        # Show back what was submitted, not what is still on disk.
+        values = {
+            "refresh_minutes": request.form.get("refresh_minutes", "").strip(),
+            "brief_time": request.form.get("brief_time", "").strip(),
+        }
+        minutes, brief = None, None
+        try:
+            minutes = int(values["refresh_minutes"])
+        except ValueError:
+            pass
+        if minutes not in allowed:
+            problems.append("Pick one of the calendar intervals offered.")
+        try:
+            # <input type="time"> posts "HH:MM", but "HH:MM:SS" with a step set.
+            brief = time.fromisoformat(values["brief_time"]).strftime("%H:%M")
+        except ValueError:
+            problems.append("The time the brief is written should look like 06:00.")
+
+        if not problems:
+            config["refresh_minutes"] = minutes
+            config["brief_time"] = config_module.quoted(brief)
+            save(config)
+            flash("Saved.", "ok")
+            return redirect(url_for("settings.refresh"))
+
+    return render_template(
+        "settings/refresh.html", config=config, values=values,
+        problems=problems, choices=choices,
+    )
+
+
+@bp.route("/refresh-now", methods=["POST"])
+def refresh_now():
+    """Fetch the calendars and nothing else — the free half of "Rewrite now"."""
+    config = current_config()
+    try:
+        payload = refresh_calendars(config, base=current_app.config["CONFIG_PATH"].parent)
+    except Exception as exc:  # a broken feed or an unwritable file shouldn't 500 the UI
+        log.exception("Calendar refresh failed")
+        flash(f"Could not refresh the calendars: {exc}", "error")
+        return redirect(url_for("settings.home"))
+
+    count = len(payload.get("events") or [])
+    days = int(config.get("calendar_days_ahead") or 14)
+    broken = [s for s in payload.get("calendar_statuses") or [] if s.get("ok") is False]
+    message = f"Calendars refreshed — {count} event{'' if count == 1 else 's'} over the next {days} days."
+    if broken:
+        # Named, because "which one" is the first thing anybody asks. The URL
+        # stays out of it: it is a password.
+        message += (f" {len(broken)} didn't answer: "
+                    f"{', '.join(sorted(s['label'] for s in broken))}.")
+    flash(message, "error" if broken else "ok")
+    return redirect(url_for("settings.home"))
 
 
 @bp.route("/system", methods=["GET", "POST"])

--- a/web/templates/board.html
+++ b/web/templates/board.html
@@ -14,7 +14,7 @@
     <title>{{ view.family_name or "DinkyDash" }}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
     <meta name="robots" content="noindex, nofollow">
-    <meta http-equiv="refresh" content="{{ 60 if view.state == 'waiting' else 300 }}">
+    <meta http-equiv="refresh" content="{{ view.reload_seconds }}">
     <link rel="icon" href="{{ url_for('static', filename='favicon.svg') }}" type="image/svg+xml">
     <!-- On a tablet used as the panel, saving this to the home screen gives a
          full-screen board with no browser around it. -->

--- a/web/templates/settings/base.html
+++ b/web/templates/settings/base.html
@@ -119,7 +119,7 @@
         .field { display: flex; flex-direction: column; gap: 0.375rem; }
         .field > label { font-size: 0.6875rem; font-weight: 800; letter-spacing: 0.07em; text-transform: uppercase; color: var(--text-muted); }
         .field input[type=text], .field input[type=url], .field input[type=date],
-        .field select, .field textarea {
+        .field input[type=time], .field select, .field textarea {
             width: 100%; min-height: 3rem; padding: 0.75rem 0.875rem;
             border: 1.5px solid var(--border); border-radius: 0.75rem;
             background: var(--surface); color: var(--text);

--- a/web/templates/settings/home.html
+++ b/web/templates/settings/home.html
@@ -16,11 +16,18 @@
             <span style="font-size:0.8125rem;color:var(--text-mid);">{{ status.detail }}</span>
         </div>
     </div>
-    <div style="display:flex;gap:0.625rem;">
-        <a class="btn outline" style="flex:1;" href="{{ url_for('board.index') }}">{{ icons.screen() }} View board</a>
-        <form class="inline-form" method="post" action="{{ url_for('settings.generate_now') }}" style="flex:1;">
-            <button class="btn" type="submit">{{ icons.refresh() }} Rewrite now</button>
+    <div style="display:flex;flex-direction:column;gap:0.625rem;">
+        {# The cheap half first: fetching the calendars costs a few requests,
+           while rewriting the line costs a call to Claude. #}
+        <form class="inline-form" method="post" action="{{ url_for('settings.refresh_now') }}">
+            <button class="btn" type="submit">{{ icons.refresh() }} Refresh calendars</button>
         </form>
+        <div style="display:flex;gap:0.625rem;">
+            <a class="btn outline" style="flex:1;" href="{{ url_for('board.index') }}">{{ icons.screen() }} View board</a>
+            <form class="inline-form" method="post" action="{{ url_for('settings.generate_now') }}" style="flex:1;">
+                <button class="btn outline" type="submit">Rewrite now</button>
+            </form>
+        </div>
     </div>
 </div>
 
@@ -76,6 +83,12 @@
             <div class="row-main">
                 <div class="row-title">Colours</div>
                 <div class="row-sub">{{ config.theme | capitalize }}</div>
+            </div>{{ icons.chevron() }}
+        </a>
+        <a class="row" href="{{ url_for('settings.refresh') }}">
+            <div class="row-main">
+                <div class="row-title">How often it updates</div>
+                <div class="row-sub">{{ cadence }}</div>
             </div>{{ icons.chevron() }}
         </a>
         <a class="row" href="{{ url_for('settings.system') }}">

--- a/web/templates/settings/refresh.html
+++ b/web/templates/settings/refresh.html
@@ -47,7 +47,8 @@
 </div>
 
 <div class="note-box">
-    Both need <strong>generate.py --tick</strong> running from cron every five minutes. The setup
-    guide has the line. Without it, nothing updates on its own however this page is set.
+    Both need <strong>generate.py --tick</strong> in your crontab, every five minutes. If yours
+    still says <strong>0 6 * * *</strong> without <strong>--tick</strong> — the line older setup
+    guides gave — nothing on this page has any effect, and the board updates once at 6am as before.
 </div>
 {% endblock %}

--- a/web/templates/settings/refresh.html
+++ b/web/templates/settings/refresh.html
@@ -1,0 +1,53 @@
+{% extends "settings/base.html" %}
+{% import "settings/_icons.html" as icons %}
+{% block title %}How often it updates{% endblock %}
+
+{% block appbar %}
+<a class="back" href="{{ url_for('settings.home') }}">{{ icons.back() }}</a>
+<h1>How often it updates</h1>
+<button class="action" type="submit" form="refresh-form">Save</button>
+{% endblock %}
+
+{% block content %}
+{% if problems %}
+<ul class="problems">
+    {% for problem in problems %}<li>{{ problem }}</li>{% endfor %}
+</ul>
+{% endif %}
+
+<form id="refresh-form" method="post" class="card pad" style="display:flex;flex-direction:column;gap:1rem;">
+    <div class="field">
+        <label for="refresh_minutes">Fetch the calendars</label>
+        <select id="refresh_minutes" name="refresh_minutes">
+            {% for minutes, label in choices %}
+            <option value="{{ minutes }}"{{ ' selected' if minutes|string == values.refresh_minutes|string }}>{{ label }}</option>
+            {% endfor %}
+        </select>
+        <div class="hint">
+            How soon an appointment added on your phone reaches the board. Google's calendar links
+            are themselves cached and can lag by a few hours, so shorter is not always sooner.
+        </div>
+    </div>
+
+    <div class="field">
+        <label for="brief_time">Write the daily line at</label>
+        <input type="time" id="brief_time" name="brief_time" value="{{ values.brief_time }}" required>
+        <div class="hint">
+            Written once a day, on your clock — {{ config.timezone }}. Press
+            <strong>Rewrite now</strong> if you want a fresh one sooner.
+        </div>
+    </div>
+
+    <button class="btn" type="submit">Save</button>
+</form>
+
+<div class="note-box">
+    Fetching the calendars costs nothing but a few requests, so it can be as often as you like.
+    The daily line is the part that costs money: one call to Claude, once a day.
+</div>
+
+<div class="note-box">
+    Both need <strong>generate.py --tick</strong> running from cron every five minutes. The setup
+    guide has the line. Without it, nothing updates on its own however this page is set.
+</div>
+{% endblock %}

--- a/web/templates/settings/screen.html
+++ b/web/templates/settings/screen.html
@@ -42,7 +42,8 @@
 
 <div class="note-box">
     The board lives at <strong>{{ url_for('board.index', _external=True) }}</strong> — open that on the
-    TV, tablet or Pi and leave the page up. It refreshes itself every five minutes.
+    TV, tablet or Pi and leave the page up. It redraws itself on its own; how often is under
+    <a href="{{ url_for('settings.refresh') }}">How often it updates</a>.
 </div>
 
 <div class="note-box">

--- a/website/content/getting-started.md
+++ b/website/content/getting-started.md
@@ -278,9 +278,12 @@ sudo systemctl enable dinkydash.service
 sudo systemctl start dinkydash.service
 ```
 
-### Step 6: Generate a fresh board every morning
+### Step 6: Keep the board up to date
 
-A cron job writes a new board at 6am. If a run fails, the previous board stays up and labels itself stale — the screen never goes blank.
+A cron job ticks every five minutes, and each tick does only what your settings say is owed —
+nothing at all, most of the time. Calendars are re-fetched every hour, so an appointment added at
+09:00 for 15:00 reaches the board the same afternoon. The daily line is written once, at 6am. Both
+are yours to change under **Settings → How often it updates**.
 
 ```bash
 crontab -e
@@ -289,8 +292,21 @@ crontab -e
 Add this line:
 
 ```cron
+*/5 * * * * cd /home/pi/dinkydash && venv/bin/python generate.py --tick >> generate.log 2>&1
+```
+
+Runs never pile up: if one is still going when the next is due, the next skips itself. If a run
+fails, the previous board stays up and labels itself stale — the screen never goes blank, and the
+next tick tries again.
+
+The old daily line still works, and does the fetch and the line together:
+
+```cron
 0 6 * * * cd /home/pi/dinkydash && venv/bin/python generate.py >> generate.log 2>&1
 ```
+
+It just never sees a change you make to your calendar during the day, and the settings above have
+no effect on it. Use one line or the other, not both.
 
 ### Step 7: Show the board full screen at boot (kiosk)
 


### PR DESCRIPTION
DIN-17 shipped the engine half of PLAN.md decision 11, but `refresh_minutes` and `brief_time` could only be changed by editing `config.yaml` by hand — so this adds `/settings/refresh`, where a parent picks how often the calendars are fetched and what time the daily line is written, plus a **Refresh calendars** button on the settings home that does the free half of **Rewrite now** and names a failing feed by its label rather than its URL.

The select also offers whatever the file already says if that is not one of the five intervals, so a hand-edited `refresh_minutes: 45` survives somebody opening the page and pressing Save; `brief_time` is written through a new `config.quoted()`, because a bare `06:00` is a string to ruamel and a sexagesimal integer to a YAML 1.1 parser; and the board's reload is now derived rather than hard-coded in the template (`board.reload_seconds`), with five minutes still the ceiling.

**Review turned up a live docs bug, fixed in the second and third commits:** DIN-17 updated the README's cron line to `generate.py --tick` but missed the marketing site's own copy, so dinkydash.co/getting-started/ has been installing `0 6 * * * generate.py` ever since — meaning this whole feature would do nothing for anyone who followed the public guide. The guide now leads with the tick line, and the settings page no longer claims the guide has it.

23 new tests (250 total, all passing); saving 15/07:30 through the running app changes exactly the two lines it means to, the meta refresh really renders 300 / 120 / 60 in the three cases, and both pages were checked at 375x812 in an iframe of exactly that size rather than trusting `--window-size`. The six unrelated `docs/` pages move only their date stamps, which the build takes from each page's last commit date — they were a build cycle behind #52 and #53.

Known and deliberately not fixed here: the settings buttons write `dashboard_data.json` without taking the tick's `flock`, so a press during a tick's model call can be silently discarded. **Rewrite now** has had the same exposure since it existed, and the fix needs to cover both — filed as DIN-28.

🤖 Generated with [Claude Code](https://claude.com/claude-code)