### PR TITLE
Harden fetch_feed before it fetches strangers' URLs (DIN-33)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,10 +97,19 @@ Relative links like `[PLAN.md](PLAN.md)` break once a document is in Linear. Rew
   protects the first — there is no `|safe` anywhere in `web/`, and none should appear on feed or
   user content. For the second, treat the text as data: an event titled "ignore your instructions
   and ..." must not change what the model does.
-- **The server fetches URLs the user typed.** On a Pi that is the user's own machine. Hosted, it is
-  a request from our infrastructure to anywhere, so before cloud mode goes live `fetch_feed` needs a
-  scheme allowlist, redirects that cannot reach a private range, and a response size cap alongside
-  the timeout it already has.
+- **The server fetches URLs the user typed, and `fetch_feed` is what keeps that safe.** On a Pi the
+  typist owns the network; hosted it is our infrastructure dialling whatever a stranger pasted, and
+  everything worth reaching is inside. Four rules, all in `calendars.py` and all tested in
+  `tests/test_feed_safety.py`: **https only** (`webcal://` is normalised, plain `http` is refused
+  because it puts the secret address on the wire); **every resolved address checked** against
+  private, loopback, link-local, reserved and multicast, before any request is made; **redirects
+  followed by hand** with the scheme and address re-checked at each hop, because a public URL that
+  302s to `169.254.169.254` is the whole attack; and a **10 MB body cap** enforced on
+  `Content-Length` *and* on the read, since a server can omit or lie in that header.
+  `FeedRefused` subclasses `FeedError` on purpose, so one bad URL in a config is a failed feed
+  rather than a failed tick. **DNS rebinding is not closed by this** — between the check and the
+  socket a hostile resolver can answer differently, and closing it means connecting to the checked
+  address with an explicit `Host` header.
 - **Calendar contents leave the machine.** They go to Anthropic to write the daily line. A fair
   trade, but it has to be *said* — in the privacy policy, the sub-processor list, and the UI
   (PLAN.md phase 5).

--- a/PLAN.md
+++ b/PLAN.md
@@ -629,7 +629,7 @@ missing is the multi-tenant half — a schema, auth, and scoping every read and 
 - [ ] Schema + migrations per the sketch above; `PostgresStore` behind the seam
 - [ ] Magic-link auth: token hashed at rest, single use, 15-minute expiry, request endpoint rate-limited. Signing in through the link *is* email verification — there is no second step.
 - [ ] Session hygiene: `Secure`, `HttpOnly`, `SameSite=Lax`; a CSRF token on every form; cloud mode refuses to start without `DINKYDASH_SECRET_KEY`
-- [ ] `fetch_feed` hardening before any stranger's URL is fetched: `https` only, redirects that cannot land on a private range, a response size cap beside the timeout. The settings page's "Check this link" is the interactive way in, so it goes through the same function.
+- [x] `fetch_feed` hardening before any stranger's URL is fetched: `https` only, redirects that cannot land on a private range, a response size cap beside the timeout *(DIN-33)*. The settings page's "Check this link" goes through the same function, so it is covered too. DNS rebinding is documented as still open.
 - [ ] Family setup wizard: people + DOBs, emoji/color avatars, pets, chores, special dates
 - [ ] Multi-calendar management: add/label/enable/remove iCal feeds, with live validation on paste
 - [ ] Per-provider help content — Google, iCloud, Outlook each expose iCal URLs differently

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ pip install -r requirements-dev.txt   # adds pytest and the website build; not n
 python -m pytest tests/ -q
 ```
 
-325 tests, well under a second. They cover leap years, timezone conversion, event ordering, chore
+356 tests, well under a second. They cover leap years, timezone conversion, event ordering, chore
 rotation, the stale-board logic, the config round-trip, and the settings routes that write it.
 
 GitHub Actions runs the same command on every push and pull request, on Python 3.11
@@ -263,7 +263,7 @@ Where the link lives, per provider:
 | Provider | Where to find the iCal link |
 |---|---|
 | **Google Calendar** | Settings and sharing → **Integrate calendar** → **Secret address in iCal format** |
-| **Apple iCloud** | iCloud Calendar → share the calendar → **Public Calendar** → Copy Link, then change `webcal://` to `https://` |
+| **Apple iCloud** | iCloud Calendar → share the calendar → **Public Calendar** → Copy Link. A `webcal://` link is fine — it is converted for you |
 | **Outlook / Microsoft 365** | Settings → Calendar → **Shared calendars** → **Publish a calendar**, permission **Can view all details**, then copy the **ICS** link |
 
 Nothing here signs you in to an account. DinkyDash fetches the link on a schedule and can only read.
@@ -638,7 +638,7 @@ tail -f /home/pi/dinkydash/generate.log   # last night's generation
 | `app.py` | Flask entry point |
 | `config.yaml` | All configuration. The settings UI writes this same file |
 | `config.example.yaml` | Template config, documenting every key |
-| `tests/` | 325 tests. Run them before committing |
+| `tests/` | 356 tests. Run them before committing |
 | `design/` | Mockups for the board and settings UI, with the reasoning |
 | `deploy_to_pi.sh` | Deployment (rsync + service restart) |
 | `.env` | `ANTHROPIC_API_KEY` (not in git) |

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -21,7 +21,7 @@ theme: light
 # One entry per iCal feed; they are merged into a single agenda.
 # Google, Apple iCloud and Outlook all publish an iCal link:
 #   Google   → Settings and sharing → Integrate calendar → Secret address in iCal format
-#   iCloud   → share the calendar → Public Calendar → Copy Link, then webcal:// → https://
+#   iCloud   → share the calendar → Public Calendar → Copy Link (webcal:// is fine)
 #   Outlook  → Settings → Calendar → Shared calendars → Publish a calendar → the ICS link
 calendars:
   - label: "Family"

--- a/dinkydash/calendars.py
+++ b/dinkydash/calendars.py
@@ -6,8 +6,11 @@ the way through — the old code formatted them to a string too early and then
 sorted those strings, which ordered the day alphabetically by weekday name.
 """
 
+import ipaddress
 import logging
+import socket
 from datetime import date, datetime, time, timedelta
+from urllib.parse import urljoin, urlsplit, urlunsplit
 from zoneinfo import ZoneInfo
 
 import requests
@@ -19,12 +22,33 @@ log = logging.getLogger(__name__)
 DEFAULT_DAYS_AHEAD = 14
 DEFAULT_TIMEOUT = 30
 
+# A calendar feed the size of a fortnight's appointments is tens of kilobytes.
+# Ten megabytes is generous for a decade of a busy family, and it is the
+# difference between a bad URL being an error and a bad URL filling the disk.
+MAX_FEED_BYTES = 10 * 1024 * 1024
+
+# Enough for a provider's own shortener or a http->https hop, few enough that a
+# redirect loop ends as an error rather than a hang.
+MAX_REDIRECTS = 5
+
 
 class FeedError(Exception):
     """A feed could not be fetched or parsed.
 
     Its message is shown on the settings page and written to generate.log, so
     it must never carry the URL or the feed's contents — see `_why`.
+    """
+
+
+class FeedRefused(FeedError):
+    """The URL was refused before any request was made.
+
+    Its own type because the two mean different things to whoever reads the
+    message — `FeedError` is "we asked and it went wrong", this is "we are not
+    going to ask" — but a *subclass*, deliberately, so that every existing
+    `except FeedError` keeps working. One bad URL in a config must not abort
+    the whole tick, and a handler nobody remembered to add is exactly how that
+    would happen.
     """
 
 
@@ -97,14 +121,126 @@ def parse_feed(ical_text, start, end, tzinfo, label=None):
     return events
 
 
-def fetch_feed(url, start, end, tzinfo, label=None, timeout=DEFAULT_TIMEOUT):
-    """Fetch one iCal URL and return its events. Raises FeedError."""
+def normalise_url(url):
+    """The URL we will actually fetch, or a refusal.
+
+    Two jobs. `webcal://` is what Apple hands people when they share a
+    calendar, and it is an ordinary HTTPS URL wearing a different scheme, so it
+    is translated rather than rejected — the alternative is a support question
+    from everybody with an iPhone.
+
+    Then: **https only**. Plain http sends the secret address in cleartext to
+    every hop, so an http feed was never safe, and Google, iCloud and Outlook
+    are all https. This is a real change for anyone with an internal http feed,
+    and it applies on a Pi too — the fetch layer sits below the seam and does
+    not know which mode it is in.
+    """
+    parts = urlsplit((url or "").strip())
+    if parts.scheme in ("webcal", "webcals"):
+        parts = parts._replace(scheme="https")
+    if parts.scheme != "https":
+        raise FeedRefused(
+            f"the link has to start with https:// (this one starts with "
+            f"{parts.scheme or 'nothing'}://)")
+    if not parts.hostname:
+        raise FeedRefused("the link has no server name in it")
+    return urlunsplit(parts)
+
+
+def _check_address(hostname):
+    """Refuse a host that resolves anywhere it has no business being.
+
+    The board fetches URLs a person typed. On a Pi that person owns the
+    network. Hosted it is our infrastructure dialling whatever a stranger
+    pasted, and the interesting targets are all *inside*: the cloud metadata
+    endpoint on 169.254.169.254, a database on 127.0.0.1, anything on the
+    platform's own private range.
+
+    Every resolved address has to pass, not just the first, because a host with
+    one public and one private address is otherwise a way through.
+
+    **This does not close DNS rebinding.** Between this check and the socket,
+    a hostile resolver can answer differently. Closing that means connecting to
+    the checked address with an explicit Host header, which is a bigger change
+    than this and is written down rather than implied.
+    """
     try:
-        response = requests.get(url, timeout=timeout)
-        response.raise_for_status()
-    except Exception as exc:
-        raise FeedError(f"could not fetch the calendar: {_why(exc)}") from exc
-    return parse_feed(response.text, start, end, tzinfo, label=label)
+        infos = socket.getaddrinfo(hostname, 443, proto=socket.IPPROTO_TCP)
+    except socket.gaierror as exc:
+        raise FeedRefused("that server name does not resolve") from exc
+
+    for info in infos:
+        address = ipaddress.ip_address(info[4][0])
+        if (address.is_private or address.is_loopback or address.is_link_local
+                or address.is_reserved or address.is_multicast
+                or address.is_unspecified):
+            # Deliberately does not say which address. The answer would
+            # otherwise be a way to map the inside of the network from outside.
+            raise FeedRefused("that link points inside a private network")
+
+
+def fetch_feed(url, start, end, tzinfo, label=None, timeout=DEFAULT_TIMEOUT):
+    """Fetch one iCal URL and return its events.
+
+    Raises FeedRefused if the URL is one we will not ask for, and FeedError if
+    asking went wrong. Redirects are followed by hand rather than by requests,
+    because a public URL that 302s to 169.254.169.254 is the whole attack and
+    `allow_redirects=True` would walk straight into it.
+    """
+    target = normalise_url(url)
+
+    for _hop in range(MAX_REDIRECTS + 1):
+        parts = urlsplit(target)
+        _check_address(parts.hostname)
+        try:
+            response = requests.get(target, timeout=timeout, stream=True,
+                                    allow_redirects=False)
+        except Exception as exc:
+            raise FeedError(f"could not fetch the calendar: {_why(exc)}") from exc
+
+        if response.is_redirect or response.is_permanent_redirect:
+            location = response.headers.get("Location", "")
+            response.close()
+            if not location:
+                raise FeedError("could not fetch the calendar: a redirect with nowhere to go")
+            # urljoin covers all three legal shapes of a Location: absolute,
+            # root-relative and relative. normalise_url then re-applies the
+            # scheme rule, so a 302 to http:// or file:// is refused here too.
+            target = normalise_url(urljoin(target, location))
+            continue
+
+        try:
+            response.raise_for_status()
+        except Exception as exc:
+            response.close()
+            raise FeedError(f"could not fetch the calendar: {_why(exc)}") from exc
+        return parse_feed(_read_capped(response), start, end, tzinfo, label=label)
+
+    raise FeedError("could not fetch the calendar: too many redirects")
+
+
+def _read_capped(response):
+    """The body, refusing anything over MAX_FEED_BYTES.
+
+    Content-Length is checked first because it is free, and then the read is
+    budgeted anyway — a server that omits the header, or lies in it, must not
+    be able to hand us an unbounded body.
+    """
+    declared = response.headers.get("Content-Length")
+    if declared and declared.isdigit() and int(declared) > MAX_FEED_BYTES:
+        response.close()
+        raise FeedError("could not fetch the calendar: it is too big to be a calendar")
+
+    chunks, total = [], 0
+    try:
+        for chunk in response.iter_content(chunk_size=64 * 1024):
+            total += len(chunk)
+            if total > MAX_FEED_BYTES:
+                raise FeedError("could not fetch the calendar: it is too big to be a calendar")
+            chunks.append(chunk)
+    finally:
+        response.close()
+    return b"".join(chunks).decode(response.encoding or "utf-8", errors="replace")
 
 
 def sort_key(event):

--- a/docs/getting-started/index.html
+++ b/docs/getting-started/index.html
@@ -385,7 +385,7 @@
 <li>Open <a href="https://www.icloud.com/calendar/">iCloud Calendar</a> in a browser and sign in. You can also do this from the Calendar app on a Mac, iPhone or iPad.</li>
 <li>Hover over the calendar in the sidebar and open its share options.</li>
 <li>Switch on <strong>Public Calendar</strong>, then <strong>Copy Link</strong>.</li>
-<li><strong>Change the <code>webcal://</code> at the front to <code>https://</code>.</strong> The rest of the address stays exactly as it is. DinkyDash fetches over https, so a <code>webcal://</code> link fails.</li>
+<li><strong>Paste it as it is.</strong> A <code>webcal://</code> link is converted to <code>https://</code> for you — the rest of the address stays exactly as it is. Links have to be https; a plain <code>http://</code> feed is refused, because it would send the secret address across the network in the clear.</li>
 </ol>
 <p>"Public" here means a long random address rather than a listed page, but anyone holding it can read that calendar — keep it to yourself. Turning sharing off and on again issues a <em>different</em> link, and the old one stops working, so the board will need the new one.</p>
 <h3>Outlook and Microsoft 365</h3>

--- a/tests/test_feed_safety.py
+++ b/tests/test_feed_safety.py
@@ -1,0 +1,266 @@
+"""What the fetch layer refuses to do.
+
+`fetch_feed` is pointed at a URL somebody typed. On a Pi that somebody owns the
+network, so the worst case is their own business. Hosted, it is our
+infrastructure dialling whatever a stranger pasted, and everything worth
+reaching is *inside*: the cloud metadata endpoint, a database on loopback, the
+platform's own private range.
+
+So the rules are: https only, every hop checked, and a body that cannot grow
+without limit. Nothing here touches the network — the resolver and the HTTP
+call are both replaced.
+"""
+
+import socket
+from datetime import date
+
+import pytest
+import requests
+
+from dinkydash import calendars
+from dinkydash.calendars import (MAX_FEED_BYTES, FeedError, FeedRefused,
+                                 fetch_feed, normalise_url, zone)
+
+START, END = date(2026, 9, 7), date(2026, 9, 21)
+SECRET = "https://calendar.google.com/calendar/ical/x/private-DEADBEEF/basic.ics"
+
+ICS = """BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+SUMMARY:Swimming
+DTSTART:20260908T153000Z
+DTEND:20260908T163000Z
+END:VEVENT
+END:VCALENDAR
+"""
+
+
+def resolves_to(monkeypatch, *addresses):
+    """Pin what every hostname resolves to."""
+    def fake(host, port, **kwargs):
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", (a, port)) for a in addresses]
+    monkeypatch.setattr(calendars.socket, "getaddrinfo", fake)
+
+
+class FakeResponse:
+    def __init__(self, status=200, body=b"", headers=None, location=None):
+        self.status_code = status
+        self.headers = dict(headers or {})
+        if location:
+            self.headers["Location"] = location
+        self._body = body
+        self.encoding = "utf-8"
+        self.closed = False
+        self.reason = "OK" if status == 200 else "Moved"
+
+    @property
+    def is_redirect(self):
+        return self.status_code in (301, 302, 303, 307, 308)
+
+    is_permanent_redirect = property(lambda self: self.status_code in (301, 308))
+
+    def iter_content(self, chunk_size=1):
+        for i in range(0, len(self._body), chunk_size):
+            yield self._body[i:i + chunk_size]
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.HTTPError(f"{self.status_code}", response=self)
+
+    def close(self):
+        self.closed = True
+
+
+def serves(monkeypatch, *responses):
+    """Answer each successive GET with the next response. Records the URLs."""
+    asked = []
+    queue = list(responses)
+
+    def fake_get(url, **kwargs):
+        asked.append(url)
+        return queue.pop(0) if queue else FakeResponse(body=ICS.encode())
+    monkeypatch.setattr(calendars.requests, "get", fake_get)
+    return asked
+
+
+def never_called(monkeypatch):
+    def fake_get(url, **kwargs):
+        raise AssertionError(f"a request was made to {url}")
+    monkeypatch.setattr(calendars.requests, "get", fake_get)
+
+
+class TestTheSchemeRule:
+    def test_https_is_kept(self):
+        assert normalise_url(SECRET) == SECRET
+
+    def test_webcal_becomes_https(self):
+        """What Apple hands people when they share a calendar."""
+        assert normalise_url("webcal://p1.icloud.com/published/2/abc") == \
+            "https://p1.icloud.com/published/2/abc"
+        assert normalise_url("webcals://p1.icloud.com/x") == "https://p1.icloud.com/x"
+
+    @pytest.mark.parametrize("url", [
+        "http://example.com/cal.ics",     # cleartext: the secret address on the wire
+        "file:///etc/passwd",
+        "ftp://example.com/cal.ics",
+        "gopher://example.com/",
+        "",
+    ])
+    def test_everything_else_is_refused(self, url):
+        with pytest.raises(FeedRefused, match="https"):
+            normalise_url(url)
+
+    def test_a_url_with_no_host_is_refused(self):
+        with pytest.raises(FeedRefused, match="server name"):
+            normalise_url("https:///cal.ics")
+
+    def test_a_refusal_never_names_the_url(self, monkeypatch):
+        never_called(monkeypatch)
+        with pytest.raises(FeedError) as caught:
+            fetch_feed("http://host/private-DEADBEEF/x.ics", START, END, zone("UTC"))
+        assert "DEADBEEF" not in str(caught.value)
+
+
+class TestWhereItWillNotGo:
+    @pytest.mark.parametrize("address,what", [
+        ("127.0.0.1", "loopback"),
+        ("169.254.169.254", "the cloud metadata endpoint"),
+        ("10.1.2.3", "private"),
+        ("192.168.1.10", "private"),
+        ("172.16.5.4", "private"),
+        ("0.0.0.0", "unspecified"),
+        ("224.0.0.1", "multicast"),
+    ])
+    def test_it_refuses_and_does_not_even_ask(self, monkeypatch, address, what):
+        resolves_to(monkeypatch, address)
+        never_called(monkeypatch)   # the point: no request is made at all
+        with pytest.raises(FeedRefused, match="private network"):
+            fetch_feed("https://sneaky.example/cal.ics", START, END, zone("UTC"))
+
+    def test_a_public_address_is_allowed(self, monkeypatch):
+        resolves_to(monkeypatch, "142.250.185.174")
+        serves(monkeypatch, FakeResponse(body=ICS.encode()))
+        events = fetch_feed(SECRET, START, END, zone("UTC"), label="Family")
+        assert [e["title"] for e in events] == ["Swimming"]
+
+    def test_every_resolved_address_has_to_pass(self, monkeypatch):
+        """One public and one private answer is otherwise a way through."""
+        resolves_to(monkeypatch, "142.250.185.174", "127.0.0.1")
+        never_called(monkeypatch)
+        with pytest.raises(FeedRefused, match="private network"):
+            fetch_feed(SECRET, START, END, zone("UTC"))
+
+    def test_it_does_not_say_which_address(self, monkeypatch):
+        # Otherwise the error is a way to map the inside of the network.
+        resolves_to(monkeypatch, "10.1.2.3")
+        never_called(monkeypatch)
+        with pytest.raises(FeedRefused) as caught:
+            fetch_feed(SECRET, START, END, zone("UTC"))
+        assert "10.1.2.3" not in str(caught.value)
+
+    def test_a_name_that_does_not_resolve_is_refused(self, monkeypatch):
+        def boom(*args, **kwargs):
+            raise socket.gaierror("nope")
+        monkeypatch.setattr(calendars.socket, "getaddrinfo", boom)
+        never_called(monkeypatch)
+        with pytest.raises(FeedRefused, match="does not resolve"):
+            fetch_feed(SECRET, START, END, zone("UTC"))
+
+
+class TestRedirects:
+    """A public URL that 302s inward is the whole attack."""
+
+    def test_a_redirect_to_a_private_address_is_caught_at_the_hop(self, monkeypatch):
+        seen = {"n": 0}
+
+        def fake(host, port, **kwargs):
+            seen["n"] += 1
+            addr = "142.250.185.174" if seen["n"] == 1 else "169.254.169.254"
+            return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", (addr, port))]
+        monkeypatch.setattr(calendars.socket, "getaddrinfo", fake)
+        serves(monkeypatch, FakeResponse(302, location="https://inside.example/meta"))
+
+        with pytest.raises(FeedRefused, match="private network"):
+            fetch_feed(SECRET, START, END, zone("UTC"))
+
+    def test_a_redirect_to_http_is_refused(self, monkeypatch):
+        resolves_to(monkeypatch, "142.250.185.174")
+        serves(monkeypatch, FakeResponse(302, location="http://example.com/cal.ics"))
+        with pytest.raises(FeedRefused, match="https"):
+            fetch_feed(SECRET, START, END, zone("UTC"))
+
+    def test_an_ordinary_redirect_is_followed(self, monkeypatch):
+        resolves_to(monkeypatch, "142.250.185.174")
+        asked = serves(monkeypatch,
+                       FakeResponse(301, location="https://elsewhere.example/real.ics"),
+                       FakeResponse(body=ICS.encode()))
+        events = fetch_feed(SECRET, START, END, zone("UTC"))
+        assert [e["title"] for e in events] == ["Swimming"]
+        assert asked[1] == "https://elsewhere.example/real.ics"
+
+    def test_a_relative_location_resolves_against_the_url_it_came_from(self, monkeypatch):
+        resolves_to(monkeypatch, "142.250.185.174")
+        asked = serves(monkeypatch,
+                       FakeResponse(302, location="/moved/real.ics"),
+                       FakeResponse(body=ICS.encode()))
+        fetch_feed("https://host.example/a/b.ics", START, END, zone("UTC"))
+        assert asked[1] == "https://host.example/moved/real.ics"
+
+    def test_a_redirect_loop_ends_as_an_error(self, monkeypatch):
+        resolves_to(monkeypatch, "142.250.185.174")
+        loop = [FakeResponse(302, location="https://host.example/again")
+                for _ in range(calendars.MAX_REDIRECTS + 2)]
+        serves(monkeypatch, *loop)
+        with pytest.raises(FeedError, match="too many redirects"):
+            fetch_feed("https://host.example/x", START, END, zone("UTC"))
+
+    def test_a_redirect_with_no_location_is_an_error(self, monkeypatch):
+        resolves_to(monkeypatch, "142.250.185.174")
+        serves(monkeypatch, FakeResponse(302))
+        with pytest.raises(FeedError, match="nowhere to go"):
+            fetch_feed(SECRET, START, END, zone("UTC"))
+
+
+class TestTheSizeCap:
+    def test_a_declared_size_over_the_cap_is_refused(self, monkeypatch):
+        resolves_to(monkeypatch, "142.250.185.174")
+        serves(monkeypatch, FakeResponse(
+            headers={"Content-Length": str(MAX_FEED_BYTES + 1)}, body=b"x"))
+        with pytest.raises(FeedError, match="too big"):
+            fetch_feed(SECRET, START, END, zone("UTC"))
+
+    def test_a_body_over_the_cap_is_refused_even_with_no_header(self, monkeypatch):
+        # A server that omits Content-Length, or lies in it, must not be able
+        # to hand us an unbounded body.
+        resolves_to(monkeypatch, "142.250.185.174")
+        serves(monkeypatch, FakeResponse(body=b"x" * (MAX_FEED_BYTES + 1024)))
+        with pytest.raises(FeedError, match="too big"):
+            fetch_feed(SECRET, START, END, zone("UTC"))
+
+    def test_an_ordinary_calendar_is_well_under_it(self, monkeypatch):
+        resolves_to(monkeypatch, "142.250.185.174")
+        serves(monkeypatch, FakeResponse(
+            headers={"Content-Length": str(len(ICS))}, body=ICS.encode()))
+        assert len(fetch_feed(SECRET, START, END, zone("UTC"))) == 1
+
+    def test_the_response_is_closed_even_when_refused(self, monkeypatch):
+        resolves_to(monkeypatch, "142.250.185.174")
+        response = FakeResponse(body=b"x" * (MAX_FEED_BYTES + 1))
+        serves(monkeypatch, response)
+        with pytest.raises(FeedError):
+            fetch_feed(SECRET, START, END, zone("UTC"))
+        assert response.closed, "a refused body must not leave the socket open"
+
+
+class TestOneBadFeedDoesNotBreakTheRest:
+    def test_a_refused_url_is_a_failed_feed_not_a_failed_tick(self, monkeypatch):
+        """FeedRefused subclasses FeedError precisely so this keeps working."""
+        resolves_to(monkeypatch, "142.250.185.174")
+        serves(monkeypatch, FakeResponse(body=ICS.encode()))
+        events, statuses = calendars.fetch_events([
+            {"label": "Bad", "url": "http://169.254.169.254/", "enabled": True},
+            {"label": "Good", "url": SECRET, "enabled": True},
+        ], START, zone("UTC"))
+        assert [s["ok"] for s in statuses] == [False, True]
+        assert [e["title"] for e in events] == ["Swimming"]
+        assert "DEADBEEF" not in statuses[0]["detail"]

--- a/web/routes/settings.py
+++ b/web/routes/settings.py
@@ -93,9 +93,9 @@ SECTIONS = {
             ("label", "Call it", "text", True, ""),
             ("url", "iCal link", "url", True,
              "Google → Settings and sharing → Integrate calendar → Secret address in iCal format. "
-             "iCloud → share the calendar → Public Calendar → Copy Link, then change webcal:// to "
-             "https://. Outlook → Settings → Calendar → Shared calendars → Publish a calendar, "
-             "then the ICS link."),
+             "iCloud → share the calendar → Public Calendar → Copy Link (a webcal:// link is "
+             "fine, it is converted for you). Outlook → Settings → Calendar → Shared calendars → "
+             "Publish a calendar, then the ICS link. Links must be https."),
             ("enabled", "Show on the board", "checkbox", False, ""),
         ],
     },

--- a/website/content/getting-started.md
+++ b/website/content/getting-started.md
@@ -37,7 +37,7 @@ If the address ever leaks, **Reset** on that same screen issues a new one and ki
 1. Open [iCloud Calendar](https://www.icloud.com/calendar/) in a browser and sign in. You can also do this from the Calendar app on a Mac, iPhone or iPad.
 2. Hover over the calendar in the sidebar and open its share options.
 3. Switch on **Public Calendar**, then **Copy Link**.
-4. **Change the `webcal://` at the front to `https://`.** The rest of the address stays exactly as it is. DinkyDash fetches over https, so a `webcal://` link fails.
+4. **Paste it as it is.** A `webcal://` link is converted to `https://` for you — the rest of the address stays exactly as it is. Links have to be https; a plain `http://` feed is refused, because it would send the secret address across the network in the clear.
 
 "Public" here means a long random address rather than a listed page, but anyone holding it can read that calendar — keep it to yourself. Turning sharing off and on again issues a *different* link, and the old one stops working, so the board will need the new one.
 


### PR DESCRIPTION
`fetch_feed` was a bare `requests.get(url)`. I verified that before changing it — no scheme check, no redirect control, no size cap, no address check — and that the request really is made: asking the settings page to check `http://169.254.169.254/latest/meta-data/` dialled the cloud metadata endpoint and waited out the timeout. Today that is LAN-scoped, since a Pi is the owner's own machine. On App Platform it becomes our infrastructure dialling whatever a stranger pastes, so this wants to land before DIN-26.

**Four rules, each one of the ways in.** *https only* — `webcal://` is normalised rather than rejected (it is what Apple hands people), and plain `http` is refused because an http iCal feed puts the secret address on the wire in the clear. *Every resolved address is checked* against private, loopback, link-local, reserved, multicast and unspecified **before any request is made** — every address, not just the first, since one public and one private answer is otherwise a way through, and the refusal deliberately does not say *which* address, because that would map the inside of the network from outside. *Redirects are followed by hand* with the scheme and address re-checked at each hop, because a public URL that 302s inward is the whole attack and `allow_redirects=True` walks into it. *A 10 MB cap*, enforced on `Content-Length` **and** on the read, because a server can omit that header or lie in it.

**`FeedRefused` subclasses `FeedError` deliberately.** The two mean different things to whoever reads the message, but every existing `except FeedError` keeps working — one bad URL in a config has to be a failed feed, not a failed tick, and a handler nobody remembered to add is exactly how that would have broken. There is a test for it.

**DNS rebinding is not closed by this,** and that is written down in the code and in CLAUDE.md rather than implied: between the check and the socket a hostile resolver can answer differently, and closing it means connecting to the checked address with an explicit `Host` header.

**One user-visible change:** four documents told people to convert `webcal://` by hand, and the public getting-started guide claimed a `webcal://` link *fails*. It does not any more, so they say so — and the guide now explains why `http` is refused rather than just refusing it. The `docs/` rebuild is a separate commit because the build stamps each page with its last commit date.

31 new tests, all offline — the resolver and the HTTP call are both replaced, so nothing in them touches the network. 356 total with a database, 334 and 22 skips without. Also in this branch: the repo description now matches the README (DIN-23; the social preview still needs the web UI, which has no API).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
