### PR TITLE
Name the storage seam: gather the file I/O into a FileStore (DIN-19)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -228,9 +228,10 @@ dinkydash/
 ├── generate.py        orchestrator: config + date + events -> payload
 ├── board.py           payload + config -> what the template renders
 ├── config.py          config.yaml load/save (ruamel round-trip), item ids
-├── history.py         rolling record of recent notes, to avoid repeats
+├── history.py         what the recent notes say, and how they trim (pure)
 ├── schedule.py        due(config, payload, now) -> what a tick owes (pure)
-└── runner.py          the one place that does I/O around the engine
+├── store.py           the six storage operations; FileStore is the only one yet
+└── runner.py          the two halves of the day, reading and writing through a store
 
 web/
 ├── __init__.py        create_app()
@@ -238,6 +239,32 @@ web/
 ├── routes/settings.py the settings UI (one table drives every list section)
 └── templates/         board.html, preview.html, settings/*.html
 ```
+
+### The storage seam
+
+Six operations, on one object, and nothing above them knows what is behind it:
+
+```python
+load_config()                save_config(config)
+load_payload(config)         save_payload(config, payload)
+recent_notes(config, days)   record_note(config, entry, keep)
+```
+
+`FileStore(config_path)` is the only implementation today — `config.yaml` and two JSON files in one
+directory. `PostgresStore` is the cloud one, where the payload is composed from two rows and comes
+back as the same dict (PLAN.md decision 10). The runner, the board route and the settings routes all
+take a store; `create_app(store=None)` builds one and every route reads `app.config["STORE"]`.
+
+Three rules keep it a seam rather than a name:
+
+- **`store.py` and `config.py` are the only files under `dinkydash/` that open a file.** `grep -rn
+  "open(" dinkydash web` is the check, and it should stay that short. A new file read anywhere else
+  is a caller that cloud mode will have to fork.
+- **`data_file` and `content_history_file` are storage-layer keys.** They stay in `DEFAULTS` and in
+  `config.example.yaml` for compatibility, and only `FileStore` reads them. They mean nothing hosted.
+- **The store is passed, never constructed, below the entry points.** `generate.py`, `app.py` and
+  `sample_board.py` build one; everything else is handed it. That is what makes a second
+  implementation a constructor argument rather than an edit.
 
 ### What the payload holds, and what it does not
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -2,6 +2,8 @@
 
 *Last updated: September 7, 2026. Supersedes `HOSTING_ANALYSIS.md` (deleted — it predated both the AI generation feature and the July 2026 calendar-display repositioning, and its recommended stack and data model no longer matched the product).*
 
+*September 7, later: the storage seam is built (DIN-19). `dinkydash/store.py` holds the six operations, `FileStore` is the one implementation, and the runner and both blueprints take a store rather than a path. The seam section below describes what exists; `PostgresStore` is now a constructor argument away.*
+
 *September 7 changes: the host is settled — decision 12, DigitalOcean App Platform in Frankfurt with DigitalOcean Managed Postgres and Cloudflare in front. The "Which host?" open question is closed, the hosting section is rewritten around it, DNS gets its own Phase 0 line, and the Compose file's job changes: the shared artefact between the two modes is now the **Dockerfile**, not `docker-compose.yml`.*
 
 *September 6 changes: decision 11 (the refresh cadence is a setting), a storage seam for the payload and history, a hosting and deployment recommendation, the Batch API deferred, and the phases re-sequenced so the Docker Compose file arrives first rather than last.*
@@ -87,12 +89,12 @@ else's edit form.
 
 ### The storage seam
 
-Decision 10 covers the config. The runtime writes two more things — the
-payload and the note history — and today those are file calls scattered across
-`web/__init__.py` (`load_payload`), `runner.py` (`write_payload`) and
-`history.py` (`load_history`, `record`). Cloud mode needs the same operations
-against Postgres, so name them before Phase 1 rather than discovering them
-during it:
+*Built in DIN-19.* Decision 10 covers the config. The runtime writes two more
+things — the payload and the note history — and those used to be file calls
+scattered across `web/__init__.py` (`load_payload`), `runner.py`
+(`write_payload`) and `history.py` (`load_history`, `record`). Cloud mode needs
+the same operations against Postgres, so they were named before Phase 1 rather
+than discovered during it:
 
 ```
 load_config   / save_config
@@ -100,17 +102,22 @@ load_payload  / save_payload
 recent_notes  / record_note
 ```
 
-One object with those six methods. `FileStore` is what exists now, just
-gathered up; `PostgresStore` is the cloud one. `board.build_view`, the runner
-and the settings routes take a store and never learn which. In single mode the
+One object with those six methods, in `dinkydash/store.py`. `FileStore` is what
+exists now, gathered up; `PostgresStore` is the cloud one. The runner, the board
+route and the settings routes take a store and never learn which — `create_app`
+accepts one, and every route reads `app.config["STORE"]`. In single mode the
 payload is `dashboard_data.json`. In cloud mode it is composed from two rows —
 the brief in `generations`, the fetched calendar window in `agendas` — and
 comes back as the same dict.
 
-`data_file` and `content_history_file` are storage-layer keys that have been
+`data_file` and `content_history_file` are storage-layer keys that had been
 living in the family's config dict. They mean nothing in cloud mode. The store
 owns them; they stay in `config.yaml` for compatibility and nothing else reads
 them.
+
+`store.py` and `config.py` are now the only files under `dinkydash/` that open
+a file. That is the invariant to keep: a read anywhere else is a caller cloud
+mode would have to fork.
 
 ### Three clocks, one setting
 
@@ -186,8 +193,10 @@ dinkydash/                  # the engine — pure, no clock, no file reads
 ├── generate.py             # orchestrator: config + date + events -> payload
 ├── board.py                # payload + config -> what the template renders
 ├── config.py               # the config dict: load, save, defaults, migrations, ids
-├── history.py              # rolling record of recent notes, to avoid repeats
-└── runner.py               # the one place that does I/O around the engine
+├── history.py              # what the recent notes say, and how they trim (pure)
+├── schedule.py             # due(config, payload, now) -> what a tick owes (pure)
+├── store.py                # the six storage operations; FileStore today
+└── runner.py               # the two halves of the day, over a store
 
 web/
 ├── __init__.py             # create_app()
@@ -522,7 +531,7 @@ Critical path is 0 → 1 → 2 → 3. Phases 4–6 can run alongside 3. Nothing 
 - [x] Update the Claude model; switch to structured outputs *(#28 — `claude-haiku-4-5` takes no `thinking` parameter, so leaving it unset is the explicit choice)*
 - [ ] The small jobs above: CI, `gitleaks`, push protection, `.env.example`, pinned requirements, key rotation *(DIN-16)*; self-hosted font, URL scrub, referrer policy, `/healthz`. The `Dockerfile` has its own line below.
 - [x] **Decision 11, single-mode half:** `refresh_minutes` and `brief_time` in `DEFAULTS`; `runner.run` split into `refresh_calendars` and `write_brief`; a pure `due()`; `generate.py --tick`; the settings page under *This screen*; the board's reload derived from the interval; README cron line updated. Ships to the Pi at once and needs no database. *(DIN-17 for the engine and cron, DIN-18 for the page)*
-- [ ] Name the storage seam: `FileStore` gathering the six operations that exist today, and the settings routes, runner and board taking a store *(DIN-19)*
+- [x] Name the storage seam: `FileStore` gathering the six operations that exist today, and the settings routes, runner and board taking a store *(DIN-19)*
 - [ ] `Dockerfile` and `docker-compose.yml` for single mode (`web` only) — the self-host path is real from here on, the image is what App Platform builds, and every later phase reuses both *(DIN-30)*
 - [ ] Postgres + plain-SQL migrations; CI running the suite against a Postgres service container *(DIN-31)*
 - [ ] Move DNS to Cloudflare and add the `app` and `staging.app` records *(DIN-29)*. The apex keeps pointing at GitHub Pages until DIN-27 moves the marketing pages onto the app.

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ pip install -r requirements-dev.txt   # adds pytest and the website build; not n
 python -m pytest tests/ -q
 ```
 
-227 tests, well under a second. They cover leap years, timezone conversion, event ordering, chore
+264 tests, well under a second. They cover leap years, timezone conversion, event ordering, chore
 rotation, the stale-board logic, the config round-trip, and the settings routes that write it.
 
 GitHub Actions runs the same command on every push and pull request, on Python 3.11
@@ -630,13 +630,14 @@ tail -f /home/pi/dinkydash/generate.log   # last night's generation
 | `dinkydash/board.py` | Turns config + payload into what the board renders |
 | `dinkydash/runner.py` | The two halves of the cycle: `refresh_calendars` and `write_brief` |
 | `dinkydash/schedule.py` | `due()` — which of the two the clock and the config owe right now |
+| `dinkydash/store.py` | Where the config, the board and the note history are kept |
 | `web/` | Flask app — board, settings UI, templates |
 | `web/templates/board.html` | The board itself, light and dark, all screen sizes |
 | `generate.py` | Command-line skin over `dinkydash.runner` — this is what cron calls |
 | `app.py` | Flask entry point |
 | `config.yaml` | All configuration. The settings UI writes this same file |
 | `config.example.yaml` | Template config, documenting every key |
-| `tests/` | 227 tests. Run them before committing |
+| `tests/` | 264 tests. Run them before committing |
 | `design/` | Mockups for the board and settings UI, with the reasoning |
 | `deploy_to_pi.sh` | Deployment (rsync + service restart) |
 | `.env` | `ANTHROPIC_API_KEY` (not in git) |

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -89,5 +89,9 @@ refresh_minutes: 60
 # 06:00 is a number in older YAML. One brief a day; "Rewrite now" covers the rest.
 brief_time: "06:00"
 
+# Where the generated board and the record of recent notes are kept. Relative
+# paths sit beside this file, so `generate.py --config` moves them with it.
+# These two are storage-layer keys: only the file store reads them, and the
+# hosted version keeps the same two things as rows instead.
 data_file: "dashboard_data.json"
 content_history_file: "content_history.json"

--- a/dinkydash/config.py
+++ b/dinkydash/config.py
@@ -35,6 +35,9 @@ DEFAULTS = {
     # Read only by `generate.py --tick`. A plain run still does both at once.
     "refresh_minutes": 60,
     "brief_time": "06:00",
+    # Storage-layer keys, read only by dinkydash.store.FileStore. They say
+    # where a self-hoster's generated files go and mean nothing in cloud mode,
+    # where the same two things are rows.
     "data_file": "dashboard_data.json",
     "content_history_file": "content_history.json",
 }
@@ -199,19 +202,3 @@ def today_for(config):
 
 def people_names(config):
     return [p.get("name", "") for p in config.get("people", []) if p.get("name")]
-
-
-def data_path(config, base=None):
-    return _resolve(config.get("data_file", DEFAULTS["data_file"]), base)
-
-
-def history_path(config, base=None):
-    return _resolve(config.get("content_history_file", DEFAULTS["content_history_file"]), base)
-
-
-def _resolve(value, base):
-    path = Path(value).expanduser()
-    if path.is_absolute():
-        return path
-    base = Path(base) if base else config_path().parent
-    return base / path

--- a/dinkydash/history.py
+++ b/dinkydash/history.py
@@ -2,31 +2,10 @@
 
 Fed back into the prompt so the board doesn't tell you the same octopus fact
 every fortnight.
+
+Pure: this decides what the history says, `dinkydash.store` decides where it
+is kept. On a Pi that is a JSON file; hosted it is a table.
 """
-
-import json
-import logging
-import os
-import tempfile
-from pathlib import Path
-
-log = logging.getLogger(__name__)
-
-
-def load_history(path):
-    """Recent entries, oldest first. Never raises — a missing file just means
-    there is nothing to avoid yet."""
-    try:
-        with open(path) as f:
-            data = json.load(f)
-        if isinstance(data, list):
-            return data
-        log.warning("Content history is not a list, ignoring it")
-    except FileNotFoundError:
-        pass
-    except Exception as exc:
-        log.warning("Could not read content history: %s", exc)
-    return []
 
 
 def recent_notes(history, days):
@@ -34,21 +13,6 @@ def recent_notes(history, days):
     return [entry.get("note", "") for entry in history[-days:] if entry.get("note")]
 
 
-def record(path, entry, keep=30):
-    """Append one entry, keeping the most recent `keep`."""
-    history = load_history(path)
-    history.append(entry)
-    history = history[-keep:]
-    path = Path(path)
-    try:
-        fd, tmp = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
-        try:
-            with os.fdopen(fd, "w") as f:
-                json.dump(history, f, indent=2, ensure_ascii=False)
-            os.replace(tmp, str(path))
-        except Exception:
-            if os.path.exists(tmp):
-                os.unlink(tmp)
-            raise
-    except Exception as exc:
-        log.warning("Could not write content history: %s", exc)
+def appended(history, entry, keep=30):
+    """The history with one more entry on the end, trimmed to the last `keep`."""
+    return (list(history) + [entry])[-keep:]

--- a/dinkydash/runner.py
+++ b/dinkydash/runner.py
@@ -1,4 +1,4 @@
-"""The two halves of the daily cycle, and the one place that does I/O.
+"""The two halves of the daily cycle: fetch the calendars, write the brief.
 
 `refresh_calendars` re-fetches the feeds and costs a few HTTP requests.
 `write_brief` asks Claude for the headline and note and costs money. They were
@@ -8,16 +8,17 @@ the wall the same day (`generate.py --tick`, and `dinkydash.schedule.due`).
 
 `run` is still both, in order, which is what `python generate.py` has always
 meant and what the settings page's "Rewrite now" does.
+
+All three take a `store` and read and write only through it, so nothing here
+knows whether the board it is replacing is a file on a Pi or a row belonging to
+one family among thousands.
 """
 
-import json
 import logging
 import os
-import tempfile
 from datetime import datetime, timedelta, timezone
 
 from . import config as config_module
-from . import history as history_module
 from .calendars import fetch_events, sort_key
 from .claude_client import GenerationError
 from .generate import generate
@@ -30,33 +31,7 @@ log = logging.getLogger(__name__)
 REFRESH_KEYS = ("events", "calendar_statuses", "calendars_fetched_at")
 
 
-def read_payload(path):
-    """The stored payload, or None when there isn't a usable one."""
-    try:
-        with open(path) as f:
-            data = json.load(f)
-    except FileNotFoundError:
-        return None
-    except (OSError, json.JSONDecodeError) as exc:
-        log.warning("Dashboard data is not readable (%s); treating it as no board yet", exc)
-        return None
-    return data if isinstance(data, dict) else None
-
-
-def write_payload(payload, path):
-    """Write the payload atomically so the board never reads a half-written file."""
-    fd, tmp = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
-    try:
-        with os.fdopen(fd, "w") as f:
-            json.dump(payload, f, indent=2, ensure_ascii=False)
-        os.replace(tmp, str(path))
-    except Exception:
-        if os.path.exists(tmp):
-            os.unlink(tmp)
-        raise
-
-
-def refresh_calendars(config, now=None, base=None, today=None):
+def refresh_calendars(config, store, now=None, today=None):
     """Re-fetch every enabled feed and store the merged agenda. No model call.
 
     `now` is when this is happening and becomes the `calendars_fetched_at`
@@ -73,8 +48,7 @@ def refresh_calendars(config, now=None, base=None, today=None):
         config.get("calendars"), today, tzinfo, days_ahead=days_ahead,
     )
 
-    path = config_module.data_path(config, base=base)
-    payload = read_payload(path) or {}
+    payload = store.load_payload(config) or {}
 
     failed = {s["label"] for s in statuses if s["ok"] is False}
     if failed:
@@ -85,7 +59,7 @@ def refresh_calendars(config, now=None, base=None, today=None):
     payload["events"] = events
     payload["calendar_statuses"] = statuses
     payload["calendars_fetched_at"] = now.astimezone(timezone.utc).isoformat()
-    write_payload(payload, path)
+    store.save_payload(config, payload)
     log.info("Calendars refreshed: %d events stored", len(payload["events"]))
     return payload
 
@@ -120,7 +94,7 @@ def _with_last_known(fresh, previous, failed_labels, start, end):
     return sorted(fresh + kept, key=sort_key)
 
 
-def write_brief(config, today=None, base=None, client=None):
+def write_brief(config, store, today=None, client=None):
     """Ask Claude for today's headline and note, and store them. Costs one call.
 
     The events come from the stored payload rather than a second fetch, so the
@@ -133,12 +107,10 @@ def write_brief(config, today=None, base=None, client=None):
     require_api_key()
     today = today or config_module.today_for(config)
 
-    path = config_module.data_path(config, base=base)
-    stored = read_payload(path) or {}
+    stored = store.load_payload(config) or {}
 
-    history_file = config_module.history_path(config, base=base)
     keep = int(config.get("history_days") or 30)
-    recent = history_module.recent_notes(history_module.load_history(history_file), keep)
+    recent = store.recent_notes(config, keep)
 
     payload = generate(
         config, today, stored.get("events") or [], recent_notes=recent, client=client
@@ -147,9 +119,9 @@ def write_brief(config, today=None, base=None, client=None):
         if key in stored:
             payload[key] = stored[key]
 
-    write_payload(payload, path)
-    history_module.record(
-        history_file,
+    store.save_payload(config, payload)
+    store.record_note(
+        config,
         {
             "date": today.isoformat(),
             "headline": payload["headline"],
@@ -165,11 +137,11 @@ def write_brief(config, today=None, base=None, client=None):
     return payload
 
 
-def run(config, today=None, client=None, base=None):
+def run(config, store, today=None, client=None):
     """Both halves: fetch the calendars, then write the brief. Returns the payload."""
     require_api_key()  # before the fetch, so a missing key fails in a second
-    refresh_calendars(config, base=base, today=today)
-    return write_brief(config, today=today, base=base, client=client)
+    refresh_calendars(config, store, today=today)
+    return write_brief(config, store, today=today, client=client)
 
 
 def require_api_key():

--- a/dinkydash/store.py
+++ b/dinkydash/store.py
@@ -1,0 +1,141 @@
+"""The storage seam: where a family's config, board and history are kept.
+
+The engine takes a config dict and hands back a payload dict. Something has to
+keep those somewhere, and today that is three files beside `config.yaml`. In
+cloud mode it is rows in Postgres, keyed on a family (PLAN.md decision 10).
+
+So the six operations get a name now, while there is still one implementation:
+
+    load_config()                save_config(config)
+    load_payload(config)         save_payload(config, payload)
+    recent_notes(config, days)   record_note(config, entry, keep)
+
+The runner, the board route and the settings routes take a store and never
+learn which one they were given. `PostgresStore` is then a second class rather
+than a fork of every caller.
+
+The payload and history calls are handed the config because `FileStore` needs
+two keys out of it — `data_file` and `content_history_file` — to know where to
+write. Those are storage-layer keys: they mean nothing in cloud mode, and this
+is the only module that reads them.
+
+This module and `config.py` are the only places under `dinkydash/` that touch
+a file. Everything else stays pure.
+"""
+
+import json
+import logging
+import os
+import tempfile
+from pathlib import Path
+
+from . import config as config_module
+from . import history as history_module
+
+log = logging.getLogger(__name__)
+
+
+class FileStore:
+    """One family, as files beside its own `config.yaml`.
+
+    A relative `data_file` or `content_history_file` resolves against the
+    config's own directory, so `generate.py --config /tmp/scratch.yaml` keeps
+    its generated files with it rather than in whatever directory it was run
+    from.
+    """
+
+    def __init__(self, config_path=None):
+        path = Path(config_path) if config_path else config_module.config_path()
+        self.config_path = path.expanduser()
+        self.base = self.config_path.parent
+
+    # -- the config ---------------------------------------------------------
+
+    def load_config(self):
+        """The config as a plain dict, defaults filled in and old shapes migrated."""
+        return config_module.load_config(self.config_path)
+
+    def save_config(self, config):
+        """Write it back, comments and key order intact."""
+        config_module.save_config(config, self.config_path)
+
+    # -- the board ----------------------------------------------------------
+
+    def load_payload(self, config):
+        """The last generated board, or None when there is not a usable one."""
+        payload = _read_json(self._data_path(config), "the stored board")
+        return payload if isinstance(payload, dict) else None
+
+    def save_payload(self, config, payload):
+        """Write the board atomically, so nothing ever reads half a file."""
+        _write_json(self._data_path(config), payload)
+
+    # -- what was written recently ------------------------------------------
+
+    def recent_notes(self, config, days):
+        """The note text from the last `days` entries, oldest first."""
+        return history_module.recent_notes(self._history(config), days)
+
+    def record_note(self, config, entry, keep=30):
+        """Add one entry to the history, keeping the most recent `keep`.
+
+        Never raises. A history that cannot be written costs a repeated octopus
+        fact in a fortnight; it is not worth losing a written board over.
+        """
+        try:
+            _write_json(self._history_path(config),
+                        history_module.appended(self._history(config), entry, keep))
+        except Exception as exc:
+            log.warning("Could not write the note history: %s", exc)
+
+    def _history(self, config):
+        history = _read_json(self._history_path(config), "the note history")
+        if history is None:
+            return []
+        if not isinstance(history, list):
+            log.warning("The note history is not a list; ignoring it")
+            return []
+        return history
+
+    # -- where the files are ------------------------------------------------
+
+    def _data_path(self, config):
+        return self._resolve(config.get("data_file") or config_module.DEFAULTS["data_file"])
+
+    def _history_path(self, config):
+        return self._resolve(config.get("content_history_file")
+                             or config_module.DEFAULTS["content_history_file"])
+
+    def _resolve(self, value):
+        path = Path(value).expanduser()
+        return path if path.is_absolute() else self.base / path
+
+
+def _read_json(path, what):
+    """Parsed JSON, or None when there is nothing usable there.
+
+    Never raises. A missing file means this family has not got one yet, and an
+    unreadable one must not take the board down with it — the caller carries on
+    as though it were absent, and the next write replaces it.
+    """
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except FileNotFoundError:
+        return None
+    except (OSError, ValueError) as exc:
+        log.warning("Could not read %s (%s); carrying on as if it were not there", what, exc)
+        return None
+
+
+def _write_json(path, data):
+    """Write via a temporary file and rename, so a reader sees old or new, never half."""
+    fd, tmp = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(data, f, indent=2, ensure_ascii=False)
+        os.replace(tmp, str(path))
+    except Exception:
+        if os.path.exists(tmp):
+            os.unlink(tmp)
+        raise

--- a/generate.py
+++ b/generate.py
@@ -17,7 +17,6 @@ import logging
 import sys
 from contextlib import contextmanager
 from datetime import date, datetime, timezone
-from pathlib import Path
 
 try:
     import fcntl  # POSIX only; the board runs on a Pi
@@ -28,8 +27,9 @@ from dotenv import load_dotenv
 
 from dinkydash import config as config_module
 from dinkydash.claude_client import GenerationError
-from dinkydash.runner import read_payload, refresh_calendars, run, write_brief
+from dinkydash.runner import refresh_calendars, run, write_brief
 from dinkydash.schedule import due
+from dinkydash.store import FileStore
 
 load_dotenv()
 log = logging.getLogger("dinkydash")
@@ -53,26 +53,26 @@ def main(argv=None):
         stream=sys.stdout,
     )
 
-    path = args.config or config_module.config_path()
-    try:
-        config = config_module.load_config(path)
-    except FileNotFoundError:
-        log.error("No config found at %s. Copy config.example.yaml to config.yaml.", path)
-        return 1
-
     # Generated data sits beside the config it was generated from, so --config
     # moves the payload and the history with it.
-    base = Path(path).expanduser().parent
+    store = FileStore(args.config)
+    try:
+        config = store.load_config()
+    except FileNotFoundError:
+        log.error("No config found at %s. Copy config.example.yaml to config.yaml.",
+                  store.config_path)
+        return 1
+
     if args.tick:
-        with only_one_tick(base / LOCK_FILE) as mine:
+        with only_one_tick(store.base / LOCK_FILE) as mine:
             if not mine:
                 log.warning("A previous tick is still running; skipping this one.")
                 return 0
-            return tick(config, base)
+            return tick(config, store)
 
     today = date.fromisoformat(args.date) if args.date else config_module.today_for(config)
     try:
-        payload = run(config, today=today, base=base)
+        payload = run(config, store, today=today)
     except GenerationError as exc:
         # The previous board is left in place rather than blanking the screen.
         log.error("%s", exc)
@@ -111,10 +111,10 @@ def only_one_tick(path):
         handle.close()  # releases the lock, and so does the process exiting
 
 
-def tick(config, base):
+def tick(config, store):
     """Do what the clock and the config say is owed, and no more."""
     now = datetime.now(timezone.utc)
-    payload = read_payload(config_module.data_path(config, base=base))
+    payload = store.load_payload(config)
     owed = due(config, payload, now)
 
     if not any(owed.values()):
@@ -124,12 +124,12 @@ def tick(config, base):
         return 0
 
     if owed["refresh"]:
-        refresh_calendars(config, now=now, base=base)
+        refresh_calendars(config, store, now=now)
 
     if owed["brief"]:
         today = now.astimezone(config_module.tzinfo_for(config)).date()
         try:
-            report(write_brief(config, today=today, base=base))
+            report(write_brief(config, store, today=today))
         except GenerationError as exc:
             # Not fatal: the brief is simply due again on the next tick.
             log.error("%s", exc)

--- a/sample_board.py
+++ b/sample_board.py
@@ -12,11 +12,11 @@ present. It costs nothing and calls no API. Real data always wins: if a payload
 in the current schema is already here, this leaves it alone.
 """
 
-import json
 import sys
 from datetime import datetime, timedelta, timezone
 
 from dinkydash import config as config_module
+from dinkydash.store import FileStore
 
 # Enough to fill today's agenda and leave a fortnight of context behind it, the
 # same window a real run fetches.
@@ -40,16 +40,11 @@ NOTE = ("Sample data, so the board has something to show. Run generate.py, or "
         "press “Rewrite now” in settings, for the real thing.")
 
 
-def is_usable(path):
-    """True if a payload is already here and speaks the current schema."""
-    try:
-        with open(path) as f:
-            payload = json.load(f)
-    except (FileNotFoundError, json.JSONDecodeError):
-        return False
+def is_usable(payload):
+    """True if a payload is already stored and speaks the current schema."""
     # Pre-rebuild payloads carry `generated_date` and `ai_content` instead, and
     # nothing build_view reads, so they are worse than no payload at all.
-    return isinstance(payload, dict) and "generated_for_date" in payload
+    return bool(payload) and "generated_for_date" in payload
 
 
 def build_payload(config, today, tzinfo):
@@ -87,18 +82,16 @@ def build_payload(config, today, tzinfo):
 
 
 def main():
-    config = config_module.load_config(config_module.config_path())
-    path = config_module.data_path(config)
+    store = FileStore()
+    config = store.load_config()
 
-    if is_usable(path):
-        print(f"{path} is already a current payload; leaving it alone.")
+    if is_usable(store.load_payload(config)):
+        print("A current board is already stored; leaving it alone.")
         return 0
 
     today = config_module.today_for(config)
-    payload = build_payload(config, today, config_module.tzinfo_for(config))
-    with open(path, "w") as f:
-        json.dump(payload, f, indent=2, ensure_ascii=False)
-    print(f"Wrote sample board data for {today} to {path}.")
+    store.save_payload(config, build_payload(config, today, config_module.tzinfo_for(config)))
+    print(f"Wrote sample board data for {today}.")
     return 0
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -232,19 +232,6 @@ class TestTimezone:
         assert config_module.tzinfo_for(config).key == "UTC"
 
 
-class TestPaths:
-    def test_relative_paths_resolve_next_to_the_config(self, config_file):
-        config = config_module.load_config(config_file)
-        assert config_module.data_path(config, base=config_file.parent) == \
-            config_file.parent / "dashboard_data.json"
-
-    def test_absolute_paths_are_left_alone(self, config_file, tmp_path):
-        config = config_module.load_config(config_file)
-        config["data_file"] = str(tmp_path / "elsewhere.json")
-        assert config_module.data_path(config, base=config_file.parent) == \
-            tmp_path / "elsewhere.json"
-
-
 def test_people_names_skips_the_nameless(config_file):
     config = config_module.load_config(config_file)
     config["people"].append({"date_of_birth": "2020-01-01"})

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -14,6 +14,7 @@ import pytest
 import generate as cli
 from dinkydash import runner
 from dinkydash.claude_client import GenerationError
+from dinkydash.store import FileStore
 
 from test_generate import FakeClient  # the same stand-in the generator tests use
 
@@ -60,9 +61,14 @@ def home(tmp_path):
 
 
 @pytest.fixture
-def config(home):
-    from dinkydash import config as config_module
-    return config_module.load_config(home / "config.yaml")
+def store(home):
+    """The one way in and out of that directory."""
+    return FileStore(home / "config.yaml")
+
+
+@pytest.fixture
+def config(store):
+    return store.load_config()
 
 
 @pytest.fixture
@@ -87,31 +93,31 @@ def fake_fetch(events, statuses, seen=None):
 
 
 class TestRefreshCalendars:
-    def test_stores_the_events_and_stamps_the_fetch(self, home, config, monkeypatch):
+    def test_stores_the_events_and_stamps_the_fetch(self, home, store, config, monkeypatch):
         monkeypatch.setattr(runner, "fetch_events", fake_fetch(EVENTS, OK_STATUS))
-        runner.refresh_calendars(config, now=datetime(2026, 9, 3, 8, tzinfo=timezone.utc),
-                                 base=home)
+        runner.refresh_calendars(config, store,
+                                 now=datetime(2026, 9, 3, 8, tzinfo=timezone.utc))
         payload = stored(home)
         assert payload["events"] == EVENTS
         assert payload["calendar_statuses"] == OK_STATUS
         assert payload["calendars_fetched_at"] == "2026-09-03T08:00:00+00:00"
 
-    def test_the_stamp_is_utc_whatever_the_clock_was(self, home, config, monkeypatch):
+    def test_the_stamp_is_utc_whatever_the_clock_was(self, home, store, config, monkeypatch):
         monkeypatch.setattr(runner, "fetch_events", fake_fetch(EVENTS, OK_STATUS))
         local = datetime.fromisoformat("2026-09-03T10:00:00+02:00")
-        runner.refresh_calendars(config, now=local, base=home)
+        runner.refresh_calendars(config, store, now=local)
         assert stored(home)["calendars_fetched_at"] == "2026-09-03T08:00:00+00:00"
 
-    def test_the_window_starts_on_the_familys_today(self, home, config, monkeypatch):
+    def test_the_window_starts_on_the_familys_today(self, store, config, monkeypatch):
         seen = []
         monkeypatch.setattr(runner, "fetch_events", fake_fetch(EVENTS, OK_STATUS, seen))
         # 23:30 UTC is already the 4th in Berlin.
-        runner.refresh_calendars(config, now=datetime(2026, 9, 3, 23, 30, tzinfo=timezone.utc),
-                                 base=home)
+        runner.refresh_calendars(config, store,
+                                 now=datetime(2026, 9, 3, 23, 30, tzinfo=timezone.utc))
         assert seen[0]["today"] == date(2026, 9, 4)
         assert seen[0]["days_ahead"] == 14
 
-    def test_it_leaves_the_brief_alone(self, home, config, monkeypatch):
+    def test_it_leaves_the_brief_alone(self, home, store, config, monkeypatch):
         # The state the board labels amber: today's times under yesterday's words.
         write_stored(home, {
             "generated_for_date": "2026-09-02", "generated_at": "2026-09-02T04:00:00+00:00",
@@ -119,7 +125,7 @@ class TestRefreshCalendars:
             "note_kind": "fact", "events": [], "model": "claude-haiku-4-5",
         })
         monkeypatch.setattr(runner, "fetch_events", fake_fetch(EVENTS, OK_STATUS))
-        runner.refresh_calendars(config, base=home)
+        runner.refresh_calendars(config, store)
         payload = stored(home)
         assert payload["generated_for_date"] == "2026-09-02"
         assert payload["generated_at"] == "2026-09-02T04:00:00+00:00"
@@ -127,17 +133,17 @@ class TestRefreshCalendars:
         assert payload["note"] == "Yesterday's note"
         assert payload["events"] == EVENTS
 
-    def test_a_failed_feed_leaves_its_own_events_up(self, home, config, monkeypatch):
+    def test_a_failed_feed_leaves_its_own_events_up(self, home, store, config, monkeypatch):
         # A missing event is invisible; a stale one is at least on the wall.
         write_stored(home, {"generated_for_date": "2026-09-03", "headline": "Hi",
                             "note": "There", "events": EVENTS})
         monkeypatch.setattr(runner, "fetch_events", fake_fetch([], FAILED_STATUS))
-        runner.refresh_calendars(config, now=NOW, base=home)
+        runner.refresh_calendars(config, store, now=NOW)
         payload = stored(home)
         assert payload["events"] == EVENTS
         assert payload["calendar_statuses"] == FAILED_STATUS
 
-    def test_one_dead_feed_does_not_freeze_the_healthy_ones(self, home, config,
+    def test_one_dead_feed_does_not_freeze_the_healthy_ones(self, home, store, config,
                                                             monkeypatch):
         # The whole point of merging per feed: School answered, so School is
         # fresh, while Family holds what it last gave us. Freezing everything
@@ -146,147 +152,147 @@ class TestRefreshCalendars:
         write_stored(home, {"generated_for_date": "2026-09-03", "headline": "Hi",
                             "note": "There", "events": EVENTS})
         monkeypatch.setattr(runner, "fetch_events", fake_fetch(SCHOOL, MIXED_STATUS))
-        runner.refresh_calendars(config, now=NOW, base=home)
+        runner.refresh_calendars(config, store, now=NOW)
         titles = [(e["calendar"], e["title"]) for e in stored(home)["events"]]
         assert titles == [("Family", "Swimming"), ("School", "Sports day")]
 
-    def test_a_healthy_feed_that_dropped_an_event_really_drops_it(self, home, config,
-                                                                  monkeypatch):
+    def test_a_healthy_feed_that_dropped_an_event_really_drops_it(self, home, store,
+                                                                  config, monkeypatch):
         # Nothing stale is kept for a feed that answered, or a deleted
         # appointment would live on the board for ever.
         write_stored(home, {"events": EVENTS + SCHOOL})
         monkeypatch.setattr(runner, "fetch_events", fake_fetch(SCHOOL, MIXED_STATUS))
-        runner.refresh_calendars(config, now=NOW, base=home)
+        runner.refresh_calendars(config, store, now=NOW)
         assert [e["title"] for e in stored(home)["events"]] == ["Swimming", "Sports day"]
 
         # Now Family answers too, with nothing in it. Swimming is gone.
         monkeypatch.setattr(runner, "fetch_events", fake_fetch(SCHOOL, [
             {"label": "Family", "ok": True, "detail": "", "count": 0},
             {"label": "School", "ok": True, "detail": "", "count": 1}]))
-        runner.refresh_calendars(config, now=NOW, base=home)
+        runner.refresh_calendars(config, store, now=NOW)
         assert [e["title"] for e in stored(home)["events"]] == ["Sports day"]
 
-    def test_stale_events_outside_the_window_are_dropped(self, home, config, monkeypatch):
+    def test_stale_events_outside_the_window_are_dropped(self, home, store, config, monkeypatch):
         # A permanently broken feed empties out as the days pass rather than
         # keeping a growing tail of appointments that already happened.
         write_stored(home, {"events": EVENTS})
         monkeypatch.setattr(runner, "fetch_events", fake_fetch([], FAILED_STATUS))
         # A month on, 2026-09-03 is behind the fourteen-day window.
-        runner.refresh_calendars(config, now=datetime(2026, 10, 3, 8, tzinfo=timezone.utc),
-                                 base=home)
+        runner.refresh_calendars(config, store,
+                                 now=datetime(2026, 10, 3, 8, tzinfo=timezone.utc))
         assert stored(home)["events"] == []
 
-    def test_a_paused_feed_does_not_keep_its_old_events(self, home, config, monkeypatch):
+    def test_a_paused_feed_does_not_keep_its_old_events(self, home, store, config, monkeypatch):
         # Switching a calendar off means switching it off.
         write_stored(home, {"events": EVENTS})
         paused = [{"label": "Family", "ok": None, "detail": "paused", "count": 0}]
         monkeypatch.setattr(runner, "fetch_events", fake_fetch([], paused))
-        runner.refresh_calendars(config, now=NOW, base=home)
+        runner.refresh_calendars(config, store, now=NOW)
         assert stored(home)["events"] == []
 
-    def test_two_feeds_sharing_a_label_are_not_doubled(self, home, config, monkeypatch):
+    def test_two_feeds_sharing_a_label_are_not_doubled(self, home, store, config, monkeypatch):
         # Labels are the only identity an event carries, so a duplicate label
         # must degrade to one copy rather than two.
         write_stored(home, {"events": EVENTS})
         both = [{"label": "Family", "ok": False, "detail": "could not fetch", "count": 0},
                 {"label": "Family", "ok": True, "detail": "", "count": 1}]
         monkeypatch.setattr(runner, "fetch_events", fake_fetch(EVENTS, both))
-        runner.refresh_calendars(config, now=NOW, base=home)
+        runner.refresh_calendars(config, store, now=NOW)
         assert stored(home)["events"] == EVENTS
 
-    def test_a_failed_feed_on_the_first_run_stores_what_there_is(self, home, config,
-                                                                 monkeypatch):
+    def test_a_failed_feed_on_the_first_run_stores_what_there_is(self, home, store,
+                                                                 config, monkeypatch):
         monkeypatch.setattr(runner, "fetch_events", fake_fetch([], FAILED_STATUS))
-        runner.refresh_calendars(config, now=NOW, base=home)
+        runner.refresh_calendars(config, store, now=NOW)
         assert stored(home)["events"] == []
 
-    def test_no_calendars_configured_touches_nothing_but_the_stamp(self, home, config):
+    def test_no_calendars_configured_touches_nothing_but_the_stamp(self, store, config):
         # fetch_events is the real one here: with an empty list it must not
         # reach the network at all.
         config["calendars"] = []
-        payload = runner.refresh_calendars(config, base=home)
+        payload = runner.refresh_calendars(config, store)
         assert payload["events"] == []
         assert payload["calendar_statuses"] == []
         assert payload["calendars_fetched_at"]
 
-    def test_it_needs_no_api_key(self, home, config, monkeypatch):
+    def test_it_needs_no_api_key(self, home, store, config, monkeypatch):
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
         monkeypatch.setattr(runner, "fetch_events", fake_fetch(EVENTS, OK_STATUS))
-        runner.refresh_calendars(config, base=home)  # a fetch costs nothing
+        runner.refresh_calendars(config, store)  # a fetch costs nothing
         assert stored(home)["events"] == EVENTS
 
 
 class TestWriteBrief:
-    def test_it_uses_the_stored_events_rather_than_fetching_again(self, home, config,
-                                                                 api_key, monkeypatch):
+    def test_it_uses_the_stored_events_rather_than_fetching_again(self, home, store,
+                                                                  config, api_key, monkeypatch):
         monkeypatch.setattr(runner, "fetch_events",
                             lambda *a, **k: pytest.fail("write_brief must not fetch"))
         write_stored(home, {"events": EVENTS, "calendar_statuses": OK_STATUS,
                             "calendars_fetched_at": "2026-09-03T05:00:00+00:00"})
         client = FakeClient()
-        runner.write_brief(config, today=date(2026, 9, 3), base=home, client=client)
+        runner.write_brief(config, store, today=date(2026, 9, 3), client=client)
         payload = stored(home)
         assert payload["headline"] == "Big morning"
         assert payload["events"] == EVENTS
         assert "Swimming" in client.messages.calls[0]["messages"][0]["content"]
 
-    def test_it_carries_the_refresh_keys_forward(self, home, config, api_key):
+    def test_it_carries_the_refresh_keys_forward(self, home, store, config, api_key):
         write_stored(home, {"events": EVENTS, "calendar_statuses": FAILED_STATUS,
                             "calendars_fetched_at": "2026-09-03T05:00:00+00:00"})
-        runner.write_brief(config, today=date(2026, 9, 3), base=home, client=FakeClient())
+        runner.write_brief(config, store, today=date(2026, 9, 3), client=FakeClient())
         payload = stored(home)
         assert payload["calendars_fetched_at"] == "2026-09-03T05:00:00+00:00"
         assert payload["calendar_statuses"] == FAILED_STATUS
 
-    def test_it_records_the_note_in_the_history(self, home, config, api_key):
-        runner.write_brief(config, today=date(2026, 9, 3), base=home, client=FakeClient())
+    def test_it_records_the_note_in_the_history(self, home, store, config, api_key):
+        runner.write_brief(config, store, today=date(2026, 9, 3), client=FakeClient())
         history = json.loads((home / "content_history.json").read_text())
         assert history[-1]["note"] == "An octopus fact."
         assert history[-1]["date"] == "2026-09-03"
 
-    def test_it_works_with_no_payload_at_all(self, home, config, api_key):
-        payload = runner.write_brief(config, today=date(2026, 9, 3), base=home,
+    def test_it_works_with_no_payload_at_all(self, store, config, api_key):
+        payload = runner.write_brief(config, store, today=date(2026, 9, 3),
                                      client=FakeClient())
         assert payload["events"] == []
         assert payload["generated_for_date"] == "2026-09-03"
 
-    def test_a_failure_leaves_the_previous_board_untouched(self, home, config, api_key):
+    def test_a_failure_leaves_the_previous_board_untouched(self, home, store, config, api_key):
         write_stored(home, {"generated_for_date": "2026-09-02", "headline": "Kept",
                             "note": "Kept", "events": EVENTS})
         client = FakeClient(raises=RuntimeError("the API is down"))
         with pytest.raises(GenerationError):
-            runner.write_brief(config, today=date(2026, 9, 3), base=home, client=client)
+            runner.write_brief(config, store, today=date(2026, 9, 3), client=client)
         assert stored(home)["headline"] == "Kept"
 
-    def test_it_refuses_without_an_api_key(self, home, config, monkeypatch):
+    def test_it_refuses_without_an_api_key(self, store, config, monkeypatch):
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
         with pytest.raises(GenerationError, match="ANTHROPIC_API_KEY"):
-            runner.write_brief(config, today=date(2026, 9, 3), base=home, client=FakeClient())
+            runner.write_brief(config, store, today=date(2026, 9, 3), client=FakeClient())
 
 
 class TestRun:
-    def test_it_still_does_both(self, home, config, api_key, monkeypatch):
+    def test_it_still_does_both(self, home, store, config, api_key, monkeypatch):
         monkeypatch.setattr(runner, "fetch_events", fake_fetch(EVENTS, OK_STATUS))
-        runner.run(config, today=date(2026, 9, 3), base=home, client=FakeClient())
+        runner.run(config, store, today=date(2026, 9, 3), client=FakeClient())
         payload = stored(home)
         assert payload["events"] == EVENTS
         assert payload["headline"] == "Big morning"
         assert payload["generated_for_date"] == "2026-09-03"
         assert payload["calendars_fetched_at"]
 
-    def test_the_date_override_moves_the_fetch_window(self, home, config, api_key,
+    def test_the_date_override_moves_the_fetch_window(self, store, config, api_key,
                                                       monkeypatch):
         seen = []
         monkeypatch.setattr(runner, "fetch_events", fake_fetch(EVENTS, OK_STATUS, seen))
-        runner.run(config, today=date(2026, 12, 24), base=home, client=FakeClient())
+        runner.run(config, store, today=date(2026, 12, 24), client=FakeClient())
         assert seen[0]["today"] == date(2026, 12, 24)
 
-    def test_a_missing_key_fails_before_the_fetch(self, home, config, monkeypatch):
+    def test_a_missing_key_fails_before_the_fetch(self, store, config, monkeypatch):
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
         monkeypatch.setattr(runner, "fetch_events",
                             lambda *a, **k: pytest.fail("should not have fetched"))
         with pytest.raises(GenerationError, match="ANTHROPIC_API_KEY"):
-            runner.run(config, today=date(2026, 9, 3), base=home)
+            runner.run(config, store, today=date(2026, 9, 3))
 
 
 def refuse(what):
@@ -334,7 +340,8 @@ class TestTick:
                             "headline": "Yesterday", "note": "Yesterday", "events": EVENTS})
         client = FakeClient()
         monkeypatch.setattr(cli, "write_brief",
-                            lambda config, **kw: runner.write_brief(config, client=client, **kw))
+                            lambda config, store, **kw: runner.write_brief(
+                                config, store, client=client, **kw))
         # 08:00 Berlin, so the brief is owed and the fetch is not.
         assert self.run_tick(home, monkeypatch, datetime(2026, 9, 3, 6, tzinfo=timezone.utc)) == 0
         payload = stored(home)
@@ -348,7 +355,8 @@ class TestTick:
                             "headline": "Yesterday", "note": "Yesterday", "events": EVENTS})
         client = FakeClient(raises=RuntimeError("the API is down"))
         monkeypatch.setattr(cli, "write_brief",
-                            lambda config, **kw: runner.write_brief(config, client=client, **kw))
+                            lambda config, store, **kw: runner.write_brief(
+                                config, store, client=client, **kw))
         assert self.run_tick(home, monkeypatch, datetime(2026, 9, 3, 6, tzinfo=timezone.utc)) == 1
         # Untouched, so the next tick five minutes later asks again.
         assert stored(home)["headline"] == "Yesterday"
@@ -357,7 +365,8 @@ class TestTick:
         monkeypatch.setattr(runner, "fetch_events", fake_fetch(EVENTS, OK_STATUS))
         client = FakeClient()
         monkeypatch.setattr(cli, "write_brief",
-                            lambda config, **kw: runner.write_brief(config, client=client, **kw))
+                            lambda config, store, **kw: runner.write_brief(
+                                config, store, client=client, **kw))
         assert self.run_tick(home, monkeypatch, datetime(2026, 9, 3, 6, tzinfo=timezone.utc)) == 0
         payload = stored(home)
         assert payload["events"] == EVENTS

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -10,6 +10,7 @@ import json
 import pytest
 
 from dinkydash import config as config_module
+from dinkydash.store import FileStore
 from web import create_app
 
 CONFIG = """\
@@ -33,16 +34,16 @@ recurring:
 
 
 @pytest.fixture
-def config_path(tmp_path, monkeypatch):
+def config_path(tmp_path):
     path = tmp_path / "config.yaml"
     path.write_text(CONFIG)
-    monkeypatch.setenv("DINKYDASH_CONFIG", str(path))
     return path
 
 
 @pytest.fixture
 def client(config_path):
-    app = create_app()
+    """The app over that config, handed the store rather than finding one."""
+    app = create_app(FileStore(config_path))
     app.config["TESTING"] = True
     return app.test_client()
 
@@ -197,14 +198,13 @@ class TestTheClockOnTheStatusLine:
     """Stamps are stored in UTC; the family reads their own clock (PLAN bug 9)."""
 
     @pytest.fixture
-    def config_path(self, tmp_path, monkeypatch):
+    def config_path(self, tmp_path):
         # Kolkata is UTC+05:30 in every month of the year. Berlin would make
         # these assertions pass in summer and fail in winter, and the half hour
         # means no accidental slice of the ISO string can look like a pass.
         path = tmp_path / "config.yaml"
         path.write_text(CONFIG.replace('timezone: "Europe/Berlin"',
                                        'timezone: "Asia/Kolkata"'))
-        monkeypatch.setenv("DINKYDASH_CONFIG", str(path))
         return path
 
     @pytest.fixture
@@ -267,10 +267,9 @@ class TestTheCadencePage:
     """The two keys decision 11 added, edited from a phone rather than in YAML."""
 
     @pytest.fixture
-    def config_path(self, tmp_path, monkeypatch):
+    def config_path(self, tmp_path):
         path = tmp_path / "config.yaml"
         path.write_text(CADENCE_CONFIG)
-        monkeypatch.setenv("DINKYDASH_CONFIG", str(path))
         return path
 
     def test_the_page_is_not_swallowed_by_the_section_routes(self, client):
@@ -353,10 +352,9 @@ class TestTheCadencePage:
 
 class TestTheCadenceOnTheHomePage:
     @pytest.fixture
-    def config_path(self, tmp_path, monkeypatch):
+    def config_path(self, tmp_path):
         path = tmp_path / "config.yaml"
         path.write_text(CADENCE_CONFIG)
-        monkeypatch.setenv("DINKYDASH_CONFIG", str(path))
         return path
 
     def test_the_row_says_both_cadences(self, client):
@@ -378,7 +376,7 @@ class TestRefreshingTheCalendarsByHand:
         """Stub the runner, so the test touches neither the network nor a key."""
         calls = []
 
-        def fake(config, base=None, **kwargs):
+        def fake(config, store, **kwargs):
             calls.append(config)
             return {"events": [1, 2, 3], "calendar_statuses": [{"label": "Family", "ok": True}]}
 
@@ -399,7 +397,7 @@ class TestRefreshingTheCalendarsByHand:
     def test_a_broken_feed_is_named_without_its_url(self, client, monkeypatch):
         secret = "https://calendar.google.com/calendar/ical/private-abc123/basic.ics"
 
-        def fake(config, base=None, **kwargs):
+        def fake(config, store, **kwargs):
             return {"events": [],
                     "calendar_statuses": [{"label": "Dad's", "ok": False, "error": secret}]}
 
@@ -409,7 +407,7 @@ class TestRefreshingTheCalendarsByHand:
         assert "private-abc123" not in page
 
     def test_a_failure_flashes_rather_than_500s(self, client, monkeypatch):
-        def explode(config, base=None, **kwargs):
+        def explode(config, store, **kwargs):
             raise OSError("the disk is full")
 
         monkeypatch.setattr("web.routes.settings.refresh_calendars", explode)

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,0 +1,147 @@
+"""The storage seam.
+
+`FileStore` is the only implementation today, so what is worth asserting is the
+contract `PostgresStore` will have to keep: six operations, a payload that comes
+back as the dict that went in, a history that trims itself, and nothing that
+raises when the files are missing or corrupt. A board must not go dark because
+somebody's disk filled up mid-write.
+"""
+
+import json
+
+import pytest
+
+from dinkydash.store import FileStore
+
+CONFIG = """\
+family_name: "The Wilsons"
+timezone: "Europe/Berlin"
+people:
+  - name: "Mia"
+    date_of_birth: "2017-03-15"
+"""
+
+PAYLOAD = {
+    "generated_for_date": "2026-09-03",
+    "generated_at": "2026-09-03T04:00:00+00:00",
+    "headline": "Big morning",
+    "note": "An octopus fact.",
+    "events": [{"title": "Swimming", "date": "2026-09-03"}],
+}
+
+
+@pytest.fixture
+def store(tmp_path):
+    (tmp_path / "config.yaml").write_text(CONFIG)
+    return FileStore(tmp_path / "config.yaml")
+
+
+@pytest.fixture
+def config(store):
+    return store.load_config()
+
+
+def _explode(message):
+    def _raise(*args, **kwargs):
+        raise OSError(message)
+    return _raise
+
+
+class TestTheConfig:
+    def test_it_loads_with_the_defaults_filled_in(self, store):
+        config = store.load_config()
+        assert config["family_name"] == "The Wilsons"
+        assert config["refresh_minutes"] == 60
+
+    def test_a_save_comes_back_on_the_next_load(self, store):
+        config = store.load_config()
+        config["family_name"] = "The Bakers"
+        store.save_config(config)
+        assert store.load_config()["family_name"] == "The Bakers"
+
+
+class TestTheBoard:
+    def test_a_payload_comes_back_as_the_dict_that_went_in(self, store, config):
+        store.save_payload(config, PAYLOAD)
+        assert store.load_payload(config) == PAYLOAD
+
+    def test_nothing_generated_yet_is_none_rather_than_an_error(self, store, config):
+        assert store.load_payload(config) is None
+
+    def test_an_unreadable_payload_reads_as_no_board_at_all(self, store, config, tmp_path):
+        # Truncated by a power cut mid-write. The board shows its first-run
+        # screen and the next generation replaces the file.
+        (tmp_path / "dashboard_data.json").write_text("{not json")
+        assert store.load_payload(config) is None
+
+    def test_something_that_is_not_a_payload_is_ignored(self, store, config, tmp_path):
+        (tmp_path / "dashboard_data.json").write_text("[1, 2, 3]")
+        assert store.load_payload(config) is None
+
+
+class TestTheNoteHistory:
+    def test_a_recorded_note_comes_back(self, store, config):
+        store.record_note(config, {"date": "2026-09-03", "note": "An octopus fact."})
+        assert store.recent_notes(config, 30) == ["An octopus fact."]
+
+    def test_notes_accumulate_oldest_first(self, store, config):
+        for day in range(1, 4):
+            store.record_note(config, {"date": f"2026-09-0{day}", "note": f"Note {day}"})
+        assert store.recent_notes(config, 30) == ["Note 1", "Note 2", "Note 3"]
+
+    def test_only_the_last_kept_entries_survive(self, store, config, tmp_path):
+        for day in range(1, 6):
+            store.record_note(config, {"date": f"2026-09-0{day}", "note": f"Note {day}"},
+                              keep=3)
+        assert store.recent_notes(config, 30) == ["Note 3", "Note 4", "Note 5"]
+        assert len(json.loads((tmp_path / "content_history.json").read_text())) == 3
+
+    def test_asking_for_fewer_days_gives_the_most_recent(self, store, config):
+        for day in range(1, 4):
+            store.record_note(config, {"date": f"2026-09-0{day}", "note": f"Note {day}"})
+        assert store.recent_notes(config, 2) == ["Note 2", "Note 3"]
+
+    def test_no_history_yet_is_an_empty_list(self, store, config):
+        assert store.recent_notes(config, 30) == []
+
+    def test_a_corrupt_history_does_not_stop_a_board_being_written(self, store, config,
+                                                                   tmp_path):
+        # The cost of losing this file is one repeated octopus fact, so it must
+        # never be the reason a generation fails.
+        (tmp_path / "content_history.json").write_text("{not json")
+        assert store.recent_notes(config, 30) == []
+        store.record_note(config, {"date": "2026-09-03", "note": "Fresh start"})
+        assert store.recent_notes(config, 30) == ["Fresh start"]
+
+    def test_an_unwritable_history_is_a_warning_not_a_failure(self, store, config,
+                                                              monkeypatch):
+        monkeypatch.setattr("dinkydash.store._write_json",
+                            _explode("the disk is full"))
+        store.record_note(config, {"date": "2026-09-03", "note": "Lost"})  # no exception
+
+
+class TestWhereTheFilesGo:
+    def test_generated_files_sit_beside_their_own_config(self, tmp_path):
+        # `generate.py --config /tmp/scratch.yaml` keeps its board with it,
+        # rather than in whatever directory it happened to be run from.
+        elsewhere = tmp_path / "scratch"
+        elsewhere.mkdir()
+        (elsewhere / "config.yaml").write_text(CONFIG)
+        store = FileStore(elsewhere / "config.yaml")
+        store.save_payload(store.load_config(), PAYLOAD)
+        assert (elsewhere / "dashboard_data.json").exists()
+        assert not (tmp_path / "dashboard_data.json").exists()
+
+    def test_an_absolute_data_file_is_left_where_it_says(self, store, config, tmp_path):
+        config["data_file"] = str(tmp_path / "elsewhere.json")
+        store.save_payload(config, PAYLOAD)
+        assert json.loads((tmp_path / "elsewhere.json").read_text()) == PAYLOAD
+
+    def test_a_half_written_board_is_never_visible(self, store, config, tmp_path):
+        # The write goes to a temporary file and is renamed, so a browser
+        # loading the board mid-write reads the old one or the new one.
+        store.save_payload(config, PAYLOAD)
+        with pytest.raises(TypeError):
+            store.save_payload(config, {"headline": object()})  # not JSON
+        assert store.load_payload(config) == PAYLOAD
+        assert list(tmp_path.glob("*.tmp")) == []

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -6,24 +6,20 @@ trust model as the config file it writes.
 """
 
 import os
-from pathlib import Path
 
 from flask import Flask
 
-from dinkydash import config as config_module
-from dinkydash import runner
+from dinkydash.store import FileStore
 
 
-def load_payload(config):
-    """The last generated payload, or None if nothing has been generated yet."""
-    return runner.read_payload(config_module.data_path(config))
-
-
-def create_app():
+def create_app(store=None):
     app = Flask(__name__, static_folder="static", template_folder="templates")
     # Only ever used to sign flash messages on a LAN-local app.
     app.secret_key = os.environ.get("DINKYDASH_SECRET_KEY", "dinkydash-self-hosted")
-    app.config["CONFIG_PATH"] = Path(config_module.config_path())
+    # Every route reads and writes through this one object, and none of them is
+    # told what is behind it. Cloud mode hands in a different store here and
+    # nothing below this line changes (PLAN.md decision 10).
+    app.config["STORE"] = store or FileStore()
 
     from .routes.board import bp as board_bp
     from .routes.settings import bp as settings_bp

--- a/web/routes/board.py
+++ b/web/routes/board.py
@@ -15,16 +15,20 @@ PREVIEW_SIZES = [
 ]
 
 
+def current_store():
+    return current_app.config["STORE"]
+
+
 def current_config():
-    return config_module.load_config(current_app.config["CONFIG_PATH"])
+    return current_store().load_config()
 
 
 @bp.route("/")
 def index():
-    from web import load_payload
-    config = current_config()
+    store = current_store()
+    config = store.load_config()
     today = config_module.today_for(config)
-    view = board_view.build_view(config, load_payload(config), today)
+    view = board_view.build_view(config, store.load_payload(config), today)
     return render_template("board.html", view=view)
 
 

--- a/web/routes/settings.py
+++ b/web/routes/settings.py
@@ -118,8 +118,12 @@ MONTHS = ["January", "February", "March", "April", "May", "June", "July",
 REFRESH_CHOICES = (15, 30, 60, 360, 1440)
 
 
+def current_store():
+    return current_app.config["STORE"]
+
+
 def current_config():
-    config = config_module.load_config(current_app.config["CONFIG_PATH"])
+    config = current_store().load_config()
     if config_module.ensure_ids(config):
         # A config written by hand, or before ids existed. Give its items ids
         # once, so the links on this page keep meaning the same thing.
@@ -128,7 +132,7 @@ def current_config():
 
 
 def save(config):
-    config_module.save_config(config, current_app.config["CONFIG_PATH"])
+    current_store().save_config(config)
 
 
 def section_or_404(name):
@@ -176,10 +180,9 @@ def validate(section, item):
 
 @bp.route("/")
 def home():
-    from web import load_payload
     config = current_config()
     today = config_module.today_for(config)
-    payload = load_payload(config)
+    payload = current_store().load_payload(config)
 
     tzinfo = config_module.tzinfo_for(config)
     status = {"state": "waiting", "detail": "No board has been generated yet."}
@@ -235,10 +238,10 @@ def _clock(stamp, tzinfo):
 def manifest():
     """The name and icon a phone gives this page on its home screen.
 
-    Loaded straight from the file rather than through `current_config`: fetching
+    Read straight from the store rather than through `current_config`: fetching
     a manifest must not be able to write config.yaml.
     """
-    config = config_module.load_config(current_app.config["CONFIG_PATH"])
+    config = current_store().load_config()
     family = config.get("family_name")
     return manifest_module.response(
         id=url_for("settings.home"),
@@ -257,7 +260,7 @@ def manifest():
 def generate_now():
     config = current_config()
     try:
-        payload = run_generation(config, base=current_app.config["CONFIG_PATH"].parent)
+        payload = run_generation(config, current_store())
     except GenerationError as exc:
         flash(str(exc), "error")
     except Exception as exc:  # a broken feed or an unreadable file shouldn't 500 the UI
@@ -486,7 +489,7 @@ def refresh_now():
     """Fetch the calendars and nothing else — the free half of "Rewrite now"."""
     config = current_config()
     try:
-        payload = refresh_calendars(config, base=current_app.config["CONFIG_PATH"].parent)
+        payload = refresh_calendars(config, current_store())
     except Exception as exc:  # a broken feed or an unwritable file shouldn't 500 the UI
         log.exception("Calendar refresh failed")
         flash(f"Could not refresh the calendars: {exc}", "error")


### PR DESCRIPTION
PLAN.md decision 10 makes the config dict the storage contract, but the runtime also writes the payload and the note history, and those were file calls scattered across `web/__init__.py` (`load_payload`), `runner.py` (`write_payload`) and `history.py` (`load_history`, `record`) — so this gathers all six operations into `dinkydash/store.py`, where `FileStore(config_path)` is the only implementation and its bodies are moves rather than rewrites.

The runner's three entry points take a `store` where they took a `base` directory, `create_app(store=None)` builds one and both blueprints read `app.config["STORE"]`, and `generate.py` and `sample_board.py` build their own; `board.build_view` is untouched and stays pure, which is the whole reason the seam can sit at this level rather than inside the engine.

`history.py` is now pure (`recent_notes` plus a new `appended`) and `config.py` loses `data_path`/`history_path`, because `data_file` and `content_history_file` are storage-layer keys that mean nothing hosted — they stay in `DEFAULTS` and in `config.example.yaml` for compatibility, and only the file store reads them. The invariant the issue asked for holds: `grep -rn "open(" dinkydash web` returns four lines, all in `store.py` and `config.py`.

**One real fix fell out:** `web.load_payload` resolved the payload's location from the `DINKYDASH_CONFIG` environment variable while the routes read their config from `app.config["CONFIG_PATH"]`, so if those two ever disagreed the board read the wrong file — there is one path now, though they were always the same in practice.

16 new tests written against the contract rather than the files (a payload that returns as the dict that went in, a history that trims itself, and a corrupt or unwritable file that never stops a board being written — the suite `PostgresStore` will have to pass too), 264 total and all passing; verified outside the suite on a scratch config, where `sample_board.py` seeds a board, `generate.py --tick` refreshes the calendars and correctly declines to write a brief, both pages render, and saving the family name and both cadences writes `config.yaml` back with its comments intact. No behaviour change otherwise; this unblocks DIN-31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
