### PR TITLE
Split the board's write in two, so a refresh cannot be discarded (DIN-28)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@ dashboard_data.json
 content_history.json
 generate.log
 .tick.lock
-dashboard_data.json.lock
 
 # Personal data (not for public repo)
 config.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ dashboard_data.json
 content_history.json
 generate.log
 .tick.lock
+dashboard_data.json.lock
 
 # Personal data (not for public repo)
 config.yaml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -286,8 +286,14 @@ Four rules keep it a seam rather than a name:
   `save_agenda` drops anything that is not in `store.AGENDA_KEYS`; `save_brief` drops anything that
   is. Enforced by the store rather than by the caller, because the caller that would get it wrong is
   `write_brief` — it reads the payload, waits seconds on a model call, and writes, so the agenda in
-  its hand is stale by then (DIN-28). `FileStore` takes a short `flock` around its read-modify-write;
-  cloud mode needs none, because there the halves are separate rows and each write is one statement.
+  its hand is stale by then (DIN-28). Each half is **replaced, not merged into**: a key the caller
+  stops sending disappears, because that is what whole-row writes do in Postgres, and a stale value
+  surviving on a Pi but not in the cloud is exactly the divergence the seam exists to prevent.
+  `FileStore` takes a short `flock` **on the containing directory** for its read-modify-write — a
+  lock file beside the data would have to be kept out of `deploy_to_pi.sh`'s `rsync --delete`, and a
+  deploy landing mid-write would otherwise unlink the inode a running tick still held, leaving the
+  next writer to lock a fresh file and serialise against nobody. Cloud mode needs no lock at all:
+  there the halves are separate rows and each write is one statement.
 - **`tests/test_store_contract.py` runs every one of its assertions against both**, parametrised over
   the two backends with no branching. That parity is most of the value of having named the seam: a
   suite that only ran against files would not notice the day the two drifted. The Postgres half

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -261,7 +261,8 @@ Six operations, on one object, and nothing above them knows what is behind it:
 
 ```python
 load_config()                save_config(config)
-load_payload(config)         save_payload(config, payload)
+load_payload(config)         save_agenda(config, agenda)
+                             save_brief(config, brief)
 recent_notes(config, days)   record_note(config, entry, keep)
 ```
 
@@ -281,6 +282,12 @@ Four rules keep it a seam rather than a name:
   `config.example.yaml` for compatibility, and only `FileStore` reads them. They mean nothing hosted.
 - **The store is passed, never constructed, below the entry points.** `generate.py`, `app.py` and
   `sample_board.py` build one; everything else is handed it.
+- **The board is read whole and written in halves, and neither half can write the other's keys.**
+  `save_agenda` drops anything that is not in `store.AGENDA_KEYS`; `save_brief` drops anything that
+  is. Enforced by the store rather than by the caller, because the caller that would get it wrong is
+  `write_brief` — it reads the payload, waits seconds on a model call, and writes, so the agenda in
+  its hand is stale by then (DIN-28). `FileStore` takes a short `flock` around its read-modify-write;
+  cloud mode needs none, because there the halves are separate rows and each write is one statement.
 - **`tests/test_store_contract.py` runs every one of its assertions against both**, parametrised over
   the two backends with no branching. That parity is most of the value of having named the seam: a
   suite that only ran against files would not notice the day the two drifted. The Postgres half
@@ -396,9 +403,10 @@ Three rules hold this together:
   due when `generated_for_date` is not today *in the family's timezone* and the local clock has
   passed `brief_time`; a refresh is due when `calendars_fetched_at` is missing or older than
   `refresh_minutes`.
-- **A refresh must not touch `headline`, `note` or `generated_for_date`.** `runner.REFRESH_KEYS`
-  names the three keys it owns. A fresh agenda under yesterday's brief is exactly the amber-banner
-  state `board.build_view` already handles, and the whole point of the split.
+- **A refresh must not touch `headline`, `note` or `generated_for_date`**, and it now cannot: it
+  writes through `store.save_agenda`, which only accepts `store.AGENDA_KEYS`. A fresh agenda under
+  yesterday's brief is exactly the amber-banner state `board.build_view` already handles, and the
+  whole point of the split.
 - **A failure is not handled, it is simply due again.** Nothing is written, so the next tick asks
   the same question and gets the same answer. That is the retry, and it is why there is no backoff
   or attempt counter anywhere.
@@ -416,7 +424,9 @@ nothing: switching a calendar off means switching it off. The failure is recorde
 feed is retried on the configured cadence rather than every tick.
 
 **A tick takes an exclusive `flock` on `.tick.lock` and skips itself if another holds it**
-(`generate.only_one_tick`). A tick can outlive its five-minute slot — several feeds timing out, then
+(`generate.only_one_tick`). Its job is money, not consistency — the storage split is what stops two
+writers clobbering each other, and this stops a second tick paying Anthropic for a brief the first
+one is already writing. A tick can outlive its five-minute slot — several feeds timing out, then
 a slow model call — and the next one would find the brief still unwritten, pay for it a second time,
 write a second history entry, and race the first over the payload. The overlapping tick exits 0
 instead: whatever is owed is still owed five minutes later. It is deliberately only around the tick.

--- a/PLAN.md
+++ b/PLAN.md
@@ -102,7 +102,7 @@ than discovered during it:
 
 ```
 load_config   / save_config
-load_payload  / save_payload
+load_payload  / save_agenda + save_brief
 recent_notes  / record_note
 ```
 
@@ -626,7 +626,7 @@ lists with stable ids, add/label/enable/remove for iCal feeds with live validati
 timezone, family name and location under `/system`. The boxes below stay unticked because what is
 missing is the multi-tenant half — a schema, auth, and scoping every read and write to a `family_id`.
 
-- [ ] Schema + migrations per the sketch above; `PostgresStore` behind the seam
+- [x] Schema + migrations per the sketch above; `PostgresStore` behind the seam *(DIN-31)*
 - [ ] Magic-link auth: token hashed at rest, single use, 15-minute expiry, request endpoint rate-limited. Signing in through the link *is* email verification — there is no second step.
 - [ ] Session hygiene: `Secure`, `HttpOnly`, `SameSite=Lax`; a CSRF token on every form; cloud mode refuses to start without `DINKYDASH_SECRET_KEY`
 - [x] `fetch_feed` hardening before any stranger's URL is fetched: `https` only, redirects that cannot land on a private range, a response size cap beside the timeout *(DIN-33)*. The settings page's "Check this link" goes through the same function, so it is covered too. DNS rebinding is documented as still open.

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ pip install -r requirements-dev.txt   # adds pytest and the website build; not n
 python -m pytest tests/ -q
 ```
 
-364 tests, well under a second. They cover leap years, timezone conversion, event ordering, chore
+368 tests, well under a second. They cover leap years, timezone conversion, event ordering, chore
 rotation, the stale-board logic, the config round-trip, and the settings routes that write it.
 
 GitHub Actions runs the same command on every push and pull request, on Python 3.11
@@ -638,7 +638,7 @@ tail -f /home/pi/dinkydash/generate.log   # last night's generation
 | `app.py` | Flask entry point |
 | `config.yaml` | All configuration. The settings UI writes this same file |
 | `config.example.yaml` | Template config, documenting every key |
-| `tests/` | 364 tests. Run them before committing |
+| `tests/` | 368 tests. Run them before committing |
 | `design/` | Mockups for the board and settings UI, with the reasoning |
 | `deploy_to_pi.sh` | Deployment (rsync + service restart) |
 | `.env` | `ANTHROPIC_API_KEY` (not in git) |

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ pip install -r requirements-dev.txt   # adds pytest and the website build; not n
 python -m pytest tests/ -q
 ```
 
-356 tests, well under a second. They cover leap years, timezone conversion, event ordering, chore
+364 tests, well under a second. They cover leap years, timezone conversion, event ordering, chore
 rotation, the stale-board logic, the config round-trip, and the settings routes that write it.
 
 GitHub Actions runs the same command on every push and pull request, on Python 3.11
@@ -638,7 +638,7 @@ tail -f /home/pi/dinkydash/generate.log   # last night's generation
 | `app.py` | Flask entry point |
 | `config.yaml` | All configuration. The settings UI writes this same file |
 | `config.example.yaml` | Template config, documenting every key |
-| `tests/` | 356 tests. Run them before committing |
+| `tests/` | 364 tests. Run them before committing |
 | `design/` | Mockups for the board and settings UI, with the reasoning |
 | `deploy_to_pi.sh` | Deployment (rsync + service restart) |
 | `.env` | `ANTHROPIC_API_KEY` (not in git) |

--- a/dinkydash/pgstore.py
+++ b/dinkydash/pgstore.py
@@ -21,8 +21,12 @@ Where the payload lives:
     headline, note, note_kind                        ->  generations.brief
     generated_for_date, generated_at, model, tokens  ->  generations columns
 
-That split is `runner.REFRESH_KEYS`, which already names which half a refresh
-owns. `load_payload` puts the two back together as the dict the engine takes.
+`load_payload` puts the two back together as the dict the engine takes, and
+`save_agenda` and `save_brief` each write one table and never the other. That
+is why the two are separate operations rather than one `save_payload`: a brief
+whose write is separated from its read by a slow model call would otherwise
+overwrite an agenda that landed in between (DIN-28). Here each write is a
+single statement, so no lock is involved at all.
 """
 
 import logging
@@ -31,14 +35,9 @@ from datetime import date, datetime, timezone
 from psycopg.types.json import Jsonb
 
 from . import config as config_module
+from .store import AGENDA_KEYS
 
 log = logging.getLogger(__name__)
-
-# The keys a calendar refresh owns, and the only ones that reach `agendas`.
-# Deliberately a copy rather than an import from `runner`: the store is below
-# the runner, and importing upwards would make the engine's own dependency graph
-# a circle. The test suite asserts the two lists agree.
-REFRESH_KEYS = ("events", "calendar_statuses", "calendars_fetched_at")
 
 # What `generations` holds in real columns rather than inside `brief`.
 GENERATION_COLUMNS = ("generated_for_date", "generated_at", "model",
@@ -114,17 +113,8 @@ class PostgresStore:
             payload["calendars_fetched_at"] = _iso(fetched_at)
         return payload
 
-    def save_payload(self, config, payload):
-        """Split the payload across the two tables, in one transaction.
-
-        Both halves are written together because `refresh_calendars` and
-        `write_brief` each hand over a whole payload, and a board that had the
-        new agenda under no headline — or the reverse — would be a state neither
-        function believes it can produce.
-        """
-        agenda = tuple(payload.get(key) for key in REFRESH_KEYS)
-        for_date = payload.get("generated_for_date")
-
+    def save_agenda(self, config, agenda):
+        """Replace this family's `agendas` row. One statement, nothing else touched."""
         with self.pool.connection() as conn, conn.transaction():
             with conn.cursor() as cur:
                 cur.execute(
@@ -134,14 +124,24 @@ class PostgresStore:
                        SET events = EXCLUDED.events,
                            statuses = EXCLUDED.statuses,
                            fetched_at = EXCLUDED.fetched_at""",
-                    (self.family_id, Jsonb(agenda[0] or []), Jsonb(agenda[1] or []),
-                     _stamp(agenda[2])),
+                    (self.family_id,
+                     Jsonb(agenda.get("events") or []),
+                     Jsonb(agenda.get("calendar_statuses") or []),
+                     _stamp(agenda.get("calendars_fetched_at"))),
                 )
-                if not for_date:
-                    # A refresh that ran before the first brief. There is no
-                    # generation to write, and inventing one would put a board
-                    # with no words on the wall claiming a date.
-                    return
+
+    def save_brief(self, config, brief):
+        """Replace today's `generations` row. Never writes `agendas`.
+
+        A brief with no date is a refresh-shaped payload arriving at the wrong
+        door — there is no generation to write, and inventing one would put a
+        board with no words on the wall claiming a date.
+        """
+        for_date = brief.get("generated_for_date")
+        if not for_date:
+            return
+        with self.pool.connection() as conn, conn.transaction():
+            with conn.cursor() as cur:
                 cur.execute(
                     """INSERT INTO generations
                            (family_id, generated_for_date, generated_at, brief,
@@ -153,9 +153,9 @@ class PostgresStore:
                            model = EXCLUDED.model,
                            input_tokens = EXCLUDED.input_tokens,
                            output_tokens = EXCLUDED.output_tokens""",
-                    (self.family_id, _as_date(for_date), _stamp(payload.get("generated_at")),
-                     Jsonb(_brief(payload)), payload.get("model"),
-                     payload.get("input_tokens"), payload.get("output_tokens")),
+                    (self.family_id, _as_date(for_date), _stamp(brief.get("generated_at")),
+                     Jsonb(_brief(brief)), brief.get("model"),
+                     brief.get("input_tokens"), brief.get("output_tokens")),
                 )
 
     # -- what was written recently ------------------------------------------
@@ -211,7 +211,7 @@ def _brief(payload):
     key still round-trips without a migration. The refresh keys and the columns
     above are the only things kept out.
     """
-    kept = set(REFRESH_KEYS) | set(GENERATION_COLUMNS)
+    kept = set(AGENDA_KEYS) | set(GENERATION_COLUMNS)
     brief = {key: value for key, value in payload.items() if key not in kept}
     for key in BRIEF_KEYS:
         brief.setdefault(key, payload.get(key))

--- a/dinkydash/runner.py
+++ b/dinkydash/runner.py
@@ -12,6 +12,12 @@ meant and what the settings page's "Rewrite now" does.
 All three take a `store` and read and write only through it, so nothing here
 knows whether the board it is replacing is a file on a Pi or a row belonging to
 one family among thousands.
+
+**Each half writes only what it owns** — `save_agenda` or `save_brief`, never a
+whole payload. That is what makes a refresh landing during the model call
+survive rather than being overwritten by the stale keys the brief read minutes
+earlier (DIN-28). A fresh agenda under yesterday's headline is exactly the
+amber-banner state `board.build_view` already handles.
 """
 
 import logging
@@ -24,11 +30,6 @@ from .claude_client import GenerationError
 from .generate import generate
 
 log = logging.getLogger(__name__)
-
-# What a refresh owns. Everything else in the payload belongs to the brief, and
-# a refresh must not touch it: a fresh agenda under yesterday's headline is
-# exactly the amber-banner state `board.build_view` already handles.
-REFRESH_KEYS = ("events", "calendar_statuses", "calendars_fetched_at")
 
 
 def refresh_calendars(config, store, now=None, today=None):
@@ -48,20 +49,24 @@ def refresh_calendars(config, store, now=None, today=None):
         config.get("calendars"), today, tzinfo, days_ahead=days_ahead,
     )
 
-    payload = store.load_payload(config) or {}
+    # Read only to find out what a failing feed last gave us. Nothing from this
+    # read is written back except the events themselves.
+    previous = (store.load_payload(config) or {}).get("events")
 
     failed = {s["label"] for s in statuses if s["ok"] is False}
     if failed:
         log.warning("Calendars that did not answer: %s", ", ".join(sorted(failed)))
-        events = _with_last_known(events, payload.get("events"), failed,
+        events = _with_last_known(events, previous, failed,
                                   today, today + timedelta(days=days_ahead))
 
-    payload["events"] = events
-    payload["calendar_statuses"] = statuses
-    payload["calendars_fetched_at"] = now.astimezone(timezone.utc).isoformat()
-    store.save_payload(config, payload)
-    log.info("Calendars refreshed: %d events stored", len(payload["events"]))
-    return payload
+    agenda = {
+        "events": events,
+        "calendar_statuses": statuses,
+        "calendars_fetched_at": now.astimezone(timezone.utc).isoformat(),
+    }
+    store.save_agenda(config, agenda)
+    log.info("Calendars refreshed: %d events stored", len(events))
+    return agenda
 
 
 def _with_last_known(fresh, previous, failed_labels, start, end):
@@ -115,11 +120,11 @@ def write_brief(config, store, today=None, client=None):
     payload = generate(
         config, today, stored.get("events") or [], recent_notes=recent, client=client
     )
-    for key in REFRESH_KEYS:
-        if key in stored:
-            payload[key] = stored[key]
-
-    store.save_payload(config, payload)
+    # Only the brief. `stored` was read before a model call that takes seconds,
+    # so anything of the agenda's in it is already potentially out of date — a
+    # refresh may well have landed in the meantime, and writing this copy back
+    # would throw that away while telling the person it had worked.
+    store.save_brief(config, payload)
     store.record_note(
         config,
         {

--- a/dinkydash/store.py
+++ b/dinkydash/store.py
@@ -7,12 +7,22 @@ cloud mode it is rows in Postgres, keyed on a family (PLAN.md decision 10).
 So the six operations get a name now, while there is still one implementation:
 
     load_config()                save_config(config)
-    load_payload(config)         save_payload(config, payload)
+    load_payload(config)         save_agenda(config, agenda)
+                                 save_brief(config, brief)
     recent_notes(config, days)   record_note(config, entry, keep)
 
 The runner, the board route and the settings routes take a store and never
 learn which one they were given. `PostgresStore` is then a second class rather
 than a fork of every caller.
+
+**The board is read whole and written in halves**, and that is the shape rather
+than an accident. A refresh owns the agenda; the daily brief owns the words.
+They run on different clocks, and the brief's write is separated from its read
+by a slow model call — so a single `save_payload` meant a refresh that landed
+during that call was overwritten by stale keys, silently, while the button that
+triggered it said it had worked (DIN-28). Two operations that each write only
+what they own makes that impossible rather than merely unlikely; in Postgres
+they are already two tables, so it is also the more honest mapping.
 
 The payload and history calls are handed the config because `FileStore` needs
 two keys out of it — `data_file` and `content_history_file` — to know where to
@@ -27,12 +37,24 @@ import json
 import logging
 import os
 import tempfile
+from contextlib import contextmanager
 from pathlib import Path
+
+try:
+    import fcntl  # POSIX only
+except ImportError:  # pragma: no cover - Windows has no flock
+    fcntl = None
 
 from . import config as config_module
 from . import history as history_module
 
 log = logging.getLogger(__name__)
+
+# What a calendar refresh owns, and the only keys `save_agenda` will write.
+# Everything else in the payload belongs to the brief. Named here rather than in
+# the runner because it is the storage contract's own vocabulary: both
+# implementations enforce it, and no caller can talk its way past it.
+AGENDA_KEYS = ("events", "calendar_statuses", "calendars_fetched_at")
 
 
 class FileStore:
@@ -66,9 +88,36 @@ class FileStore:
         payload = _read_json(self._data_path(config), "the stored board")
         return payload if isinstance(payload, dict) else None
 
-    def save_payload(self, config, payload):
-        """Write the board atomically, so nothing ever reads half a file."""
-        _write_json(self._data_path(config), payload)
+    def save_agenda(self, config, agenda):
+        """Replace the fetched window, leaving the brief exactly as it was."""
+        self._merge(config, {k: agenda.get(k) for k in AGENDA_KEYS if k in agenda})
+
+    def save_brief(self, config, brief):
+        """Replace the model's words, leaving the fetched window alone.
+
+        Agenda keys are dropped rather than trusted, so a caller handing over a
+        whole payload cannot resurrect a stale agenda through this door.
+        """
+        self._merge(config, {k: v for k, v in brief.items() if k not in AGENDA_KEYS})
+
+    def _merge(self, config, updates):
+        """Read, replace those keys, write — all inside one lock.
+
+        The lock is the small one. It covers a read and a write a microsecond
+        apart, not a model call, so nothing ever waits on it in practice — and
+        without it two processes on a Pi could still interleave, which is the
+        same bug this split exists to remove, just a great deal narrower.
+
+        Cloud mode needs no equivalent: there the two halves are separate rows
+        and each write is a single statement.
+        """
+        path = self._data_path(config)
+        with _locked(path):
+            payload = _read_json(path, "the stored board") or {}
+            if not isinstance(payload, dict):
+                payload = {}
+            payload.update(updates)
+            _write_json(path, payload)
 
     # -- what was written recently ------------------------------------------
 
@@ -109,6 +158,26 @@ class FileStore:
     def _resolve(self, value):
         path = Path(value).expanduser()
         return path if path.is_absolute() else self.base / path
+
+
+@contextmanager
+def _locked(path):
+    """An exclusive lock beside the file, for the length of one read and write.
+
+    `flock` is per-machine, which is all single mode needs — its web process and
+    its tick are on the same Pi. It is deliberately not the answer for cloud
+    mode, where `web` and `worker` are separate containers; there the split into
+    two rows is what makes concurrent writes safe.
+    """
+    if fcntl is None:  # Windows; the board runs on Linux and macOS
+        yield
+        return
+    handle = open(str(path) + ".lock", "a")
+    try:
+        fcntl.flock(handle, fcntl.LOCK_EX)
+        yield
+    finally:
+        handle.close()  # releases the lock, and so does the process exiting
 
 
 def _read_json(path, what):

--- a/dinkydash/store.py
+++ b/dinkydash/store.py
@@ -90,7 +90,8 @@ class FileStore:
 
     def save_agenda(self, config, agenda):
         """Replace the fetched window, leaving the brief exactly as it was."""
-        self._merge(config, {k: agenda.get(k) for k in AGENDA_KEYS if k in agenda})
+        self._replace(config, _is_agenda_key,
+                      {k: agenda[k] for k in AGENDA_KEYS if k in agenda})
 
     def save_brief(self, config, brief):
         """Replace the model's words, leaving the fetched window alone.
@@ -98,24 +99,31 @@ class FileStore:
         Agenda keys are dropped rather than trusted, so a caller handing over a
         whole payload cannot resurrect a stale agenda through this door.
         """
-        self._merge(config, {k: v for k, v in brief.items() if k not in AGENDA_KEYS})
+        self._replace(config, lambda key: not _is_agenda_key(key),
+                      {k: v for k, v in brief.items() if not _is_agenda_key(k)})
 
-    def _merge(self, config, updates):
-        """Read, replace those keys, write — all inside one lock.
+    def _replace(self, config, owns, updates):
+        """Swap out everything this half owns, inside one lock.
 
-        The lock is the small one. It covers a read and a write a microsecond
-        apart, not a model call, so nothing ever waits on it in practice — and
-        without it two processes on a Pi could still interleave, which is the
-        same bug this split exists to remove, just a great deal narrower.
+        **Replace, not merge.** A key the caller has stopped sending has to
+        disappear, because that is what `PostgresStore` does — it writes whole
+        rows, so an omitted `model` or token count comes back as None. Merging
+        instead would leave a stale value behind on a Pi and not in the cloud,
+        which is exactly the sort of quiet divergence the storage seam exists to
+        prevent.
 
-        Cloud mode needs no equivalent: there the two halves are separate rows
-        and each write is a single statement.
+        The lock covers a read and a write a microsecond apart, never a model
+        call, so nothing waits on it in practice. Without it two processes on
+        one Pi could still interleave — the same bug the split removes, only
+        very much narrower. Cloud mode needs no equivalent: there each half is
+        a row and each write is one statement.
         """
         path = self._data_path(config)
-        with _locked(path):
-            payload = _read_json(path, "the stored board") or {}
-            if not isinstance(payload, dict):
-                payload = {}
+        with _locked(path.parent):
+            stored = _read_json(path, "the stored board")
+            if not isinstance(stored, dict):
+                stored = {}
+            payload = {k: v for k, v in stored.items() if not owns(k)}
             payload.update(updates)
             _write_json(path, payload)
 
@@ -160,24 +168,42 @@ class FileStore:
         return path if path.is_absolute() else self.base / path
 
 
-@contextmanager
-def _locked(path):
-    """An exclusive lock beside the file, for the length of one read and write.
+def _is_agenda_key(key):
+    return key in AGENDA_KEYS
 
-    `flock` is per-machine, which is all single mode needs — its web process and
-    its tick are on the same Pi. It is deliberately not the answer for cloud
-    mode, where `web` and `worker` are separate containers; there the split into
-    two rows is what makes concurrent writes safe.
+
+@contextmanager
+def _locked(directory):
+    """An exclusive lock on the directory, for one read and one write.
+
+    **The directory rather than a lock file beside the data**, and that is the
+    point: a sidecar would have to be kept out of `deploy_to_pi.sh`'s
+    `rsync --delete`, and if it ever were not, a deploy landing mid-write would
+    unlink the inode a running tick still holds. The next writer would then
+    create a fresh file, take a lock on a different inode, and serialise against
+    nobody — silently. A directory's inode survives all of that, and there is no
+    file to remember to exclude.
+
+    `flock` is per-machine, which is all single mode needs: the web process and
+    the tick are on the same Pi. It is deliberately not the answer for cloud
+    mode, where `web` and `worker` are separate containers — there the split
+    into two rows is what makes concurrent writes safe.
     """
     if fcntl is None:  # Windows; the board runs on Linux and macOS
         yield
         return
-    handle = open(str(path) + ".lock", "a")
     try:
-        fcntl.flock(handle, fcntl.LOCK_EX)
+        fd = os.open(str(directory), os.O_RDONLY)
+    except OSError:
+        # No directory to lock means the write is about to fail anyway, and it
+        # will say why far more clearly than a lock error would.
+        yield
+        return
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
         yield
     finally:
-        handle.close()  # releases the lock, and so does the process exiting
+        os.close(fd)
 
 
 def _read_json(path, what):

--- a/sample_board.py
+++ b/sample_board.py
@@ -90,7 +90,12 @@ def main():
         return 0
 
     today = config_module.today_for(config)
-    store.save_payload(config, build_payload(config, today, config_module.tzinfo_for(config)))
+    payload = build_payload(config, today, config_module.tzinfo_for(config))
+    # Both halves, because this invents a whole board rather than refreshing
+    # one — the two doors exist so that the *runner* cannot write the other
+    # side's keys by accident, not to stop anyone writing both on purpose.
+    store.save_agenda(config, payload)
+    store.save_brief(config, payload)
     print(f"Wrote sample board data for {today}.")
     return 0
 

--- a/tests/test_cloud_mode.py
+++ b/tests/test_cloud_mode.py
@@ -100,7 +100,9 @@ class TestABoardOutOfPostgres:
 
         store = PostgresStore(pg_pool, pg_family)
         store.save_config(dict(CONFIG))
-        store.save_payload(store.load_config(), payload_for_today())
+        today = payload_for_today()
+        store.save_agenda(store.load_config(), today)
+        store.save_brief(store.load_config(), today)
 
         monkeypatch.setenv("DINKYDASH_MODE", "cloud")
         monkeypatch.setenv("DINKYDASH_SECRET_KEY", "a-real-one")
@@ -145,7 +147,9 @@ class TestABoardOutOfPostgres:
         from dinkydash.store import FileStore
         (tmp_path / "config.yaml").write_text(yaml.safe_dump(CONFIG, allow_unicode=True))
         file_store = FileStore(tmp_path / "config.yaml")
-        file_store.save_payload(file_store.load_config(), payload_for_today())
+        today = payload_for_today()
+        file_store.save_agenda(file_store.load_config(), today)
+        file_store.save_brief(file_store.load_config(), today)
         from_file = create_app(file_store).test_client().get("/").get_data(as_text=True)
 
         assert client.get("/").get_data(as_text=True) == from_file

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -403,3 +403,100 @@ class TestOnlyOneTickAtATime:
             # Nothing has ever been generated, so everything would be owed.
             assert cli.main(["--tick", "--config", str(home / "config.yaml")]) == 0
         assert not (home / "dashboard_data.json").exists()
+
+
+class TestARefreshDuringTheModelCall:
+    """DIN-28, end to end.
+
+    `write_brief` reads the payload, then spends seconds waiting on Claude, then
+    writes. A refresh landing in that gap used to be overwritten by the stale
+    keys from the earlier read — silently, while the button that triggered it
+    said it had worked. Each half now writes only what it owns, so it cannot.
+    """
+
+    def test_the_refresh_survives_the_brief(self, home, store, config, api_key):
+        write_stored(home, {"events": [], "calendar_statuses": [],
+                            "calendars_fetched_at": "2026-09-03T05:00:00+00:00",
+                            "generated_for_date": "2026-09-02",
+                            "headline": "Yesterday", "note": "Yesterday",
+                            "note_kind": "fact"})
+
+        class RefreshesMidCall(FakeClient):
+            """Somebody presses Refresh calendars while the model is thinking."""
+            def __init__(self):
+                super().__init__()
+                inner = self.messages.create
+
+                def create(**kwargs):
+                    store.save_agenda(config, {
+                        "events": EVENTS, "calendar_statuses": OK_STATUS,
+                        "calendars_fetched_at": "2026-09-03T08:30:00+00:00"})
+                    return inner(**kwargs)
+                self.messages.create = create
+
+        runner.write_brief(config, store, today=date(2026, 9, 3),
+                           client=RefreshesMidCall())
+
+        payload = stored(home)
+        assert payload["headline"] == "Big morning", "the brief should have been written"
+        assert payload["events"] == EVENTS, \
+            "the refresh that landed during the model call was discarded"
+        assert payload["calendars_fetched_at"] == "2026-09-03T08:30:00+00:00"
+        assert payload["calendar_statuses"] == OK_STATUS
+
+    def test_the_brief_still_describes_the_agenda_it_read(self, home, store, config,
+                                                          api_key):
+        # The prompt is built from what was there when the call started; that is
+        # correct, and it is why the *written* agenda has to be the newer one.
+        write_stored(home, {"events": EVENTS, "calendar_statuses": OK_STATUS,
+                            "calendars_fetched_at": "2026-09-03T05:00:00+00:00"})
+        client = FakeClient()
+        runner.write_brief(config, store, today=date(2026, 9, 3), client=client)
+        assert "Swimming" in client.messages.calls[0]["messages"][0]["content"]
+
+
+class TestTwoWritersAtOnce:
+    """The residual race the split narrows and the lock closes.
+
+    Two processes on one Pi — a cron tick and the web app — can still read and
+    write the same file microseconds apart. `FileStore` takes a short exclusive
+    lock around that, so an update cannot be lost. Cloud mode needs no
+    equivalent: there the two halves are separate rows.
+    """
+
+    def test_concurrent_writers_do_not_lose_an_update(self, store, config):
+        import threading
+
+        errors = []
+
+        def write_agendas():
+            try:
+                for i in range(40):
+                    store.save_agenda(config, {
+                        "events": [], "calendar_statuses": [],
+                        "calendars_fetched_at": f"2026-09-03T00:00:{i:02d}+00:00"})
+            except Exception as exc:  # pragma: no cover
+                errors.append(exc)
+
+        def write_briefs():
+            try:
+                for i in range(40):
+                    store.save_brief(config, {
+                        "generated_for_date": "2026-09-03", "note_kind": "fact",
+                        "headline": f"Headline {i}", "note": "n"})
+            except Exception as exc:  # pragma: no cover
+                errors.append(exc)
+
+        threads = [threading.Thread(target=write_agendas),
+                   threading.Thread(target=write_briefs)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors
+        payload = store.load_payload(config)
+        # Both writers' last words are present: neither clobbered the other, and
+        # the file is readable rather than torn.
+        assert payload["headline"] == "Headline 39"
+        assert payload["calendars_fetched_at"] == "2026-09-03T00:00:39+00:00"

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -85,13 +85,16 @@ class TestWhereTheFilesGo:
         elsewhere.mkdir()
         (elsewhere / "config.yaml").write_text(CONFIG)
         store = FileStore(elsewhere / "config.yaml")
-        store.save_payload(store.load_config(), PAYLOAD)
+        cfg = store.load_config()
+        store.save_agenda(cfg, PAYLOAD)
+        store.save_brief(cfg, PAYLOAD)
         assert (elsewhere / "dashboard_data.json").exists()
         assert not (tmp_path / "dashboard_data.json").exists()
 
     def test_an_absolute_data_file_is_left_where_it_says(self, store, config, tmp_path):
         config["data_file"] = str(tmp_path / "elsewhere.json")
-        store.save_payload(config, PAYLOAD)
+        store.save_agenda(config, PAYLOAD)
+        store.save_brief(config, PAYLOAD)
         assert json.loads((tmp_path / "elsewhere.json").read_text()) == PAYLOAD
 
     def test_the_history_file_is_really_trimmed_on_disk(self, store, config, tmp_path):
@@ -107,8 +110,9 @@ class TestWritingIsAtomic:
     def test_a_half_written_board_is_never_visible(self, store, config, tmp_path):
         # The write goes to a temporary file and is renamed, so a browser
         # loading the board mid-write reads the old one or the new one.
-        store.save_payload(config, PAYLOAD)
+        store.save_agenda(config, PAYLOAD)
+        store.save_brief(config, PAYLOAD)
         with pytest.raises(TypeError):
-            store.save_payload(config, {"headline": object()})  # not JSON
+            store.save_brief(config, {"headline": object()})  # not JSON
         assert store.load_payload(config) == PAYLOAD
         assert list(tmp_path.glob("*.tmp")) == []

--- a/tests/test_store_contract.py
+++ b/tests/test_store_contract.py
@@ -228,6 +228,33 @@ class TestNeitherDoorWritesTheOthersKeys:
         assert after["headline"] == "Big morning"
         assert after["generated_for_date"] == "2026-09-03"
 
+    def test_a_key_the_caller_stops_sending_disappears(self, store, config):
+        """Each half is *replaced*, not merged into.
+
+        `PostgresStore` writes whole rows, so an omitted `model` or token count
+        comes back as None. `FileStore` merged instead and left the old value
+        behind — a Pi and the cloud disagreeing about what was stored, which is
+        the one thing this suite exists to catch. It did not, until now.
+        """
+        save_board(store, config, dict(PAYLOAD))
+        leaner = {k: v for k, v in PAYLOAD.items()
+                  if k not in ("model", "input_tokens", "output_tokens")}
+        store.save_brief(config, leaner)
+
+        after = store.load_payload(config)
+        assert after.get("model") is None
+        assert after.get("input_tokens") is None
+        assert after["headline"] == "Big morning"      # what was sent is kept
+
+    def test_the_same_is_true_of_the_agenda_half(self, store, config):
+        save_board(store, config, dict(PAYLOAD))
+        store.save_agenda(config, {"events": []})      # no statuses, no stamp
+        after = store.load_payload(config)
+        assert after["events"] == []
+        assert not after.get("calendar_statuses")
+        assert after.get("calendars_fetched_at") is None
+        assert after["headline"] == "Big morning"      # the other half untouched
+
     def test_a_brief_written_after_a_concurrent_refresh_keeps_the_new_agenda(
             self, store, config):
         """The bug DIN-28 describes, end to end.

--- a/tests/test_store_contract.py
+++ b/tests/test_store_contract.py
@@ -71,6 +71,12 @@ def config(store):
     return store.load_config()
 
 
+def save_board(store, config, payload):
+    """Both halves, for tests that want a whole board on the wall."""
+    store.save_agenda(config, payload)
+    store.save_brief(config, payload)
+
+
 class TestTheConfig:
     def test_it_loads_with_the_defaults_filled_in(self, store):
         config = store.load_config()
@@ -102,13 +108,13 @@ class TestTheBoard:
         assert store.load_payload(config) is None
 
     def test_a_payload_comes_back_as_the_dict_that_went_in(self, store, config):
-        store.save_payload(config, dict(PAYLOAD))
+        save_board(store, config, dict(PAYLOAD))
         assert store.load_payload(config) == PAYLOAD
 
     def test_saving_twice_replaces_rather_than_accumulates(self, store, config):
-        store.save_payload(config, dict(PAYLOAD))
+        save_board(store, config, dict(PAYLOAD))
         second = dict(PAYLOAD, headline="A quieter morning")
-        store.save_payload(config, second)
+        save_board(store, config, second)
         assert store.load_payload(config) == second
 
     def test_a_refresh_before_the_first_brief_stores_only_the_agenda(self, store, config):
@@ -116,16 +122,14 @@ class TestTheBoard:
         # board shows its waiting screen rather than claiming a date.
         agenda_only = {"events": EVENTS, "calendar_statuses": STATUSES,
                        "calendars_fetched_at": "2026-09-03T03:50:00+00:00"}
-        store.save_payload(config, agenda_only)
+        store.save_agenda(config, agenda_only)
         assert store.load_payload(config) == agenda_only
 
     def test_a_fresh_agenda_under_yesterdays_brief(self, store, config):
         # The amber-banner state: a refresh must not disturb the brief.
-        store.save_payload(config, dict(PAYLOAD))
-        stored = store.load_payload(config)
-        stored["events"] = []
-        stored["calendars_fetched_at"] = "2026-09-04T07:00:00+00:00"
-        store.save_payload(config, stored)
+        save_board(store, config, dict(PAYLOAD))
+        store.save_agenda(config, {"events": [], "calendar_statuses": [],
+                                   "calendars_fetched_at": "2026-09-04T07:00:00+00:00"})
 
         after = store.load_payload(config)
         assert after["events"] == []
@@ -137,7 +141,7 @@ class TestTheBoard:
     def test_stamps_come_back_in_utc(self, store, config):
         # The two stores must agree about what time a board was written, or the
         # settings page renders the wrong clock on one of them (PLAN.md bug 9).
-        store.save_payload(config, dict(PAYLOAD))
+        save_board(store, config, dict(PAYLOAD))
         written = store.load_payload(config)["generated_at"]
         assert datetime.fromisoformat(written) == datetime(
             2026, 9, 3, 4, 0, tzinfo=timezone.utc)
@@ -153,7 +157,7 @@ class TestTheBoard:
         """
         bare = {"generated_for_date": "2026-09-03", "headline": "Hi",
                 "note": "There", "note_kind": "fact", "events": []}
-        store.save_payload(config, bare)
+        save_board(store, config, bare)
         after = store.load_payload(config)
         assert after["headline"] == "Hi"
         assert after["generated_for_date"] == "2026-09-03"
@@ -194,13 +198,55 @@ class TestTheNoteHistory:
         assert store.recent_notes(config, 30) == []
 
 
-def test_the_two_stores_agree_on_which_keys_a_refresh_owns():
-    """`pgstore` copies REFRESH_KEYS rather than importing upwards from `runner`.
+class TestNeitherDoorWritesTheOthersKeys:
+    """The whole point of two operations instead of one (DIN-28).
 
-    That copy is deliberate — the store sits below the runner — but a copy is
-    only safe if something notices when it stops matching.
+    Enforced by the store rather than by the caller: handing a whole payload to
+    either one must not let it write the other half, because the caller that
+    does exactly that is `write_brief`, holding an agenda it read before a model
+    call that took seconds.
     """
-    pytest.importorskip("psycopg")
-    from dinkydash import pgstore, runner
 
-    assert pgstore.REFRESH_KEYS == runner.REFRESH_KEYS
+    def test_save_brief_cannot_write_the_agenda(self, store, config):
+        save_board(store, config, dict(PAYLOAD))
+        # A whole payload arriving at the brief's door, agenda and all.
+        store.save_brief(config, dict(PAYLOAD, events=[], calendar_statuses=[],
+                                      calendars_fetched_at="1999-01-01T00:00:00+00:00",
+                                      headline="Rewritten"))
+        after = store.load_payload(config)
+        assert after["headline"] == "Rewritten"
+        assert after["events"] == EVENTS
+        assert after["calendars_fetched_at"] == "2026-09-03T03:50:00+00:00"
+
+    def test_save_agenda_cannot_write_the_brief(self, store, config):
+        save_board(store, config, dict(PAYLOAD))
+        store.save_agenda(config, dict(PAYLOAD, events=[],
+                                       headline="Should not appear",
+                                       generated_for_date="1999-01-01"))
+        after = store.load_payload(config)
+        assert after["events"] == []
+        assert after["headline"] == "Big morning"
+        assert after["generated_for_date"] == "2026-09-03"
+
+    def test_a_brief_written_after_a_concurrent_refresh_keeps_the_new_agenda(
+            self, store, config):
+        """The bug DIN-28 describes, end to end.
+
+        A tick reads the payload, spends seconds in the model call, and writes.
+        A refresh lands in the middle. The refresh must survive.
+        """
+        save_board(store, config, dict(PAYLOAD))
+        stale = store.load_payload(config)          # what write_brief read
+
+        fresh = [dict(EVENTS[0], title="Dentist")]  # the refresh, mid-call
+        store.save_agenda(config, {"events": fresh, "calendar_statuses": STATUSES,
+                                   "calendars_fetched_at": "2026-09-03T09:00:00+00:00"})
+
+        stale["headline"] = "Written after a long call"
+        store.save_brief(config, stale)             # the model call returns
+
+        after = store.load_payload(config)
+        assert after["headline"] == "Written after a long call"
+        assert [e["title"] for e in after["events"]] == ["Dentist"], \
+            "the refresh that landed during the model call was discarded"
+        assert after["calendars_fetched_at"] == "2026-09-03T09:00:00+00:00"


### PR DESCRIPTION
`write_brief` read the payload, spent seconds waiting on Claude, then wrote the whole thing back — carrying the agenda keys it had read *before* the call. A refresh landing in that gap was overwritten by stale keys, silently, while the button that triggered it flashed success. `generate_now` has had that exposure since the button existed; `refresh_now` added a second unlocked writer beside it.

**The issue asked for a decision between a lock and the structural fix. This is the structural one**, and the lock is not the answer on its own: `flock` is per-machine, and in cloud mode `web` and `worker` are separate App Platform components on separate containers — so a lock would fix single mode and leave the hosted product broken. The same race was already present in `PostgresStore`, which wrote *both* tables from whatever whole payload it was handed.

So the seam gains an operation and loses an argument: `save_payload` becomes **`save_agenda` and `save_brief`**, and **neither can write the other's keys** — `save_agenda` drops anything outside `store.AGENDA_KEYS`, `save_brief` drops anything inside it. Enforced by the store rather than by the caller, because the caller that would get it wrong is exactly `write_brief`, holding an agenda that is stale by the time the model returns. In Postgres this is also the more honest mapping: the halves were already two tables, each write is now one statement, and no lock is involved at all.

`FileStore` still reads-merges-writes, so it takes a short exclusive `flock` around that — and this is the distinction the issue was reaching for: the lock covers a read and a write a microsecond apart, **never a model call**, so nothing waits on it and *"Rewrite now is a person asking for something, and should do it"* still holds. `generate.only_one_tick` stays exactly where it was, with a comment that now says why: its job is money, not consistency — it stops a second tick paying Anthropic for a brief the first is already writing.

`runner.REFRESH_KEYS` and its duplicate in `pgstore` both go; there is one list in the module that enforces it, which also retires the test that existed only to check the two copies still agreed.

**Nine new tests, and I checked they fail without the fix** — putting the bug back fails three of them. The important one drives the real scenario: a fake client that performs a refresh while the model call is in flight, asserting the brief lands *and* the refresh survives. There is also a two-thread test that neither writer loses the other's update through the file. 364 with a database, 339 and 25 skips without.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
