### PR TITLE
Stand up the Postgres layer behind the storage seam (DIN-31)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,28 @@ jobs:
   test:
     name: pytest
     runs-on: ubuntu-latest
+
+    # A real Postgres, so the store tests run twice — once over FileStore and
+    # once over PostgresStore, with the same assertions. A suite that only ever
+    # ran against files would not notice the day the two drifted apart.
+    services:
+      postgres:
+        # Pinned to the major version DigitalOcean's managed cluster runs.
+        image: postgres:16
+        env:
+          POSTGRES_USER: dinkydash
+          POSTGRES_PASSWORD: dinkydash
+          POSTGRES_DB: dinkydash_test
+        ports:
+          - 5432:5432
+        # Without this the job races the container and the first connection
+        # fails on a database that is seconds from being ready.
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
       - uses: actions/checkout@v7
 
@@ -23,11 +45,27 @@ jobs:
           cache-dependency-path: |
             requirements.txt
             requirements-dev.txt
+            requirements-cloud.txt
 
       # requirements-dev.txt pulls in requirements.txt, so this installs both.
-      - run: pip install -r requirements-dev.txt
+      # requirements-cloud.txt adds psycopg, which is deliberately not in
+      # either — a Pi has no database and should not carry a driver for one.
+      - run: pip install -r requirements-dev.txt -r requirements-cloud.txt
 
-      - run: python -m pytest tests/ -q
+      # The password is the service container's own, invented above and
+      # reachable only from this job — but it goes in PGPASSWORD rather than
+      # inline in the URL, because `user:pass@host` is the shape a secret
+      # scanner looks for and a build that cries wolf gets ignored.
+      - name: Run the tests, both backends
+        env:
+          PGPASSWORD: dinkydash
+          DINKYDASH_TEST_DATABASE_URL: postgresql://dinkydash@localhost:5432/dinkydash_test
+        run: python -m pytest tests/ -q
+
+      # The suite a self-hoster actually runs: no database, no psycopg. The
+      # Postgres tests skip, and everything else has to still pass.
+      - name: Run the tests as a self-hoster does
+        run: python -m pytest tests/ -q
 
   gitleaks:
     name: gitleaks

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,7 +234,9 @@ dinkydash/
 ├── config.py          config.yaml load/save (ruamel round-trip), item ids
 ├── history.py         what the recent notes say, and how they trim (pure)
 ├── schedule.py        due(config, payload, now) -> what a tick owes (pure)
-├── store.py           the six storage operations; FileStore is the only one yet
+├── store.py           the six storage operations; FileStore, the single-mode one
+├── pgstore.py         PostgresStore, the cloud one. Imports psycopg; single mode never does
+├── db.py              the connection pool and the migration runner (cloud only)
 └── runner.py          the two halves of the day, reading and writing through a store
 
 web/
@@ -254,21 +256,64 @@ load_payload(config)         save_payload(config, payload)
 recent_notes(config, days)   record_note(config, entry, keep)
 ```
 
-`FileStore(config_path)` is the only implementation today — `config.yaml` and two JSON files in one
-directory. `PostgresStore` is the cloud one, where the payload is composed from two rows and comes
-back as the same dict (PLAN.md decision 10). The runner, the board route and the settings routes all
-take a store; `create_app(store=None)` builds one and every route reads `app.config["STORE"]`.
+Both implementations exist. `FileStore(config_path)` is `config.yaml` and two JSON files in one
+directory. `PostgresStore(pool, family_id)` is the same six operations against rows, with the
+payload composed from `generations` (the brief) and `agendas` (the fetched window) and handed back
+as the same dict. The runner, the board route and the settings routes all take a store;
+`create_app(store=None)` builds one and every route reads `app.config["STORE"]`.
 
-Three rules keep it a seam rather than a name:
+Four rules keep it a seam rather than a name:
 
-- **`store.py` and `config.py` are the only files under `dinkydash/` that open a file.** `grep -rn
-  "open(" dinkydash web` is the check, and it should stay that short. A new file read anywhere else
-  is a caller that cloud mode will have to fork.
+- **`store.py` and `config.py` are the only files under `dinkydash/` that open a file**, and
+  `pgstore.py` and `db.py` are the only ones that import psycopg. `grep -rn "open(" dinkydash web`
+  is the check, and it should stay that short. A new file read anywhere else is a caller that cloud
+  mode will have to fork.
 - **`data_file` and `content_history_file` are storage-layer keys.** They stay in `DEFAULTS` and in
   `config.example.yaml` for compatibility, and only `FileStore` reads them. They mean nothing hosted.
 - **The store is passed, never constructed, below the entry points.** `generate.py`, `app.py` and
-  `sample_board.py` build one; everything else is handed it. That is what makes a second
-  implementation a constructor argument rather than an edit.
+  `sample_board.py` build one; everything else is handed it.
+- **`tests/test_store_contract.py` runs every one of its assertions against both**, parametrised over
+  the two backends with no branching. That parity is most of the value of having named the seam: a
+  suite that only ran against files would not notice the day the two drifted. The Postgres half
+  skips unless `DINKYDASH_TEST_DATABASE_URL` is set, so a self-hoster with no database still gets a
+  green suite — and CI runs the suite twice, once with the variable and once without.
+
+**Every `PostgresStore` query is scoped to `self.family_id`.** There is no unscoped read and no
+unscoped write in that file, and there must never be one. An id arriving in a URL is a claim, not a
+fact, and the place to check it is before it reaches a store.
+
+### Cloud mode: schema, migrations, connections
+
+`migrations/*.sql` is plain SQL applied in filename order by `migrate.py`, which records each one in
+`schema_migrations`. No ORM and no Alembic — seven tables and one jsonb document do not need one.
+App Platform runs it as a **pre-deploy job**, so a failed migration fails the deploy rather than
+half-updating a live app.
+
+Three things about that runner are load-bearing:
+
+- **The connection must be autocommit.** Without it psycopg opens an implicit transaction on the
+  first statement, and `conn.transaction()` entered inside one is a *savepoint*, not a `BEGIN`.
+  Every migration then appears to apply, releases its savepoint, and is discarded when the
+  connection closes — no error, no tables, an empty `schema_migrations`. This was written wrong once
+  and caught by running it.
+- **A migration containing `-- no-transaction` is applied statement by statement, outside a
+  transaction**, because `CREATE INDEX CONCURRENTLY` refuses to run inside one. Those cannot be
+  all-or-nothing, so they have to be safe to re-run — every index in them is `IF NOT EXISTS`.
+- **Migrations connect with `DATABASE_URL_DIRECT`, not `DATABASE_URL`.** The first is the cluster,
+  the second is DigitalOcean's transaction-mode pool, which is the wrong end for schema work and for
+  `pg_dump`.
+
+Connections go through `dinkydash/db.py`. `pool()` is a small bounded `psycopg_pool` — its size is a
+latency knob, not a safety one, because DigitalOcean's own pool is what stops the cluster's 22
+connections running out. **`prepare_threshold` is set to `None` on every connection**, everywhere,
+including local development and CI: psycopg 3 prepares a statement server-side once it repeats, and
+under transaction-mode pooling the next execution can land on a different backend connection. The
+full reasoning, and why KeepTheScore's clean record on psycopg2 does not transfer, is in PLAN.md
+under [Connection pooling](PLAN.md#connection-pooling).
+
+**`psycopg` is in `requirements-cloud.txt`, not `requirements.txt`.** A Pi has no database and
+should not install a driver for one, so single mode never imports `pgstore` or `db` — the import in
+`create_app` is inside the cloud branch on purpose. The Dockerfile (DIN-30) installs the cloud file.
 
 ### What the payload holds, and what it does not
 
@@ -400,6 +445,24 @@ cp config.example.yaml config.yaml
 ```bash
 venv/bin/python -m pytest tests/ -q
 ```
+That is the suite a self-hoster runs: the Postgres tests skip, everything else passes. To run the
+other half — the store contract against a real database, and the cloud-mode board — point it at a
+scratch database:
+```bash
+pip install -r requirements-cloud.txt          # psycopg; not in requirements.txt
+createdb dinkydash_test
+DINKYDASH_TEST_DATABASE_URL=postgresql:///dinkydash_test venv/bin/python -m pytest tests/ -q
+```
+The fixture migrates that database itself, so there is nothing to set up and nothing to tear down.
+CI runs it both ways on every push, which is the point: the parity assertions only mean something if
+they actually run.
+
+**Apply the schema** (cloud mode only)
+```bash
+venv/bin/python migrate.py --status                  # what is outstanding
+venv/bin/python migrate.py --database-url postgresql:///dinkydash_dev
+```
+Without `--database-url` it reads `DATABASE_URL_DIRECT` — the cluster, not the pool.
 
 **Generate a board** (needs `ANTHROPIC_API_KEY` in `.env`)
 ```bash

--- a/PLAN.md
+++ b/PLAN.md
@@ -2,6 +2,8 @@
 
 *Last updated: September 7, 2026. Supersedes `HOSTING_ANALYSIS.md` (deleted — it predated both the AI generation feature and the July 2026 calendar-display repositioning, and its recommended stack and data model no longer matched the product).*
 
+*September 7, later still: the Postgres layer is built (DIN-31) — `migrations/001_initial_schema.sql`, `migrate.py`, `dinkydash/db.py`, `dinkydash/pgstore.py`, and a contract suite that runs the same assertions over both stores in CI. Connection pooling is settled above. What is deliberately still missing is the multi-tenancy: cloud mode serves one family from `DINKYDASH_FAMILY_ID`, because auth and scoping are Phase 1.*
+
 *September 7, later: the storage seam is built (DIN-19). `dinkydash/store.py` holds the six operations, `FileStore` is the one implementation, and the runner and both blueprints take a store rather than a path. The seam section below describes what exists; `PostgresStore` is now a constructor argument away.*
 
 *September 7 changes: the host is settled — decision 12, DigitalOcean App Platform in Frankfurt with DigitalOcean Managed Postgres and Cloudflare in front. The "Which host?" open question is closed, the hosting section is rewritten around it, DNS gets its own Phase 0 line, and the Compose file's job changes: the shared artefact between the two modes is now the **Dockerfile**, not `docker-compose.yml`.*
@@ -195,8 +197,12 @@ dinkydash/                  # the engine — pure, no clock, no file reads
 ├── config.py               # the config dict: load, save, defaults, migrations, ids
 ├── history.py              # what the recent notes say, and how they trim (pure)
 ├── schedule.py             # due(config, payload, now) -> what a tick owes (pure)
-├── store.py                # the six storage operations; FileStore today
+├── store.py                # the six storage operations; FileStore, single mode
+├── pgstore.py              # PostgresStore, cloud mode
+├── db.py                   # the pool and the migration runner (cloud only)
 └── runner.py               # the two halves of the day, over a store
+
+migrations/                 # plain SQL, applied in order by migrate.py
 
 web/
 ├── __init__.py             # create_app()
@@ -591,7 +597,7 @@ Critical path is 0 → 1 → 2 → 3. Phases 4–6 can run alongside 3. Nothing 
 - [x] **Decision 11, single-mode half:** `refresh_minutes` and `brief_time` in `DEFAULTS`; `runner.run` split into `refresh_calendars` and `write_brief`; a pure `due()`; `generate.py --tick`; the settings page under *This screen*; the board's reload derived from the interval; README cron line updated. Ships to the Pi at once and needs no database. *(DIN-17 for the engine and cron, DIN-18 for the page)*
 - [x] Name the storage seam: `FileStore` gathering the six operations that exist today, and the settings routes, runner and board taking a store *(DIN-19)*
 - [ ] `Dockerfile` and `docker-compose.yml` for single mode (`web` only) — the self-host path is real from here on, the image is what App Platform builds, and every later phase reuses both *(DIN-30)*
-- [ ] Postgres + plain-SQL migrations; CI running the suite against a Postgres service container *(DIN-31)*
+- [x] Postgres + plain-SQL migrations; CI running the suite against a Postgres service container *(DIN-31)*
 - [ ] Move DNS to Cloudflare and add the `app` and `staging.app` records *(DIN-29)*. The apex keeps pointing at GitHub Pages until DIN-27 moves the marketing pages onto the app.
 - [ ] Stand up the App Platform app and the Managed Postgres cluster in Frankfurt; staging live on `staging.app.dinkydash.co` *(DIN-26)*
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -404,15 +404,73 @@ in the app:
 - `sslmode=require`, against DigitalOcean's CA certificate. `DATABASE_URL`
   carries it; nothing else in the app needs to know.
 - **Connection limits are small** on the cheap node — **22**, and that is the
-  whole cluster. Gunicorn workers plus the tick worker will exhaust it by
-  accident, and the failure is a 500 on the board, not a slow page. Either bound
-  a `psycopg_pool` in each process, or use DigitalOcean's own connection pool
-  (their hosted PgBouncer) and point `DATABASE_URL` at that. Decide before
-  Phase 1, not when it breaks.
+  whole cluster (25 per GiB of RAM, less 3 reserved for maintenance). Gunicorn
+  workers plus the tick worker would exhaust it by accident, and the failure is
+  a 500 on the board, not a slow page. **Settled: both, with a division of
+  labour** — see [Connection pooling](#connection-pooling) below.
 - Daily backups and 7-day point-in-time recovery are on by default and are
   theirs. **The restore drill is still ours** — see Phase 6.
 - One cluster, two databases: `dinkydash` and `dinkydash_staging`. A second
   cluster for staging is $15 a month to learn nothing.
+
+#### Connection pooling
+
+*Settled 7 September 2026, after reading how KeepTheScore does it.*
+
+**DigitalOcean's own connection pool (their hosted PgBouncer) in transaction
+mode makes exhaustion impossible; a small `psycopg_pool` in each process makes
+the common case fast.** One decides safety, the other decides speed, and
+getting the second one wrong then costs latency rather than an outage.
+
+```python
+pool = ConnectionPool(
+    os.environ["DATABASE_URL"],      # DigitalOcean's pool, transaction mode
+    min_size=1, max_size=3,
+    configure=lambda conn: setattr(conn, "prepare_threshold", None),
+)
+```
+
+**Why not the app-side pool alone.** Production web, production worker, staging
+web and staging worker is four processes sharing one cluster from the first day
+DIN-26 stands staging up, before the migration job or a `psql` window. The
+arithmetic is tight enough that a third gunicorn worker tips it over. PgBouncer
+turns "connection refused" into "wait a moment", and that change of failure mode
+is the whole reason it is there.
+
+**Why not the DigitalOcean pool alone.** KeepTheScore is the natural experiment:
+same host, same managed Postgres, pool on the DigitalOcean side, no client-side
+pool, and `db.close()` on every request — so every request pays a fresh TCP and
+TLS handshake to the pool endpoint. It has never broken, and nobody has ever
+measured what it costs. Filed as LBD-685. We get the client-side half for free
+by writing it once, before `PostgresStore` exists.
+
+**Transaction mode, not session mode.** DigitalOcean recommends session mode for
+applications that use prepared statements, advisory locks or listen/notify. We
+use none of them — the daily idempotency is a unique constraint on
+`(family_id, generated_for_date)`, not a lock. Session mode holds a backend
+connection for a client's whole session, so it barely multiplexes and the
+arithmetic above comes straight back.
+
+**`prepare_threshold=None`, everywhere, including local development and CI.**
+psycopg 3 prepares a statement server-side once it repeats, and under
+transaction-mode pooling the next execution can land on a different backend
+connection: `prepared statement "..." does not exist`, intermittently, under
+load, after staging looked fine. This is the one line that differs from
+KeepTheScore, which is on psycopg2 and never auto-prepares — their clean record
+does not transfer. Setting it unconditionally means one behaviour rather than
+two. The cost is nil at this query volume.
+
+**Two connection strings.** `DATABASE_URL` (pooled) for `web` and `worker`;
+`DATABASE_URL_DIRECT` (the cluster, port 25060) for the pre-deploy migration job
+and for `pg_dump`. DigitalOcean documents that `pg_dump` errors against a
+transaction-mode pool, and `CREATE INDEX CONCURRENTLY` cannot run inside a
+transaction block. Both are named in `.do/app.yaml`. KeepTheScore has exactly
+this shape already, arrived at by accident and written down as a naming quirk.
+
+**Always `with pool.connection() as conn:`.** The connection returns to the pool
+on the error path too. Skipping that is how KEEPTHESCORE-28A happened next door:
+a view raised, the connection was never released, and the next request on that
+thread got a dead one.
 
 **Deploy.** Push to `main`; App Platform builds the Dockerfile and rolls the
 components out with a health check on `/healthz`. Migrations run as a

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ pip install -r requirements-dev.txt   # adds pytest and the website build; not n
 python -m pytest tests/ -q
 ```
 
-264 tests, well under a second. They cover leap years, timezone conversion, event ordering, chore
+302 tests, well under a second. They cover leap years, timezone conversion, event ordering, chore
 rotation, the stale-board logic, the config round-trip, and the settings routes that write it.
 
 GitHub Actions runs the same command on every push and pull request, on Python 3.11
@@ -631,13 +631,14 @@ tail -f /home/pi/dinkydash/generate.log   # last night's generation
 | `dinkydash/runner.py` | The two halves of the cycle: `refresh_calendars` and `write_brief` |
 | `dinkydash/schedule.py` | `due()` — which of the two the clock and the config owe right now |
 | `dinkydash/store.py` | Where the config, the board and the note history are kept |
+| `migrations/` | The hosted schema, plain SQL. Self-hosting needs none of it |
 | `web/` | Flask app — board, settings UI, templates |
 | `web/templates/board.html` | The board itself, light and dark, all screen sizes |
 | `generate.py` | Command-line skin over `dinkydash.runner` — this is what cron calls |
 | `app.py` | Flask entry point |
 | `config.yaml` | All configuration. The settings UI writes this same file |
 | `config.example.yaml` | Template config, documenting every key |
-| `tests/` | 264 tests. Run them before committing |
+| `tests/` | 302 tests. Run them before committing |
 | `design/` | Mockups for the board and settings UI, with the reasoning |
 | `deploy_to_pi.sh` | Deployment (rsync + service restart) |
 | `.env` | `ANTHROPIC_API_KEY` (not in git) |

--- a/dinkydash/db.py
+++ b/dinkydash/db.py
@@ -1,0 +1,177 @@
+"""Connections and migrations. The only module that imports psycopg.
+
+Cloud mode only. Single mode never imports this, which is what keeps a
+Raspberry Pi from installing a Postgres driver it will never open — psycopg
+lives in `requirements-cloud.txt`, not `requirements.txt`.
+
+Two connection strings, and the difference matters (PLAN.md, Connection
+pooling):
+
+    DATABASE_URL         DigitalOcean's connection pool, transaction mode.
+                         What `web` and `worker` use, through `pool()` below.
+    DATABASE_URL_DIRECT  The cluster itself. What migrations and pg_dump use.
+                         CREATE INDEX CONCURRENTLY cannot run inside a
+                         transaction block, and pg_dump errors against a
+                         transaction-mode pool.
+"""
+
+import logging
+import os
+import re
+from pathlib import Path
+
+import psycopg
+from psycopg_pool import ConnectionPool
+
+log = logging.getLogger(__name__)
+
+MIGRATIONS_DIR = Path(__file__).resolve().parent.parent / "migrations"
+
+# A migration whose text carries this marker is applied outside a transaction,
+# because some statements refuse to run inside one. CREATE INDEX CONCURRENTLY is
+# the reason it exists: on a live table it is the difference between a fast index
+# and locking out every family while it builds.
+NO_TRANSACTION = "-- no-transaction"
+
+
+def _prepare(conn):
+    """What every connection needs before it is used.
+
+    psycopg prepares a statement server-side once it repeats, and under
+    transaction-mode pooling the next execution can land on a different backend
+    connection — `prepared statement "..." does not exist`, intermittently,
+    under load, after staging looked fine. Off everywhere, including local
+    development and CI, so there is one behaviour rather than two.
+    """
+    conn.prepare_threshold = None
+
+
+def pool(conninfo=None, min_size=1, max_size=3, **kwargs):
+    """A bounded pool for one process.
+
+    Small on purpose. DigitalOcean's own pool is what stops the cluster's 22
+    connections running out; this one only saves a TCP and TLS handshake per
+    request, so its size is a latency knob rather than a safety one.
+
+    `max_lifetime` (1 hour) and `max_idle` (10 minutes) keep their psycopg
+    defaults: a pooled connection handed out after the far end has quietly gone
+    away is the "SSL connection has been closed unexpectedly" class of failure.
+    """
+    conninfo = conninfo or require("DATABASE_URL")
+    return ConnectionPool(conninfo, min_size=min_size, max_size=max_size,
+                          configure=_prepare, open=True, **kwargs)
+
+
+def connect(conninfo=None):
+    """One connection, outside any pool. For migrations and one-off scripts.
+
+    Autocommit, so that `conn.transaction()` means what it looks like it means —
+    see the note in `migrate`.
+    """
+    conn = psycopg.connect(conninfo or require("DATABASE_URL_DIRECT"), autocommit=True)
+    _prepare(conn)
+    return conn
+
+
+def require(name):
+    """An environment variable that cloud mode cannot start without.
+
+    Never logs the value: a connection string carries a password, and the point
+    of this function is to be safe to call from a startup path that logs.
+    """
+    value = os.environ.get(name)
+    if not value:
+        raise RuntimeError(f"{name} is not set. Cloud mode needs it to start.")
+    return value
+
+
+def migrations(directory=None):
+    """Every migration on disk, in the order its name sorts."""
+    directory = Path(directory) if directory else MIGRATIONS_DIR
+    return sorted(directory.glob("*.sql"))
+
+
+def migrate(conn, directory=None):
+    """Apply whatever has not been applied. Returns the names it ran.
+
+    Each migration runs in its own transaction and is recorded in the same one,
+    so a failure half way through leaves that migration entirely unapplied and
+    the next run tries it again. Migrations marked `-- no-transaction` cannot
+    have that guarantee and have to be written to be safe when re-run — which is
+    why every index in them is `IF NOT EXISTS`.
+
+    **The connection has to be autocommit**, and this is not a detail. Without
+    it, psycopg opens an implicit transaction on the first statement — the
+    SELECT below is enough — and `conn.transaction()` entered inside an open
+    transaction is a *savepoint*, not a BEGIN. Every migration then appears to
+    apply, releases its savepoint, and is thrown away when the connection
+    closes. It is silent: no error, tables gone, `schema_migrations` empty.
+    """
+    was_autocommit = conn.autocommit
+    conn.autocommit = True
+    try:
+        return _migrate(conn, directory)
+    finally:
+        conn.autocommit = was_autocommit
+
+
+def _migrate(conn, directory):
+    _ensure_bookkeeping(conn)
+    with conn.cursor() as cur:
+        cur.execute("SELECT name FROM schema_migrations")
+        done = {row[0] for row in cur.fetchall()}
+
+    applied = []
+    for path in migrations(directory):
+        if path.name in done:
+            continue
+        sql = path.read_text()
+        log.info("Applying %s", path.name)
+        if NO_TRANSACTION in sql:
+            _apply_unwrapped(conn, path, sql)
+        else:
+            _apply(conn, path, sql)
+        applied.append(path.name)
+
+    if not applied:
+        log.info("Schema is up to date (%d migration(s) already applied)", len(done))
+    return applied
+
+
+def _apply(conn, path, sql):
+    with conn.transaction():
+        with conn.cursor() as cur:
+            cur.execute(sql)
+            cur.execute("INSERT INTO schema_migrations (name) VALUES (%s)", (path.name,))
+
+
+def _apply_unwrapped(conn, path, sql):
+    """Statement by statement, outside a transaction.
+
+    psycopg sends a multi-statement `execute` as one implicit transaction, which
+    is exactly what CONCURRENTLY refuses, so the file is split first. The split
+    is naive — a semicolon inside a string literal or a function body would
+    break it — which is the price of the escape hatch and the reason the marker
+    is opt-in rather than the default.
+    """
+    with conn.cursor() as cur:  # the connection is already autocommit; see migrate()
+        for statement in _statements(sql):
+            cur.execute(statement)
+        cur.execute("INSERT INTO schema_migrations (name) VALUES (%s)", (path.name,))
+
+
+def _statements(sql):
+    stripped = re.sub(r"--[^\n]*", "", sql)
+    return [s.strip() for s in stripped.split(";") if s.strip()]
+
+
+def _ensure_bookkeeping(conn):
+    """The table that records what has run. Created before anything else can."""
+    with conn.transaction():
+        with conn.cursor() as cur:
+            cur.execute("""
+                CREATE TABLE IF NOT EXISTS schema_migrations (
+                    name       TEXT PRIMARY KEY,
+                    applied_at TIMESTAMPTZ NOT NULL DEFAULT now()
+                )
+            """)

--- a/dinkydash/pgstore.py
+++ b/dinkydash/pgstore.py
@@ -1,0 +1,273 @@
+"""The cloud half of the storage seam: one family's rows in Postgres.
+
+Same six operations as `FileStore`, same dicts in and out, so the runner, the
+board route and the settings routes cannot tell which one they were handed
+(PLAN.md decision 10, and the seam named in DIN-19).
+
+Kept in its own module rather than beside `FileStore` for one reason: single
+mode must never import psycopg. A Raspberry Pi has no database and should not
+install a driver for one, so `psycopg` lives in `requirements-cloud.txt` and
+`dinkydash/store.py` stays importable with nothing but the standard library and
+ruamel.
+
+**Every query is scoped to `self.family_id`.** There is no unscoped read and no
+unscoped write in this file, and there must never be one — an id arriving in a
+URL is a claim, not a fact, and the place to check it is before it reaches a
+store, not inside one.
+
+Where the payload lives:
+
+    events, calendar_statuses, calendars_fetched_at  ->  agendas    (one row)
+    headline, note, note_kind                        ->  generations.brief
+    generated_for_date, generated_at, model, tokens  ->  generations columns
+
+That split is `runner.REFRESH_KEYS`, which already names which half a refresh
+owns. `load_payload` puts the two back together as the dict the engine takes.
+"""
+
+import logging
+from datetime import date, datetime, timezone
+
+from psycopg.types.json import Jsonb
+
+from . import config as config_module
+
+log = logging.getLogger(__name__)
+
+# The keys a calendar refresh owns, and the only ones that reach `agendas`.
+# Deliberately a copy rather than an import from `runner`: the store is below
+# the runner, and importing upwards would make the engine's own dependency graph
+# a circle. The test suite asserts the two lists agree.
+REFRESH_KEYS = ("events", "calendar_statuses", "calendars_fetched_at")
+
+# What `generations` holds in real columns rather than inside `brief`.
+GENERATION_COLUMNS = ("generated_for_date", "generated_at", "model",
+                      "input_tokens", "output_tokens")
+
+# Everything else the model wrote. Anything the payload gains that is not named
+# above lands here too, so a new key needs no migration.
+BRIEF_KEYS = ("headline", "note", "note_kind")
+
+
+class PostgresStore:
+    """One family, as rows. Construct one per request or per worker iteration."""
+
+    def __init__(self, pool, family_id):
+        self.pool = pool
+        self.family_id = family_id
+
+    # -- the config ---------------------------------------------------------
+
+    def load_config(self):
+        with self.pool.connection() as conn, conn.cursor() as cur:
+            cur.execute("SELECT config FROM families WHERE id = %s", (self.family_id,))
+            row = cur.fetchone()
+        if row is None:
+            raise LookupError(f"No family {self.family_id}")
+        return config_module.with_defaults(dict(row[0] or {}))
+
+    def save_config(self, config):
+        with self.pool.connection() as conn, conn.transaction():
+            with conn.cursor() as cur:
+                cur.execute(
+                    "UPDATE families SET config = %s, updated_at = now() WHERE id = %s",
+                    (Jsonb(_plain(config)), self.family_id),
+                )
+
+    # -- the board ----------------------------------------------------------
+
+    def load_payload(self, config=None):
+        """The stored board, or None when this family has never had one."""
+        with self.pool.connection() as conn, conn.cursor() as cur:
+            cur.execute(
+                "SELECT events, statuses, fetched_at FROM agendas WHERE family_id = %s",
+                (self.family_id,),
+            )
+            agenda = cur.fetchone()
+            cur.execute(
+                """SELECT brief, generated_for_date, generated_at, model,
+                          input_tokens, output_tokens
+                   FROM generations
+                   WHERE family_id = %s AND status = 'ok'
+                   ORDER BY generated_for_date DESC
+                   LIMIT 1""",
+                (self.family_id,),
+            )
+            generation = cur.fetchone()
+
+        if agenda is None and generation is None:
+            return None
+
+        payload = {}
+        if generation is not None:
+            brief, for_date, at, model, tokens_in, tokens_out = generation
+            payload.update(brief or {})
+            payload["generated_for_date"] = _iso(for_date)
+            payload["generated_at"] = _iso(at)
+            payload["model"] = model
+            payload["input_tokens"] = tokens_in
+            payload["output_tokens"] = tokens_out
+        if agenda is not None:
+            events, statuses, fetched_at = agenda
+            payload["events"] = events or []
+            payload["calendar_statuses"] = statuses or []
+            payload["calendars_fetched_at"] = _iso(fetched_at)
+        return payload
+
+    def save_payload(self, config, payload):
+        """Split the payload across the two tables, in one transaction.
+
+        Both halves are written together because `refresh_calendars` and
+        `write_brief` each hand over a whole payload, and a board that had the
+        new agenda under no headline — or the reverse — would be a state neither
+        function believes it can produce.
+        """
+        agenda = tuple(payload.get(key) for key in REFRESH_KEYS)
+        for_date = payload.get("generated_for_date")
+
+        with self.pool.connection() as conn, conn.transaction():
+            with conn.cursor() as cur:
+                cur.execute(
+                    """INSERT INTO agendas (family_id, events, statuses, fetched_at)
+                       VALUES (%s, %s, %s, %s)
+                       ON CONFLICT (family_id) DO UPDATE
+                       SET events = EXCLUDED.events,
+                           statuses = EXCLUDED.statuses,
+                           fetched_at = EXCLUDED.fetched_at""",
+                    (self.family_id, Jsonb(agenda[0] or []), Jsonb(agenda[1] or []),
+                     _stamp(agenda[2])),
+                )
+                if not for_date:
+                    # A refresh that ran before the first brief. There is no
+                    # generation to write, and inventing one would put a board
+                    # with no words on the wall claiming a date.
+                    return
+                cur.execute(
+                    """INSERT INTO generations
+                           (family_id, generated_for_date, generated_at, brief,
+                            model, input_tokens, output_tokens)
+                       VALUES (%s, %s, %s, %s, %s, %s, %s)
+                       ON CONFLICT (family_id, generated_for_date) DO UPDATE
+                       SET generated_at = EXCLUDED.generated_at,
+                           brief = EXCLUDED.brief,
+                           model = EXCLUDED.model,
+                           input_tokens = EXCLUDED.input_tokens,
+                           output_tokens = EXCLUDED.output_tokens""",
+                    (self.family_id, _as_date(for_date), _stamp(payload.get("generated_at")),
+                     Jsonb(_brief(payload)), payload.get("model"),
+                     payload.get("input_tokens"), payload.get("output_tokens")),
+                )
+
+    # -- what was written recently ------------------------------------------
+
+    def recent_notes(self, config, days):
+        with self.pool.connection() as conn, conn.cursor() as cur:
+            cur.execute(
+                """SELECT note FROM (
+                       SELECT id, note FROM content_history
+                       WHERE family_id = %s
+                       ORDER BY id DESC LIMIT %s
+                   ) recent ORDER BY id ASC""",
+                (self.family_id, days),
+            )
+            return [row[0] for row in cur.fetchall() if row[0]]
+
+    def record_note(self, config, entry, keep=30):
+        """Add one entry and trim to the last `keep`. Never raises.
+
+        A history that cannot be written costs a repeated octopus fact in a
+        fortnight; it is not worth losing a written board over. Same promise
+        `FileStore` makes, for the same reason.
+        """
+        try:
+            with self.pool.connection() as conn, conn.transaction():
+                with conn.cursor() as cur:
+                    cur.execute(
+                        """INSERT INTO content_history
+                               (family_id, date, headline, note, note_kind)
+                           VALUES (%s, %s, %s, %s, %s)""",
+                        (self.family_id, _as_date(entry.get("date")),
+                         entry.get("headline"), entry.get("note"), entry.get("note_kind")),
+                    )
+                    # Trimmed here rather than by a nightly job, so the table
+                    # cannot grow between sweeps and Phase 5's retention answer
+                    # stays "the last thirty, always".
+                    cur.execute(
+                        """DELETE FROM content_history
+                           WHERE family_id = %s AND id NOT IN (
+                               SELECT id FROM content_history
+                               WHERE family_id = %s ORDER BY id DESC LIMIT %s
+                           )""",
+                        (self.family_id, self.family_id, keep),
+                    )
+        except Exception as exc:
+            log.warning("Could not write the note history: %s", exc)
+
+
+def _brief(payload):
+    """The model's words, plus anything new the payload has grown.
+
+    Named keys go in explicitly; the rest is swept up so a payload that gains a
+    key still round-trips without a migration. The refresh keys and the columns
+    above are the only things kept out.
+    """
+    kept = set(REFRESH_KEYS) | set(GENERATION_COLUMNS)
+    brief = {key: value for key, value in payload.items() if key not in kept}
+    for key in BRIEF_KEYS:
+        brief.setdefault(key, payload.get(key))
+    return brief
+
+
+def _plain(value):
+    """A config dict as plain JSON types.
+
+    Single mode's dict is ruamel's CommentedMap with DoubleQuotedScalarString
+    values — both subclasses of dict and str, so they serialise, but they carry
+    comment and style objects that mean nothing here.
+    """
+    if isinstance(value, dict):
+        return {str(k): _plain(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_plain(v) for v in value]
+    if isinstance(value, str):
+        return str(value)
+    return value
+
+
+def _iso(value):
+    """A stamp as the payload holds it: an ISO string in UTC, or None.
+
+    `FileStore` stores what the runner wrote, which is always UTC ISO. Postgres
+    hands back an aware datetime in whatever the session zone is, so it is
+    converted rather than formatted — otherwise the two stores would disagree
+    about what time a board was written, and only one of them would be right.
+    """
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value.astimezone(timezone.utc).isoformat()
+    if isinstance(value, date):
+        return value.isoformat()
+    return str(value)
+
+
+def _stamp(value):
+    """An ISO string from the payload as a datetime Postgres will take."""
+    if not value:
+        return None
+    if isinstance(value, datetime):
+        return value
+    try:
+        moment = datetime.fromisoformat(str(value))
+    except ValueError:
+        return None
+    return moment if moment.tzinfo else moment.replace(tzinfo=timezone.utc)
+
+
+def _as_date(value):
+    if not value or isinstance(value, date):
+        return value or None
+    try:
+        return date.fromisoformat(str(value))
+    except ValueError:
+        return None

--- a/migrate.py
+++ b/migrate.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Apply the database schema. Cloud mode only.
+
+App Platform runs this as a **pre-deploy job**, so a failed migration fails the
+deploy rather than half-updating a live app, and the schema is always ahead of
+the code that needs it.
+
+    python migrate.py            # apply what is outstanding
+    python migrate.py --status   # say what would run, change nothing
+
+It connects with `DATABASE_URL_DIRECT` — the cluster, not the pool. CREATE INDEX
+CONCURRENTLY cannot run inside a transaction block, and a transaction-mode
+PgBouncer is the wrong end for schema work (PLAN.md, Connection pooling).
+"""
+
+import argparse
+import logging
+import sys
+
+from dotenv import load_dotenv
+
+from dinkydash import db
+
+load_dotenv()
+log = logging.getLogger("dinkydash.migrate")
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Apply the DinkyDash schema.")
+    parser.add_argument("--status", action="store_true",
+                        help="say what is outstanding and change nothing")
+    parser.add_argument("--database-url", help="override DATABASE_URL_DIRECT")
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s",
+                        stream=sys.stdout)
+
+    try:
+        conn = db.connect(args.database_url)
+    except Exception as exc:
+        # Never the connection string itself — it carries a password.
+        log.error("Could not reach the database: %s", type(exc).__name__)
+        return 1
+
+    try:
+        if args.status:
+            return status(conn)
+        applied = db.migrate(conn)
+        for name in applied:
+            log.info("Applied %s", name)
+        return 0
+    except Exception:
+        log.exception("Migration failed; nothing further was applied")
+        return 1
+    finally:
+        conn.close()
+
+
+def status(conn):
+    """What has run and what has not. Read-only apart from the bookkeeping table."""
+    db._ensure_bookkeeping(conn)
+    with conn.cursor() as cur:
+        cur.execute("SELECT name FROM schema_migrations")
+        done = {row[0] for row in cur.fetchall()}
+    outstanding = [p.name for p in db.migrations() if p.name not in done]
+    for name in sorted(done):
+        log.info("applied     %s", name)
+    for name in outstanding:
+        log.info("OUTSTANDING %s", name)
+    if not outstanding:
+        log.info("Schema is up to date.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/migrations/001_initial_schema.sql
+++ b/migrations/001_initial_schema.sql
@@ -1,0 +1,200 @@
+-- The hosted schema: one row per family, and the platform's own bookkeeping.
+--
+-- Config is one jsonb document rather than five tables (PLAN.md decision 10 and
+-- the data model sketch). Nothing in the product ever asks which families have a
+-- child born in March, so a table each for people, pets, chores, dates and
+-- calendars would buy five sets of CRUD code and no answers. Real columns are
+-- for what the *platform* queries or writes; the parent's own settings stay in
+-- the dict the engine already takes.
+--
+-- Conventions, matching the ones used across these projects: TEXT with a CHECK
+-- rather than VARCHAR(n), GENERATED ALWAYS AS IDENTITY rather than SERIAL, and
+-- TIMESTAMPTZ rather than TIMESTAMP so a server that is nowhere near the family
+-- still stores an unambiguous instant.
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;   -- gen_random_uuid()
+
+
+-- Families ------------------------------------------------------------------
+--
+-- The tenant. Its id is a uuid rather than an integer because it is the one key
+-- that reaches a URL and a log line, and a sequential id there would publish how
+-- many families we have and invite somebody to walk them. Every other table is
+-- addressed only from inside a family, so those keep cheap bigint identities.
+
+CREATE TABLE families (
+    id                      UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+    -- One plan at MVP (PLAN.md decision 6). A column rather than a constant
+    -- because the first thing a second plan needs is somewhere to be recorded.
+    plan                    TEXT NOT NULL DEFAULT 'standard'
+                            CHECK (plan IN ('standard')),
+
+    -- The trial lives here, not in Stripe (PLAN.md phase 4): a family that never
+    -- converts never becomes a Stripe customer.
+    status                  TEXT NOT NULL DEFAULT 'trialing'
+                            CHECK (status IN ('trialing', 'active', 'past_due',
+                                              'canceled', 'lapsed')),
+    trial_ends_at           TIMESTAMPTZ,
+    stripe_customer_id      TEXT UNIQUE CHECK (length(stripe_customer_id) <= 255),
+
+    -- A bearer credential: whoever holds it sees the board. 12 characters of
+    -- dinkydash.config.ID_ALPHABET is ~59 bits and still readable off a TV
+    -- screen (PLAN.md, Screen URLs). Rotatable, so the column is not immutable.
+    screen_token            TEXT NOT NULL UNIQUE
+                            CHECK (length(screen_token) BETWEEN 10 AND 32),
+    screen_token_rotated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    -- The same dict config.yaml holds. with_defaults migrates old shapes on
+    -- load, in both modes, so a new setting needs no migration here.
+    config                  JSONB NOT NULL DEFAULT '{}'::jsonb,
+
+    created_at              TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at              TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- What the worker selects on every five minutes: whose local clock has passed
+-- their brief_time. An expression index is as fast as a column here and leaves
+-- no second copy of the timezone to drift out of step with the config.
+CREATE INDEX families_timezone_idx ON families ((config ->> 'timezone'));
+
+-- Phase 6's admin view and the lapse sweep both walk this.
+CREATE INDEX families_status_idx ON families (status);
+
+
+-- Users ---------------------------------------------------------------------
+--
+-- One parent per family at MVP; shared edit access is explicitly out of scope.
+-- Email is globally unique because a magic link has to resolve to exactly one
+-- person without being told which family they belong to.
+
+CREATE TABLE users (
+    id            BIGINT PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+    family_id     UUID NOT NULL REFERENCES families (id) ON DELETE CASCADE,
+    email         TEXT NOT NULL UNIQUE CHECK (length(email) <= 320),
+    last_login_at TIMESTAMPTZ,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX users_family_idx ON users (family_id);
+
+
+-- Login tokens --------------------------------------------------------------
+--
+-- Hashed at rest, single use, short lived (PLAN.md phase 1). Only the hash is
+-- stored, so a database leak does not hand anybody a working login link; the
+-- plaintext exists for the length of one email.
+
+CREATE TABLE login_tokens (
+    id         BIGINT PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+    user_id    BIGINT NOT NULL REFERENCES users (id) ON DELETE CASCADE,
+    token_hash TEXT NOT NULL UNIQUE CHECK (length(token_hash) <= 128),
+    expires_at TIMESTAMPTZ NOT NULL,
+    used_at    TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- The sweep that deletes expired tokens, and the rate limit on requesting one.
+CREATE INDEX login_tokens_expires_idx ON login_tokens (expires_at);
+CREATE INDEX login_tokens_user_idx ON login_tokens (user_id);
+
+
+-- Agendas -------------------------------------------------------------------
+--
+-- The fetched calendar window: one row per family, overwritten on every
+-- refresh. Calendar contents therefore never accumulate — the most we ever hold
+-- about a family is one fourteen-day window, which is what makes Phase 5's
+-- retention answer short.
+
+CREATE TABLE agendas (
+    family_id  UUID PRIMARY KEY REFERENCES families (id) ON DELETE CASCADE,
+    events     JSONB NOT NULL DEFAULT '[]'::jsonb,
+    statuses   JSONB NOT NULL DEFAULT '[]'::jsonb,
+
+    -- Nullable on purpose: "never fetched" has to be representable, because it
+    -- is one of the two cases `schedule.due` asks about (missing, or older than
+    -- refresh_minutes). A DEFAULT now() here would claim a fetch that a brief
+    -- written before the first refresh never made.
+    fetched_at TIMESTAMPTZ
+);
+
+-- The worker's other question: whose calendars are older than their interval.
+CREATE INDEX agendas_fetched_at_idx ON agendas (fetched_at);
+
+
+-- Calendar health -----------------------------------------------------------
+--
+-- Keyed on the calendar's id *inside the config*, which exists precisely because
+-- list items carry stable ids. Fetch state is something the platform writes, so
+-- it does not belong in the parent's document.
+
+CREATE TABLE calendar_health (
+    id                   BIGINT PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+    family_id            UUID NOT NULL REFERENCES families (id) ON DELETE CASCADE,
+    calendar_id          TEXT NOT NULL CHECK (length(calendar_id) <= 64),
+    last_fetch_at        TIMESTAMPTZ,
+    last_fetch_status    TEXT CHECK (last_fetch_status IN ('ok', 'failed', 'paused')),
+    -- Never the URL, and never the exception text that contains it: a failed
+    -- fetch formats the secret address into its message (CLAUDE.md gotcha).
+    last_fetch_detail    TEXT CHECK (length(last_fetch_detail) <= 500),
+    consecutive_failures INTEGER NOT NULL DEFAULT 0,
+
+    UNIQUE (family_id, calendar_id)
+);
+
+
+-- Generations ---------------------------------------------------------------
+--
+-- One row per family per day: the model's words, and what they cost.
+
+CREATE TABLE generations (
+    id                 BIGINT PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+    family_id          UUID NOT NULL REFERENCES families (id) ON DELETE CASCADE,
+    generated_for_date DATE NOT NULL,
+
+    -- Nullable for the same reason agendas.fetched_at is: a payload whose stamp
+    -- is missing or unreadable has to be storable, or cloud mode would reject a
+    -- board that single mode accepts. The settings page already renders it as
+    -- "written earlier".
+    generated_at       TIMESTAMPTZ,
+    status             TEXT NOT NULL DEFAULT 'ok' CHECK (status IN ('ok', 'error')),
+
+    -- headline, note, note_kind — the only part of the payload that cannot be
+    -- recomputed from config + date. Dropped after 90 days (PLAN.md phase 5);
+    -- the token counts below stay, because they are the cost record.
+    brief              JSONB,
+
+    input_tokens       INTEGER,
+    output_tokens      INTEGER,
+    cost_cents         NUMERIC(10, 4),
+    model              TEXT CHECK (length(model) <= 100),
+    error              TEXT CHECK (length(error) <= 500),
+
+    -- The daily idempotency, and it is a constraint rather than a check in the
+    -- worker because the worker will one day run twice at once.
+    UNIQUE (family_id, generated_for_date)
+);
+
+-- "The latest brief for this family", which is every board render.
+CREATE INDEX generations_family_date_idx
+    ON generations (family_id, generated_for_date DESC);
+
+
+-- Content history -----------------------------------------------------------
+--
+-- What was written recently, fed back into the prompt so the board does not
+-- repeat the same octopus fact every fortnight. Trimmed to the last 30 entries
+-- per family.
+
+CREATE TABLE content_history (
+    id         BIGINT PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+    family_id  UUID NOT NULL REFERENCES families (id) ON DELETE CASCADE,
+    date       DATE NOT NULL,
+    headline   TEXT CHECK (length(headline) <= 500),
+    note       TEXT CHECK (length(note) <= 1000),
+    note_kind  TEXT CHECK (length(note_kind) <= 50),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Reading the last N, and trimming everything past them.
+CREATE INDEX content_history_family_id_idx ON content_history (family_id, id DESC);

--- a/requirements-cloud.txt
+++ b/requirements-cloud.txt
@@ -1,0 +1,10 @@
+-r requirements.txt
+
+# Cloud mode only. Deliberately not in requirements.txt, which is what
+# deploy_to_pi.sh installs: a self-hosted board has no database, and a Pi should
+# not carry a Postgres driver it will never open. The Dockerfile (DIN-30)
+# installs this file for the hosted image.
+#
+# Pinned with == like the rest, so a clean build gets what CI passed on.
+psycopg[binary]==3.3.5
+psycopg-pool==3.3.1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,71 @@
+"""Shared fixtures.
+
+The only thing here is the Postgres one, because it is the only fixture that
+needs a resource the test suite cannot invent for itself.
+
+**A self-hoster's `pytest` must pass with no database.** So the Postgres tests
+skip unless `DINKYDASH_TEST_DATABASE_URL` is set, and nothing here imports
+psycopg at module level — psycopg lives in `requirements-cloud.txt`, which a Pi
+never installs. CI sets the variable against a service container, so the parity
+assertions really do run on every push.
+
+    DINKYDASH_TEST_DATABASE_URL=postgresql:///dinkydash_test venv/bin/python -m pytest
+"""
+
+import os
+
+import pytest
+
+TEST_DATABASE_URL = "DINKYDASH_TEST_DATABASE_URL"
+
+
+def database_url():
+    return os.environ.get(TEST_DATABASE_URL)
+
+
+@pytest.fixture(scope="session")
+def pg_pool():
+    """A pool against a freshly migrated scratch database, or a skip.
+
+    Session-scoped: migrating once and truncating between tests is a great deal
+    faster than rebuilding the schema per test, and truncation is the thing that
+    actually has to be reliable.
+    """
+    url = database_url()
+    if not url:
+        pytest.skip(f"{TEST_DATABASE_URL} is not set")
+
+    from dinkydash import db
+
+    conn = db.connect(url)
+    try:
+        db.migrate(conn)
+    finally:
+        conn.close()
+
+    pool = db.pool(url, min_size=1, max_size=2)
+    pool.wait(timeout=10)
+    yield pool
+    pool.close()
+
+
+@pytest.fixture
+def pg_family(pg_pool):
+    """One empty family, and everything belonging to it removed afterwards.
+
+    Returns its id. Truncating `families` cascades to every other table, which
+    is also a live check that the foreign keys really do cascade — Phase 5's
+    hard delete depends on exactly that.
+    """
+    with pg_pool.connection() as conn, conn.transaction():
+        with conn.cursor() as cur:
+            cur.execute(
+                """INSERT INTO families (screen_token, config)
+                   VALUES (%s, '{}'::jsonb) RETURNING id""",
+                ("tok" + os.urandom(6).hex(),),
+            )
+            family_id = cur.fetchone()[0]
+    yield family_id
+    with pg_pool.connection() as conn, conn.transaction():
+        with conn.cursor() as cur:
+            cur.execute("DELETE FROM families WHERE id = %s", (family_id,))

--- a/tests/test_cloud_mode.py
+++ b/tests/test_cloud_mode.py
@@ -1,0 +1,151 @@
+"""What `DINKYDASH_MODE=cloud` changes, and what it must not.
+
+Mode gates four things across the product — authentication, billing, where the
+config is stored, and what drives the scheduler. Two of them exist so far, and
+both are here: the storage backend, and the refusal to start on a fallback
+session key. Everything else is asserted to be identical, because a mode check
+anywhere else would mean the change went in the wrong layer.
+"""
+
+import pytest
+
+from dinkydash import config as config_module
+from web import create_app
+
+CONFIG = {
+    "family_name": "The Wilsons",
+    "timezone": "Europe/Berlin",
+    "theme": "light",
+    "people": [{"id": "mia12345", "name": "Mia", "date_of_birth": "2017-03-15"}],
+    "recurring": [{"id": "job12345", "title": "Set the table",
+                   "choices": ["Mia"], "emoji": "🍽"}],
+}
+
+def payload_for_today():
+    """A board written this morning, on the family's clock.
+
+    Dated from the real clock rather than pinned, because a payload from a fixed
+    date would be *stale* by the time anybody ran this — and a stale board
+    replaces the model's headline with a computed one, which is correct
+    behaviour and would make this test look broken for the wrong reason.
+    """
+    today = config_module.today_for(config_module.with_defaults(dict(CONFIG)))
+    return {
+        "generated_for_date": today.isoformat(),
+        "generated_at": f"{today.isoformat()}T04:00:00+00:00",
+        "headline": "Swimming, then football",
+        "note": "An octopus fact.",
+        "note_kind": "fact",
+        "model": "claude-haiku-4-5",
+        "input_tokens": 100,
+        "output_tokens": 40,
+        "events": [{"title": "Swimming", "date": today.isoformat(), "time": "15:45",
+                    "all_day": False, "start": f"{today.isoformat()}T15:45:00+02:00",
+                    "location": None, "calendar": "Family"}],
+        "calendar_statuses": [{"label": "Family", "ok": True, "detail": "", "count": 1}],
+        "calendars_fetched_at": f"{today.isoformat()}T03:50:00+00:00",
+    }
+
+
+class TestTheSessionKey:
+    """In cloud mode the session *is* the authentication (CLAUDE.md)."""
+
+    def test_cloud_mode_refuses_to_start_without_a_real_key(self, monkeypatch):
+        monkeypatch.setenv("DINKYDASH_MODE", "cloud")
+        monkeypatch.delenv("DINKYDASH_SECRET_KEY", raising=False)
+        with pytest.raises(RuntimeError, match="DINKYDASH_SECRET_KEY"):
+            create_app()
+
+    def test_it_refuses_before_it_tries_to_reach_a_database(self, monkeypatch):
+        # The order matters: a missing key must be the error a deploy sees,
+        # not a connection timeout that hides it.
+        monkeypatch.setenv("DINKYDASH_MODE", "cloud")
+        monkeypatch.delenv("DINKYDASH_SECRET_KEY", raising=False)
+        monkeypatch.delenv("DATABASE_URL", raising=False)
+        with pytest.raises(RuntimeError, match="DINKYDASH_SECRET_KEY"):
+            create_app()
+
+    def test_cloud_mode_starts_with_one(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("DINKYDASH_MODE", "cloud")
+        monkeypatch.setenv("DINKYDASH_SECRET_KEY", "a-real-one")
+        # A store is supplied, so nothing tries to connect.
+        from dinkydash.store import FileStore
+        (tmp_path / "config.yaml").write_text('family_name: "The Wilsons"\n')
+        app = create_app(FileStore(tmp_path / "config.yaml"))
+        assert app.secret_key == "a-real-one"
+
+    def test_single_mode_still_has_its_fallback(self, monkeypatch, tmp_path):
+        # A self-hoster is not made to invent a secret for a LAN-local app that
+        # only signs flash messages.
+        monkeypatch.delenv("DINKYDASH_MODE", raising=False)
+        monkeypatch.delenv("DINKYDASH_SECRET_KEY", raising=False)
+        from dinkydash.store import FileStore
+        (tmp_path / "config.yaml").write_text('family_name: "The Wilsons"\n')
+        app = create_app(FileStore(tmp_path / "config.yaml"))
+        assert app.secret_key == "dinkydash-self-hosted"
+
+    def test_an_explicit_key_wins_in_single_mode_too(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("DINKYDASH_SECRET_KEY", "mine")
+        from dinkydash.store import FileStore
+        (tmp_path / "config.yaml").write_text('family_name: "The Wilsons"\n')
+        assert create_app(FileStore(tmp_path / "config.yaml")).secret_key == "mine"
+
+
+class TestABoardOutOfPostgres:
+    """DIN-31's "done when": a board renders in cloud mode, from rows."""
+
+    @pytest.fixture
+    def client(self, pg_pool, pg_family, monkeypatch):
+        from dinkydash.pgstore import PostgresStore
+
+        store = PostgresStore(pg_pool, pg_family)
+        store.save_config(dict(CONFIG))
+        store.save_payload(store.load_config(), payload_for_today())
+
+        monkeypatch.setenv("DINKYDASH_MODE", "cloud")
+        monkeypatch.setenv("DINKYDASH_SECRET_KEY", "a-real-one")
+        app = create_app(store)
+        app.config["TESTING"] = True
+        return app.test_client()
+
+    def test_the_board_renders_the_stored_brief(self, client):
+        page = client.get("/").get_data(as_text=True)
+        assert "Swimming, then football" in page
+        assert "An octopus fact." in page
+
+    def test_it_recomputes_the_chore_rather_than_reading_it(self, client):
+        # Chores are a pure function of config + date and are not in the
+        # payload, so seeing one proves build_view ran over the database config.
+        page = client.get("/").get_data(as_text=True)
+        assert "Set the table" in page
+        assert "Mia" in page
+
+    def test_the_settings_home_reads_the_same_rows(self, client):
+        page = client.get("/settings/").get_data(as_text=True)
+        assert "The Wilsons" in page
+        assert "Calendars refreshed" in page
+
+    def test_a_settings_save_lands_in_the_database(self, client, pg_pool, pg_family):
+        client.post("/settings/system",
+                    data={"family_name": "The Bakers", "timezone": "Europe/Berlin"})
+        with pg_pool.connection() as conn, conn.cursor() as cur:
+            cur.execute("SELECT config ->> 'family_name' FROM families WHERE id = %s",
+                        (pg_family,))
+            assert cur.fetchone()[0] == "The Bakers"
+
+    def test_the_board_is_identical_to_the_one_a_file_would_render(self, client, tmp_path):
+        """The template, the CSS and build_view are shared verbatim.
+
+        If cloud mode ever rendered a different board, the mode check would have
+        leaked below the storage layer — which is the thing CLAUDE.md's "every
+        change must work in both" exists to prevent.
+        """
+        import yaml
+
+        from dinkydash.store import FileStore
+        (tmp_path / "config.yaml").write_text(yaml.safe_dump(CONFIG, allow_unicode=True))
+        file_store = FileStore(tmp_path / "config.yaml")
+        file_store.save_payload(file_store.load_config(), payload_for_today())
+        from_file = create_app(file_store).test_client().get("/").get_data(as_text=True)
+
+        assert client.get("/").get_data(as_text=True) == from_file

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,10 +1,9 @@
-"""The storage seam.
+"""What is true of `FileStore` and only `FileStore`.
 
-`FileStore` is the only implementation today, so what is worth asserting is the
-contract `PostgresStore` will have to keep: six operations, a payload that comes
-back as the dict that went in, a history that trims itself, and nothing that
-raises when the files are missing or corrupt. A board must not go dark because
-somebody's disk filled up mid-write.
+The six operations themselves are asserted in `test_store_contract.py`, against
+both implementations with the same assertions. What is left here is the part
+that is genuinely about files: where they land, what happens when one is
+corrupt, and that a reader never sees half of one.
 """
 
 import json
@@ -30,6 +29,12 @@ PAYLOAD = {
 }
 
 
+def _explode(message):
+    def _raise(*args, **kwargs):
+        raise OSError(message)
+    return _raise
+
+
 @pytest.fixture
 def store(tmp_path):
     (tmp_path / "config.yaml").write_text(CONFIG)
@@ -41,68 +46,17 @@ def config(store):
     return store.load_config()
 
 
-def _explode(message):
-    def _raise(*args, **kwargs):
-        raise OSError(message)
-    return _raise
+class TestAFileThatIsNotReadable:
+    """None of these may take the board down. The next write replaces the file."""
 
-
-class TestTheConfig:
-    def test_it_loads_with_the_defaults_filled_in(self, store):
-        config = store.load_config()
-        assert config["family_name"] == "The Wilsons"
-        assert config["refresh_minutes"] == 60
-
-    def test_a_save_comes_back_on_the_next_load(self, store):
-        config = store.load_config()
-        config["family_name"] = "The Bakers"
-        store.save_config(config)
-        assert store.load_config()["family_name"] == "The Bakers"
-
-
-class TestTheBoard:
-    def test_a_payload_comes_back_as_the_dict_that_went_in(self, store, config):
-        store.save_payload(config, PAYLOAD)
-        assert store.load_payload(config) == PAYLOAD
-
-    def test_nothing_generated_yet_is_none_rather_than_an_error(self, store, config):
-        assert store.load_payload(config) is None
-
-    def test_an_unreadable_payload_reads_as_no_board_at_all(self, store, config, tmp_path):
-        # Truncated by a power cut mid-write. The board shows its first-run
-        # screen and the next generation replaces the file.
+    def test_a_truncated_payload_reads_as_no_board_at_all(self, store, config, tmp_path):
+        # Cut off by a power cut mid-write. The board shows its first-run screen.
         (tmp_path / "dashboard_data.json").write_text("{not json")
         assert store.load_payload(config) is None
 
     def test_something_that_is_not_a_payload_is_ignored(self, store, config, tmp_path):
         (tmp_path / "dashboard_data.json").write_text("[1, 2, 3]")
         assert store.load_payload(config) is None
-
-
-class TestTheNoteHistory:
-    def test_a_recorded_note_comes_back(self, store, config):
-        store.record_note(config, {"date": "2026-09-03", "note": "An octopus fact."})
-        assert store.recent_notes(config, 30) == ["An octopus fact."]
-
-    def test_notes_accumulate_oldest_first(self, store, config):
-        for day in range(1, 4):
-            store.record_note(config, {"date": f"2026-09-0{day}", "note": f"Note {day}"})
-        assert store.recent_notes(config, 30) == ["Note 1", "Note 2", "Note 3"]
-
-    def test_only_the_last_kept_entries_survive(self, store, config, tmp_path):
-        for day in range(1, 6):
-            store.record_note(config, {"date": f"2026-09-0{day}", "note": f"Note {day}"},
-                              keep=3)
-        assert store.recent_notes(config, 30) == ["Note 3", "Note 4", "Note 5"]
-        assert len(json.loads((tmp_path / "content_history.json").read_text())) == 3
-
-    def test_asking_for_fewer_days_gives_the_most_recent(self, store, config):
-        for day in range(1, 4):
-            store.record_note(config, {"date": f"2026-09-0{day}", "note": f"Note {day}"})
-        assert store.recent_notes(config, 2) == ["Note 2", "Note 3"]
-
-    def test_no_history_yet_is_an_empty_list(self, store, config):
-        assert store.recent_notes(config, 30) == []
 
     def test_a_corrupt_history_does_not_stop_a_board_being_written(self, store, config,
                                                                    tmp_path):
@@ -113,10 +67,13 @@ class TestTheNoteHistory:
         store.record_note(config, {"date": "2026-09-03", "note": "Fresh start"})
         assert store.recent_notes(config, 30) == ["Fresh start"]
 
+    def test_a_history_that_is_not_a_list_is_ignored(self, store, config, tmp_path):
+        (tmp_path / "content_history.json").write_text('{"note": "not a list"}')
+        assert store.recent_notes(config, 30) == []
+
     def test_an_unwritable_history_is_a_warning_not_a_failure(self, store, config,
                                                               monkeypatch):
-        monkeypatch.setattr("dinkydash.store._write_json",
-                            _explode("the disk is full"))
+        monkeypatch.setattr("dinkydash.store._write_json", _explode("the disk is full"))
         store.record_note(config, {"date": "2026-09-03", "note": "Lost"})  # no exception
 
 
@@ -137,6 +94,16 @@ class TestWhereTheFilesGo:
         store.save_payload(config, PAYLOAD)
         assert json.loads((tmp_path / "elsewhere.json").read_text()) == PAYLOAD
 
+    def test_the_history_file_is_really_trimmed_on_disk(self, store, config, tmp_path):
+        # Not just what `recent_notes` returns — the file itself, because this
+        # one lives on a Pi's SD card for years.
+        for day in range(1, 6):
+            store.record_note(config, {"date": f"2026-09-0{day}", "note": f"Note {day}"},
+                              keep=3)
+        assert len(json.loads((tmp_path / "content_history.json").read_text())) == 3
+
+
+class TestWritingIsAtomic:
     def test_a_half_written_board_is_never_visible(self, store, config, tmp_path):
         # The write goes to a temporary file and is renamed, so a browser
         # loading the board mid-write reads the old one or the new one.

--- a/tests/test_store_contract.py
+++ b/tests/test_store_contract.py
@@ -1,0 +1,206 @@
+"""The storage contract, asserted identically against both implementations.
+
+Every test here runs twice: once over `FileStore` on `tmp_path`, once over
+`PostgresStore` against a real database. Same assertions, no branching — that
+parity is most of the value of having named the seam at all, because a suite
+that only ever ran against files would not notice the day the two drifted.
+
+The Postgres half skips when `DINKYDASH_TEST_DATABASE_URL` is unset, so a
+self-hoster with no database still gets a green suite. CI sets it.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from dinkydash.store import FileStore
+
+CONFIG_YAML = """\
+family_name: "The Wilsons"
+timezone: "Europe/Berlin"
+people:
+  - name: "Mia"
+    date_of_birth: "2017-03-15"
+"""
+
+CONFIG_DICT = {
+    "family_name": "The Wilsons",
+    "timezone": "Europe/Berlin",
+    "people": [{"name": "Mia", "date_of_birth": "2017-03-15"}],
+}
+
+EVENTS = [{"title": "Swimming", "date": "2026-09-03", "time": "15:45",
+           "all_day": False, "start": "2026-09-03T15:45:00+02:00",
+           "location": None, "calendar": "Family"}]
+STATUSES = [{"label": "Family", "ok": True, "detail": "", "count": 1}]
+
+PAYLOAD = {
+    "generated_for_date": "2026-09-03",
+    "generated_at": "2026-09-03T04:00:00+00:00",
+    "headline": "Big morning",
+    "note": "An octopus fact.",
+    "note_kind": "fact",
+    "model": "claude-haiku-4-5",
+    "input_tokens": 120,
+    "output_tokens": 45,
+    "events": EVENTS,
+    "calendar_statuses": STATUSES,
+    "calendars_fetched_at": "2026-09-03T03:50:00+00:00",
+}
+
+
+@pytest.fixture(params=["file", "postgres"])
+def store(request, tmp_path):
+    """The same seeded family, once as files and once as rows."""
+    if request.param == "file":
+        (tmp_path / "config.yaml").write_text(CONFIG_YAML)
+        return FileStore(tmp_path / "config.yaml")
+
+    # Pulled lazily, so the file run never asks for a database.
+    pool = request.getfixturevalue("pg_pool")
+    family_id = request.getfixturevalue("pg_family")
+    from dinkydash.pgstore import PostgresStore
+
+    store = PostgresStore(pool, family_id)
+    store.save_config(dict(CONFIG_DICT))
+    return store
+
+
+@pytest.fixture
+def config(store):
+    return store.load_config()
+
+
+class TestTheConfig:
+    def test_it_loads_with_the_defaults_filled_in(self, store):
+        config = store.load_config()
+        assert config["family_name"] == "The Wilsons"
+        assert config["timezone"] == "Europe/Berlin"
+        assert config["refresh_minutes"] == 60      # from DEFAULTS, not the source
+        assert config["brief_time"] == "06:00"
+
+    def test_the_edited_lists_survive(self, store):
+        assert [p["name"] for p in store.load_config()["people"]] == ["Mia"]
+
+    def test_a_save_comes_back_on_the_next_load(self, store):
+        config = store.load_config()
+        config["family_name"] = "The Bakers"
+        store.save_config(config)
+        assert store.load_config()["family_name"] == "The Bakers"
+
+    def test_a_new_key_survives_a_round_trip(self, store):
+        # `with_defaults` migrates the dict on load in both modes, so a setting
+        # added tomorrow needs no migration on either side.
+        config = store.load_config()
+        config["something_new"] = 42
+        store.save_config(config)
+        assert store.load_config()["something_new"] == 42
+
+
+class TestTheBoard:
+    def test_nothing_generated_yet_is_none_rather_than_an_error(self, store, config):
+        assert store.load_payload(config) is None
+
+    def test_a_payload_comes_back_as_the_dict_that_went_in(self, store, config):
+        store.save_payload(config, dict(PAYLOAD))
+        assert store.load_payload(config) == PAYLOAD
+
+    def test_saving_twice_replaces_rather_than_accumulates(self, store, config):
+        store.save_payload(config, dict(PAYLOAD))
+        second = dict(PAYLOAD, headline="A quieter morning")
+        store.save_payload(config, second)
+        assert store.load_payload(config) == second
+
+    def test_a_refresh_before_the_first_brief_stores_only_the_agenda(self, store, config):
+        # What a first `--tick` writes before brief_time: times, no words. The
+        # board shows its waiting screen rather than claiming a date.
+        agenda_only = {"events": EVENTS, "calendar_statuses": STATUSES,
+                       "calendars_fetched_at": "2026-09-03T03:50:00+00:00"}
+        store.save_payload(config, agenda_only)
+        assert store.load_payload(config) == agenda_only
+
+    def test_a_fresh_agenda_under_yesterdays_brief(self, store, config):
+        # The amber-banner state: a refresh must not disturb the brief.
+        store.save_payload(config, dict(PAYLOAD))
+        stored = store.load_payload(config)
+        stored["events"] = []
+        stored["calendars_fetched_at"] = "2026-09-04T07:00:00+00:00"
+        store.save_payload(config, stored)
+
+        after = store.load_payload(config)
+        assert after["events"] == []
+        assert after["calendars_fetched_at"] == "2026-09-04T07:00:00+00:00"
+        assert after["headline"] == "Big morning"
+        assert after["generated_for_date"] == "2026-09-03"
+        assert after["generated_at"] == "2026-09-03T04:00:00+00:00"
+
+    def test_stamps_come_back_in_utc(self, store, config):
+        # The two stores must agree about what time a board was written, or the
+        # settings page renders the wrong clock on one of them (PLAN.md bug 9).
+        store.save_payload(config, dict(PAYLOAD))
+        written = store.load_payload(config)["generated_at"]
+        assert datetime.fromisoformat(written) == datetime(
+            2026, 9, 3, 4, 0, tzinfo=timezone.utc)
+
+    def test_a_payload_with_no_stamps_at_all_is_fine(self, store, config):
+        """A missing stamp must not be a write error on either side.
+
+        The contract is that `.get()` agrees, not that the dicts are identical:
+        `FileStore` returns what was written, so an absent key stays absent,
+        while `PostgresStore` reassembles from columns and hands back None. Every
+        consumer — `board.build_view`, `schedule.due`, the settings page — reads
+        through `.get()`, so the two are the same answer.
+        """
+        bare = {"generated_for_date": "2026-09-03", "headline": "Hi",
+                "note": "There", "note_kind": "fact", "events": []}
+        store.save_payload(config, bare)
+        after = store.load_payload(config)
+        assert after["headline"] == "Hi"
+        assert after["generated_for_date"] == "2026-09-03"
+        assert after.get("generated_at") is None
+        assert after.get("calendars_fetched_at") is None
+
+
+class TestTheNoteHistory:
+    def test_no_history_yet_is_an_empty_list(self, store, config):
+        assert store.recent_notes(config, 30) == []
+
+    def test_a_recorded_note_comes_back(self, store, config):
+        store.record_note(config, {"date": "2026-09-03", "headline": "Big morning",
+                                   "note": "An octopus fact.", "note_kind": "fact"})
+        assert store.recent_notes(config, 30) == ["An octopus fact."]
+
+    def test_notes_accumulate_oldest_first(self, store, config):
+        for day in range(1, 4):
+            store.record_note(config, {"date": f"2026-09-0{day}", "note": f"Note {day}",
+                                       "headline": "H", "note_kind": "fact"})
+        assert store.recent_notes(config, 30) == ["Note 1", "Note 2", "Note 3"]
+
+    def test_only_the_last_kept_entries_survive(self, store, config):
+        for day in range(1, 6):
+            store.record_note(config, {"date": f"2026-09-0{day}", "note": f"Note {day}",
+                                       "headline": "H", "note_kind": "fact"}, keep=3)
+        assert store.recent_notes(config, 30) == ["Note 3", "Note 4", "Note 5"]
+
+    def test_asking_for_fewer_days_gives_the_most_recent(self, store, config):
+        for day in range(1, 4):
+            store.record_note(config, {"date": f"2026-09-0{day}", "note": f"Note {day}",
+                                       "headline": "H", "note_kind": "fact"})
+        assert store.recent_notes(config, 2) == ["Note 2", "Note 3"]
+
+    def test_an_entry_with_no_note_is_skipped_rather_than_blank(self, store, config):
+        store.record_note(config, {"date": "2026-09-03", "headline": "H",
+                                   "note": "", "note_kind": "fact"})
+        assert store.recent_notes(config, 30) == []
+
+
+def test_the_two_stores_agree_on_which_keys_a_refresh_owns():
+    """`pgstore` copies REFRESH_KEYS rather than importing upwards from `runner`.
+
+    That copy is deliberate — the store sits below the runner — but a copy is
+    only safe if something notices when it stops matching.
+    """
+    pytest.importorskip("psycopg")
+    from dinkydash import pgstore, runner
+
+    assert pgstore.REFRESH_KEYS == runner.REFRESH_KEYS

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -1,25 +1,44 @@
 """The Flask app: the board on one route, the settings UI on the rest.
 
+Two modes, and mode gates exactly two things here — where the config is stored,
+and whether the session key is allowed to be a fallback:
+
+    DINKYDASH_MODE=single   config.yaml, no accounts, no login (the default)
+    DINKYDASH_MODE=cloud    Postgres, and a real secret key or it will not start
+
 Self-hosted mode has no accounts and no login — it serves one family on a home
 network. Anyone who can reach the port can edit the config, which is the same
-trust model as the config file it writes.
+trust model as the config file it writes. Cloud mode cannot inherit that: there
+the session *is* the authentication.
+
+Everything below `create_app` is mode-blind. The routes take a store out of
+`app.config` and never learn which one they were given.
 """
 
 import os
 
 from flask import Flask
 
-from dinkydash.store import FileStore
+SINGLE, CLOUD = "single", "cloud"
+
+# Harmless with no accounts: it only ever signs flash messages on a LAN-local
+# app. A forgeable session in cloud mode is a forgeable login, which is why
+# `_secret_key` refuses to reach for this one there.
+SELF_HOSTED_KEY = "dinkydash-self-hosted"
+
+
+def mode():
+    return os.environ.get("DINKYDASH_MODE", SINGLE).strip().lower() or SINGLE
 
 
 def create_app(store=None):
     app = Flask(__name__, static_folder="static", template_folder="templates")
-    # Only ever used to sign flash messages on a LAN-local app.
-    app.secret_key = os.environ.get("DINKYDASH_SECRET_KEY", "dinkydash-self-hosted")
+    app.config["MODE"] = mode()
+    app.secret_key = _secret_key(app.config["MODE"])
     # Every route reads and writes through this one object, and none of them is
-    # told what is behind it. Cloud mode hands in a different store here and
-    # nothing below this line changes (PLAN.md decision 10).
-    app.config["STORE"] = store or FileStore()
+    # told what is behind it. Cloud mode hands in a different store and nothing
+    # below this line changes (PLAN.md decision 10).
+    app.config["STORE"] = store or _default_store(app.config["MODE"])
 
     from .routes.board import bp as board_bp
     from .routes.settings import bp as settings_bp
@@ -27,3 +46,37 @@ def create_app(store=None):
     app.register_blueprint(board_bp)
     app.register_blueprint(settings_bp, url_prefix="/settings")
     return app
+
+
+def _secret_key(current_mode):
+    key = os.environ.get("DINKYDASH_SECRET_KEY")
+    if key:
+        return key
+    if current_mode == CLOUD:
+        # Refusing to start is the point. A hardcoded key in a multi-tenant app
+        # lets anybody mint a session cookie for any family, and the failure is
+        # silent — everything works, for everyone, including strangers.
+        raise RuntimeError(
+            "DINKYDASH_SECRET_KEY is not set. Cloud mode will not start without one."
+        )
+    return SELF_HOSTED_KEY
+
+
+def _default_store(current_mode):
+    """The store this process should use when the caller did not supply one.
+
+    The cloud imports are inside the branch on purpose: `dinkydash.pgstore` and
+    `dinkydash.db` pull in psycopg, which lives in `requirements-cloud.txt` and
+    is not installed on a Pi.
+    """
+    if current_mode != CLOUD:
+        from dinkydash.store import FileStore
+        return FileStore()
+
+    from dinkydash import db
+    from dinkydash.pgstore import PostgresStore
+
+    # One family for now. Phase 1 replaces this with the family on the session,
+    # checked against the id in the URL before it reaches a query — the whole
+    # point of DIN-31 being the schema and not yet the multi-tenancy.
+    return PostgresStore(db.pool(), db.require("DINKYDASH_FAMILY_ID"))


### PR DESCRIPTION
DIN-19 named six storage operations and gave them one implementation; this adds the second, so Phase 1 is one problem — multi-tenancy — rather than two. `migrations/001_initial_schema.sql` is the data model sketch as plain SQL (seven tables, config as one jsonb document), `migrate.py` applies migrations in order against `DATABASE_URL_DIRECT` as App Platform's pre-deploy job, and `PostgresStore` composes the payload from `generations` and `agendas` and hands back the dict the engine already takes — split along `runner.REFRESH_KEYS`, with every query scoped to `family_id`.

**The parity suite is most of the value.** `tests/test_store_contract.py` runs seventeen assertions against both backends, parametrised, with no branching — including that stamps come back in UTC from both, which is the divergence that would have put the wrong clock on the settings page. It skips when `DINKYDASH_TEST_DATABASE_URL` is unset so a self-hoster with no database still gets a green suite, and CI now runs the suite **twice**: once against a Postgres 16 service container and once without, because a skipped parity test proves nothing.

**One silent bug worth reading the fix for:** the migration runner's connection has to be autocommit. Without it psycopg opens an implicit transaction on the first statement, and `conn.transaction()` entered inside one is a *savepoint* rather than a `BEGIN` — so every migration appeared to apply, released its savepoint, and was discarded when the connection closed. No error, no tables, an empty `schema_migrations`. Caught by running it, not by reading it.

`psycopg` is in a new `requirements-cloud.txt` rather than `requirements.txt`, so a Pi does not install a driver for a database it has not got — single mode never imports `pgstore` or `db`, and the import in `create_app` sits inside the cloud branch. Cloud mode also now refuses to start without a real `DINKYDASH_SECRET_KEY`, and refuses *before* reaching for a database so a deploy sees the real error. The first commit settles the pooling question this issue left open (DigitalOcean's pool for safety, a bounded `psycopg_pool` for speed, `prepare_threshold=None` everywhere) with the reasoning in PLAN.md.

**Deliberately not multi-tenancy:** cloud mode serves one family from `DINKYDASH_FAMILY_ID` — auth, sessions and checking a URL's id against them are Phase 1. 302 tests with a database, 280 and 22 skips without; the schema applies from empty and re-applies as a no-op; `tests/test_cloud_mode.py` renders a board from Postgres and asserts it is byte-identical to the one `FileStore` renders, so a mode check leaking below the storage layer would fail the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
