### PR TITLE
Make deploy_to_pi.sh run on macOS 15, and correct two stale notes (DIN-20)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,16 +161,20 @@ Two things the net does not catch, both worth knowing before trusting it:
 
 **`.env` should hold `ANTHROPIC_API_KEY` and nothing else.** `FLASK_ENV`, `SECRET_KEY`,
 `DATABASE_URL`, `UPLOAD_FOLDER` and `MAX_CONTENT_LENGTH` are leftovers from an abandoned plan and
-none of them is read by any code. They have been stripped from this worktree's copy, but `.env` is
-not in git, so every other copy has to be edited where it lives — the main checkout, and the Pi,
-whose `.env` `deploy_to_pi.sh` no longer overwrites. Do not put `SECRET_KEY` back: nothing calls `from_prefixed_env`, so
-Flask never sees it, and the session key comes from `DINKYDASH_SECRET_KEY` or the hardcoded fallback
-whatever `.env` says.
+none of them is read by any code — a grep over the repo returns only `web/__init__.py`, and that
+reads `DINKYDASH_SECRET_KEY`, a different name. **They are all still there**, as of 7 September 2026:
+in the main checkout, on the Pi, and in every new worktree. `.env` is not in git, so stripping it in
+a worktree dies with that worktree, and the next workspace is seeded from the main checkout again —
+which is why an earlier note here claiming they had been stripped did not stay true. Every copy has
+to be edited where it lives, including the Pi's, whose `.env` `deploy_to_pi.sh` does not overwrite.
+Do not put `SECRET_KEY` back: nothing calls `from_prefixed_env`, so Flask never sees it, and the
+session key comes from `DINKYDASH_SECRET_KEY` or the hardcoded fallback whatever `.env` says.
 
-The Anthropic key is still not rotated after living on a Pi and having been rsynced. That is the
-one Phase 0 item still open, and CI cannot do it: revoke the key in the Anthropic console, then
-write the new one into `.env` in the main checkout and on the Pi, in place. `deploy_to_pi.sh`
-excludes `.env`, so pushing one copy over the other is not an option and is not meant to be.
+**The Anthropic key was rotated on 7 September 2026** (DIN-20), after living on a Pi and having
+been rsynced. The old key now reads 401 from the API; the new one is in `.env` in the main checkout
+and on the Pi, written in place. CI could not have done it, and a future rotation is the same manual
+job: revoke in the Anthropic console, then edit each copy where it lives. `deploy_to_pi.sh` excludes
+`.env`, so pushing one copy over the other is not an option and is not meant to be.
 
 **`requirements.txt` and `requirements-dev.txt` are pinned with `==`** to the versions CI passes on,
 so a clean venv gets what was tested. Bump deliberately, and check the release notes: `anthropic`

--- a/deploy_to_pi.sh
+++ b/deploy_to_pi.sh
@@ -32,7 +32,11 @@ $SSH "$REMOTE" "mkdir -p '$PI_DIR'"
 # with --delete, from being removed: the settings and data written on the Pi
 # (config.yaml, dashboard_data.json, content_history.json, generate.log), the
 # API key (.env), the virtualenv, and the build- and dev-only trees.
-rsync -az --info=stats1 --delete $DRY_RUN \
+#
+# --stats rather than --info=stats1: macOS 15 replaced rsync with openrsync,
+# which speaks protocol 29 and rejects --info outright. --stats is understood by
+# both, and by rsync 2.6.9 before it.
+rsync -az --stats --delete $DRY_RUN \
     --exclude='.git/' \
     --exclude='venv/' \
     --exclude='__pycache__/' \


### PR DESCRIPTION
## The bug

`deploy_to_pi.sh` could not deploy from a current Mac. macOS 15 replaced GNU rsync with **openrsync**, which speaks protocol 29 and rejects `--info=stats1` outright — the script printed a usage block, exited, and copied nothing. It was not a warning; nothing reached the Pi.

`--stats` is understood by openrsync, by rsync 3.x, and by the 2.6.9 that shipped before it. Same numbers, less terse. A comment above the line says why, so nobody tidies it back.

## Two stale notes in CLAUDE.md

Both would have misled the next reader — one by sending them after finished work, the other by reassuring them about work that never happened.

**The Anthropic key is rotated** (DIN-20, today). CLAUDE.md still called it "the one Phase 0 item still open". The old key now returns 401 from the API; the new one is in `.env` in the main checkout and on the Pi, written in place.

**The dead `.env` keys were never actually stripped.** CLAUDE.md said they "have been stripped from this worktree's copy". `FLASK_ENV`, `SECRET_KEY`, `DATABASE_URL`, `UPLOAD_FOLDER` and `MAX_CONTENT_LENGTH` are present in the main checkout, on the Pi, and in every new worktree. The reason is structural and worth writing down: `.env` is not in git, so stripping it inside a worktree dies with that worktree, and Conductor seeds the next workspace from the main checkout again. The note now says they are still there, and why the earlier claim decayed.

## Testing

- `venv/bin/python -m pytest tests/ -q` — 250 passed
- `bash -n deploy_to_pi.sh` — clean
- Dry run against the real Pi with `--stats`: 59 files, 50 to transfer, and the file-level diff confirmed `--delete` would remove nothing (the Pi's extra files are all under `design/`, `docs/`, `website/` and `tests/`, which are excluded, and rsync protects excluded paths from deletion)
- Real deploy ran end to end: code landed, `pip install` succeeded, `dinkydash.service` restarted, and `.env`, `config.yaml`, `dashboard_data.json` and `content_history.json` all survived untouched

## Not in this PR

`PLAN.md`'s "Small jobs, big return" list has at least items 1, 2, 3, 4 and 9 done and none of them ticked. Marking only the key rotation would imply the others are outstanding, so the list wants one pass rather than one line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
