### PR TITLE
One image, three commands: Dockerfile and docker-compose.yml (DIN-30)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,41 @@
+# What must never reach the image, in order of how much it would matter.
+#
+# The first four are a real family's data. They are gitignored, which keeps them
+# out of the repo — but `docker build` sends the whole directory to the daemon
+# regardless of git, so without this file they would be baked into a layer and
+# pushed to a registry. That is somebody's children's names and a calendar
+# password walking off the machine.
+.env
+config.yaml
+dashboard_data.json
+content_history.json
+generate.log
+.tick.lock
+
+# Big and pointless on a server.
+venv/
+node_modules/
+__pycache__/
+*.pyc
+.git/
+.github/
+
+# The marketing site and its build output. `website/` never runs on a board and
+# `docs/` is what GitHub Pages serves; neither belongs in a runtime image.
+website/
+docs/
+
+# Development scratch.
+.idea
+.vscode/
+.playwright-mcp/
+.conductor/
+.context/
+.claude/
+tests/
+design/
+*.md
+!README.md
+
+# The compose bind mount. Never into the image.
+data/

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ generate.log
 
 # Personal data (not for public repo)
 config.yaml
+
+# What docker-compose.yml bind-mounts: the same three files, in one directory.
+# A real family's config lives here the moment anybody runs the stack.
+data/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -313,7 +313,40 @@ under [Connection pooling](PLAN.md#connection-pooling).
 
 **`psycopg` is in `requirements-cloud.txt`, not `requirements.txt`.** A Pi has no database and
 should not install a driver for one, so single mode never imports `pgstore` or `db` — the import in
-`create_app` is inside the cloud branch on purpose. The Dockerfile (DIN-30) installs the cloud file.
+`create_app` is inside the cloud branch on purpose. The `Dockerfile` installs the cloud file, so the
+image carries the driver even in single mode; one image is the point, and the constraint that
+actually matters is `deploy_to_pi.sh`, which installs `requirements.txt` and never sees it.
+
+### The image, and what runs it
+
+`Dockerfile` builds one image and `web`, `worker` and the migration job are that image with three
+commands. App Platform builds it; `docker-compose.yml` runs it locally and is the Phase 7 self-host
+deliverable. Production does not run the compose file — what the two modes share is the image
+(PLAN.md decision 12).
+
+Five things in there are load-bearing:
+
+- **Debian slim, never Alpine.** `strftime("%-d")` is a glibc extension and musl has not got it, so
+  an Alpine base would give silently wrong dates rather than a build error.
+- **`.dockerignore` is a security control, not tidiness.** `docker build` sends the whole directory
+  to the daemon regardless of `.gitignore`, so without it `config.yaml`, `.env` and
+  `dashboard_data.json` would be baked into a layer and pushed to a registry. `docker history` is
+  the check.
+- **The compose mount is a directory (`./data`), never three separate files.** Every write goes
+  through `tempfile` and `os.replace`, and renaming onto a single-file bind mount fails with
+  "Device or resource busy" — mounting `config.yaml` directly would break every save from the
+  settings UI.
+- **`docker-entrypoint.sh` seeds an empty mount from `config.example.yaml`**, so a first
+  `docker compose up` renders a board instead of a stack trace. It only fires when
+  `DINKYDASH_CONFIG` names a file that is not there, so cloud mode never touches it. The seeding
+  belongs to the container that owns the empty directory, not to `FileStore`.
+- **The self-host tick is the `worker` service, not host cron.** `generate.py --tick` on a
+  five-minute loop, and the loop drifting by however long a tick took does not matter because a tick
+  only does what the config says is owed. Cloud mode's worker is a different thing: one loop over
+  every family that is due.
+
+**macOS holds port 5000** for AirPlay Receiver, so `docker compose up` fails there with `address
+already in use`. `DINKYDASH_PORT` is the override, and the README says so.
 
 ### What the payload holds, and what it does not
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,69 @@
+# One image, three commands, both modes.
+#
+#   web      gunicorn, the board and the settings UI      (the default below)
+#   worker   generate.py --tick, on a loop                (docker-compose.yml)
+#   migrate  migrate.py, App Platform's pre-deploy job    (cloud only)
+#
+# That is decision 2's "one artefact" argument arriving somewhere it pays: the
+# hosted version does not run the same *file* a self-hoster runs, but it runs
+# the same image. App Platform builds this; docker-compose.yml runs it locally
+# and is the Phase 7 self-host deliverable.
+
+# Debian slim, and deliberately not Alpine. strftime("%-d") — which every date
+# on the board goes through — is a glibc extension. musl does not have it, and
+# the failure would be silently wrong dates rather than a build error.
+FROM python:3.11-slim
+
+# Bytecode files in a layer help nobody, and unbuffered output means a crash
+# loop shows its traceback instead of an empty log.
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+
+WORKDIR /app
+
+# Dependencies before source, so editing a template does not reinstall the
+# world. requirements-cloud.txt pulls in requirements.txt, so this is both.
+#
+# Yes, that puts psycopg in the image a self-hoster runs. One image is the whole
+# point, and 5 MB of driver is a fair price for it — the constraint CLAUDE.md
+# actually protects is the *Pi*, which installs requirements.txt through
+# deploy_to_pi.sh and never sees this file. requirements-dev.txt is absent on
+# purpose: the site generator and Pillow have no business on a server.
+COPY requirements.txt requirements-cloud.txt ./
+RUN pip install --no-cache-dir -r requirements-cloud.txt
+
+# Gunicorn is not a runtime dependency of the app — nothing imports it — so it
+# is installed here rather than in requirements.txt, where it would follow
+# deploy_to_pi.sh onto a Pi that serves with the Flask dev server.
+RUN pip install --no-cache-dir "gunicorn==23.0.0"
+
+COPY dinkydash/ ./dinkydash/
+COPY web/ ./web/
+COPY migrations/ ./migrations/
+COPY app.py generate.py migrate.py sample_board.py config.example.yaml ./
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+
+# Not root. The app writes only to the config directory, which is a bind mount
+# in single mode and nothing at all in cloud mode, so it needs no more than this.
+RUN useradd --create-home --uid 10001 dinkydash \
+    && chown -R dinkydash:dinkydash /app
+USER dinkydash
+
+EXPOSE 5000
+
+# Seeds an empty mounted directory with config.example.yaml, then execs whatever
+# it was given — so `docker run … python migrate.py` still means that.
+ENTRYPOINT ["docker-entrypoint.sh"]
+
+# The web role, because it is the one an image with no command should serve.
+# The other two override it and are one word each:
+#
+#   docker run … python generate.py --tick
+#   docker run … python migrate.py
+#
+# --workers 2 because App Platform's smallest instance is 1 vCPU / 512 MiB and
+# the app is I/O-light; --threads because it waits on calendars and on Claude.
+CMD ["gunicorn", "--bind", "0.0.0.0:5000", \
+     "--workers", "2", "--threads", "4", "--worker-class", "gthread", \
+     "--timeout", "60", "--access-logfile", "-", "app:app"]

--- a/PLAN.md
+++ b/PLAN.md
@@ -596,7 +596,7 @@ Critical path is 0 → 1 → 2 → 3. Phases 4–6 can run alongside 3. Nothing 
 - [ ] The small jobs above: CI, `gitleaks`, push protection, `.env.example`, pinned requirements, key rotation *(DIN-16)*; self-hosted font, URL scrub, referrer policy, `/healthz`. The `Dockerfile` has its own line below.
 - [x] **Decision 11, single-mode half:** `refresh_minutes` and `brief_time` in `DEFAULTS`; `runner.run` split into `refresh_calendars` and `write_brief`; a pure `due()`; `generate.py --tick`; the settings page under *This screen*; the board's reload derived from the interval; README cron line updated. Ships to the Pi at once and needs no database. *(DIN-17 for the engine and cron, DIN-18 for the page)*
 - [x] Name the storage seam: `FileStore` gathering the six operations that exist today, and the settings routes, runner and board taking a store *(DIN-19)*
-- [ ] `Dockerfile` and `docker-compose.yml` for single mode (`web` only) — the self-host path is real from here on, the image is what App Platform builds, and every later phase reuses both *(DIN-30)*
+- [x] `Dockerfile` and `docker-compose.yml` for single mode — the self-host path is real from here on, the image is what App Platform builds, and every later phase reuses both *(DIN-30)*
 - [x] Postgres + plain-SQL migrations; CI running the suite against a Postgres service container *(DIN-31)*
 - [ ] Move DNS to Cloudflare and add the `app` and `staging.app` records *(DIN-29)*. The apex keeps pointing at GitHub Pages until DIN-27 moves the marketing pages onto the app.
 - [ ] Stand up the App Platform app and the Managed Postgres cluster in Frankfurt; staging live on `staging.app.dinkydash.co` *(DIN-26)*

--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ are still today's — the board just labels the written line as older.
 > Hosted mode is a different matter — it authenticates every request and is scoped per family. See
 > [PLAN.md](PLAN.md).
 
+> **Prefer Docker?** [Running it with Docker](#running-it-with-docker) is two commands and needs no
+> Python on the host. The rest of this section is the from-source path.
+
 ### Prerequisites
 
 - Python 3.11+
@@ -182,6 +185,72 @@ GitHub Actions runs the same command on every push and pull request, on Python 3
 (`.github/workflows/test.yml`), alongside a [gitleaks](https://github.com/gitleaks/gitleaks) scan of
 the full history. Both dependency files are pinned with `==`, so a clean `pip install` gets the
 versions CI passed on. A pull request that fails either check shows a red X.
+
+---
+
+## Running it with Docker
+
+One image, and it is the same image the hosted version runs — `web`, the generation worker and the
+database migration job are that image with different commands.
+
+```bash
+git clone https://github.com/caspii/dinkydash.git
+cd dinkydash
+echo "ANTHROPIC_API_KEY=sk-ant-..." > .env    # optional; the board runs without one
+docker compose up
+```
+
+The board is at http://localhost:5000, the settings UI at http://localhost:5000/settings.
+
+**On a Mac, use a different port.** macOS runs AirPlay Receiver on port 5000, so the stack will
+fail to start with `address already in use`. Either turn it off in **System Settings → General →
+AirDrop & Handoff**, or pick another port:
+
+```bash
+DINKYDASH_PORT=5055 docker compose up
+```
+
+### Where your data lives
+
+Everything the app reads and writes is in **`./data`** on your machine: `config.yaml` and the two
+generated JSON files, together. The first `docker compose up` seeds `data/config.yaml` from
+`config.example.yaml`, so there is a board to look at before you have configured anything. Edit it
+at `/settings` or in your editor — both write the same file, and `./data` is what you back up.
+
+It is mounted as a **directory rather than three separate files**, and that matters if you change
+it: every write goes to a temporary file and is renamed over the target, so the board never serves
+half a file. Renaming onto a single-file bind mount fails, which would break every save from the
+settings UI.
+
+### How generation actually runs
+
+The `worker` service is the container answer to the Pi's cron line. It runs `generate.py --tick`
+every five minutes, and each tick does only what `config.yaml` says is owed — re-fetch the calendars
+every `refresh_minutes`, write the daily line once a day after `brief_time`, and nothing at all the
+rest of the time. **You do not need a cron entry on the host.**
+
+The cadence is a setting, not a compose file edit: change it at
+http://localhost:5000/settings/refresh.
+
+```bash
+docker compose logs -f worker      # watch it tick
+docker compose up -d               # run it in the background
+docker compose down                # stop everything; ./data is untouched
+```
+
+To force a generation now, press **Rewrite now** in the settings UI, or:
+
+```bash
+docker compose exec worker python generate.py
+```
+
+### Updating
+
+```bash
+git pull && docker compose up -d --build
+```
+
+Your `./data` is a bind mount, so nothing in it is rebuilt or replaced.
 
 ---
 
@@ -640,6 +709,8 @@ tail -f /home/pi/dinkydash/generate.log   # last night's generation
 | `config.example.yaml` | Template config, documenting every key |
 | `tests/` | 302 tests. Run them before committing |
 | `design/` | Mockups for the board and settings UI, with the reasoning |
+| `Dockerfile` | One image, three commands: web, worker, migrate. What App Platform builds |
+| `docker-compose.yml` | The self-host stack and the local dev stack. Not what production runs |
 | `deploy_to_pi.sh` | Deployment (rsync + service restart) |
 | `.env` | `ANTHROPIC_API_KEY` (not in git) |
 | `.env.example` | The template for it — copy to `.env` |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,79 @@
+# The local development stack, and the self-host deliverable.
+#
+#   docker compose up                      the board, and the tick that feeds it
+#   docker compose --profile cloud up -d postgres    a database for the tests
+#
+# Production does not run this file — App Platform builds the Dockerfile and
+# runs the same image with different commands. What the two modes share is the
+# image, not the compose file (PLAN.md decision 12).
+
+services:
+  web:
+    build: .
+    image: dinkydash
+    ports:
+      - "${DINKYDASH_PORT:-5000}:5000"
+    environment:
+      DINKYDASH_MODE: single
+      # Everything the app reads and writes lives here: config.yaml and the two
+      # generated JSON files, together, the way `generate.py --config` keeps them.
+      DINKYDASH_CONFIG: /data/config.yaml
+      # From the host environment or a .env beside this file, never written into
+      # it. .gitignore already covers .env.
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+    volumes:
+      # A *directory*, and this is not a stylistic choice. Every write in the
+      # app goes to a temporary file and is renamed over the target, so the
+      # board never serves half a file — and `os.replace` onto a single-file
+      # bind mount fails with "Device or resource busy". Mounting
+      # ./data/config.yaml directly would break every save from the settings UI.
+      - ./data:/data
+    restart: unless-stopped
+
+  worker:
+    build: .
+    image: dinkydash
+    environment:
+      DINKYDASH_MODE: single
+      DINKYDASH_CONFIG: /data/config.yaml
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+    volumes:
+      - ./data:/data
+    # The container answer to the Pi's cron line. Each tick does only what
+    # config.yaml says is owed — refresh the calendars every `refresh_minutes`,
+    # write the brief once a day after `brief_time` — so the loop drifting by
+    # however long a tick took does not matter. The cadence lives in the config
+    # and is edited at /settings/refresh, not here.
+    #
+    # This is the self-host answer to "how does generation actually run". Cloud
+    # mode's worker is a different thing: one loop over every family that is due
+    # (PLAN.md phase 2), not one family on a sleep.
+    command: sh -c 'while true; do python generate.py --tick; sleep 300; done'
+    # No ports. It talks to Anthropic and to the calendar feeds, and nothing
+    # talks to it.
+    depends_on:
+      - web
+    restart: unless-stopped
+
+  # Not started by default: `docker compose --profile cloud up -d postgres`.
+  # This is what the store contract suite runs against locally, and it is the
+  # same major version as DigitalOcean's managed cluster.
+  postgres:
+    profiles: ["cloud"]
+    image: postgres:16
+    environment:
+      POSTGRES_USER: dinkydash
+      POSTGRES_PASSWORD: dinkydash
+      POSTGRES_DB: dinkydash_test
+    ports:
+      - "${DINKYDASH_DB_PORT:-5433}:5432"
+    volumes:
+      - dinkydash-postgres:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U dinkydash"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  dinkydash-postgres:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Give a first `docker compose up` something to render.
+#
+# The mounted directory starts empty, and a board with no config.yaml is a
+# stack trace rather than a screen. So: if DINKYDASH_CONFIG names a file that is
+# not there yet, seed it from the documented example and carry on.
+#
+# Deliberately not in the app. `FileStore` inventing a config would be magic in
+# the engine, and the one place this belongs is the container that owns the
+# empty directory. In cloud mode DINKYDASH_CONFIG is unset and this does
+# nothing at all.
+set -e
+
+if [ -n "$DINKYDASH_CONFIG" ] && [ ! -f "$DINKYDASH_CONFIG" ]; then
+    mkdir -p "$(dirname "$DINKYDASH_CONFIG")"
+    cp /app/config.example.yaml "$DINKYDASH_CONFIG"
+    echo "Seeded $DINKYDASH_CONFIG from config.example.yaml — edit it at /settings."
+fi
+
+exec "$@"


### PR DESCRIPTION
App Platform builds from a Dockerfile, so until this existed there was nothing to deploy and DIN-26 could not start — and it is where the two modes finally meet, with `web`, `worker` and the migration job as one image with three commands. Production still does not run the compose file: what the two modes share is the **image**, and the compose file is the local dev stack and the Phase 7 self-host deliverable.

**Three things in here are load-bearing rather than taste.** Debian slim and never Alpine, because `strftime("%-d")` is a glibc extension and musl would give silently wrong dates on every board instead of a build error. `.dockerignore` is a security control rather than tidiness — `docker build` sends the whole directory to the daemon regardless of `.gitignore`, so without it `config.yaml`, `.env` and `dashboard_data.json` get baked into a layer and pushed to a registry. And the compose mount is a **directory**, not three separate files: every write goes through `tempfile` + `os.replace`, and renaming onto a single-file bind mount fails with "Device or resource busy", so mounting `config.yaml` directly would have broken every save from the settings UI quietly and only in Docker.

**The issue asked me to pick how generation runs on a self-hosted container, and this picks the `worker` service over host cron** — `generate.py --tick` on a five-minute loop, no crontab to edit, and the loop drifting by however long a tick took does not matter because a tick only does what `config.yaml` says is owed. The cadence stays a setting at `/settings/refresh`. `docker-entrypoint.sh` seeds an empty mount from `config.example.yaml` so a first `docker compose up` renders a board rather than a stack trace, fires only when `DINKYDASH_CONFIG` names a missing file, and `exec`s whatever it was given so `docker run … python migrate.py` still means that.

**Verified by running it, not by reading it.** The image builds clean with `--no-cache`, runs as uid 10001, contains nothing gitignored (checked with `docker history` and by listing `/app`), prints `25 December` from `%-d`, and serves `/`, `/settings/` and `/preview`. The page it serves is **byte-identical** to a bare `python app.py` over the same data directory. The worker did a real tick and wrote a real board; `python migrate.py` applied the schema from the same image against the compose Postgres, which sits behind a `cloud` profile so the store contract suite has something local to run against (45 of those tests pass against it).

One thing every Mac self-hoster will hit and the README now says: **macOS runs AirPlay Receiver on port 5000**, so `docker compose up` fails there with `address already in use` — `DINKYDASH_PORT` is the override. This closes the last Phase 0 item that does not need your DigitalOcean and Cloudflare logins; DIN-29 (DNS) and DIN-26 (deploy) are what remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
