### PR TITLE
Filter a calendar to the events shared with a named person

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -565,7 +565,7 @@ These are latent on a single Pi and actively harmful hosted.
 
 1. ~~**`generate.py:119` sorts events by formatted string.**~~ `events.sort(key=lambda e: e["date"])` sorted `"Friday, August 15 at 03:30 PM"` alphabetically by weekday name, so today's 8:30am school run could land after next Tuesday. Now sorted on `(date, all_day, start)` in `calendars.py`.
 2. ~~**`date.today()` / `datetime.now()` use server local time.**~~ On a UTC host a family in Auckland got the wrong day. The engine now takes an injected date, from `config_module.today_for(config)`.
-3. ~~**`calendar_filter_emails` requires all listed emails as `ATTENDEE`s.**~~ Most personal Google Calendar events have no `ATTENDEE` property at all, so it silently returned zero events. Dropped on load, with a warning; multiple calendars replaces it.
+3. ~~**`calendar_filter_emails` requires all listed emails as `ATTENDEE`s.**~~ Most personal Google Calendar events have no `ATTENDEE` property at all, so it silently returned zero events. Dropped on load, with a warning; multiple calendars replaces it. Since brought back the right way round as a per-calendar `shared_with` list: any one address is enough, `ORGANIZER` counts as well as `ATTENDEE`, **Check this link** says when it matches nobody, and a legacy `calendar_filter_emails` now migrates onto the migrated feed instead of being dropped.
 4. ~~**No tests.**~~ 157 of them, in under a second.
 
 **Also fixed, found while settling decision 10:**

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Every morning, DinkyDash merges your calendars into one agenda, works out whose 
 
 - Today's agenda, in time order, merged from as many Google, Apple iCloud and Outlook
   calendars as you like — anything with an iCal link, pasted in, no account sign-in
+- A personal calendar can show only the events shared with your partner, and keep
+  work and private appointments to itself
 - A look at tomorrow underneath it, on the days today leaves room
 - Whose turn each chore is — rotated daily, nothing to tick off
 - Countdowns to birthdays, holidays and special dates

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -23,10 +23,16 @@ theme: light
 #   Google   → Settings and sharing → Integrate calendar → Secret address in iCal format
 #   iCloud   → share the calendar → Public Calendar → Copy Link (webcal:// is fine)
 #   Outlook  → Settings → Calendar → Shared calendars → Publish a calendar → the ICS link
+#
+# A personal calendar with work and private things in it can still go on the
+# board: add `shared_with` with the other parent's email address, and only the
+# events with them on the guest list (or organised by them) get through. Use
+# the address on the invitation. Leave it out to show everything.
 calendars:
   - label: "Family"
     url: "https://calendar.google.com/calendar/ical/you%40gmail.com/private-xxxx/basic.ics"
     enabled: true
+    # shared_with: ["partner@example.com"]
 
 # Birthdays here become countdowns; names here are who chores rotate between.
 people:

--- a/dinkydash/CLAUDE.md
+++ b/dinkydash/CLAUDE.md
@@ -186,6 +186,38 @@ write a second history entry, and race the first over the payload. The overlappi
 instead: whatever is owed is still owed five minutes later. It is deliberately only around the tick.
 **Rewrite now** is a person asking for something, and should do it.
 
+## The guest list on a calendar
+
+A calendar entry's `shared_with` is a list of email addresses, and `parse_feed` keeps only the
+events with one of them on the guest list or as the organiser. A personal calendar full of work
+and private appointments then contributes the family things and nothing else. Four things about
+it are deliberate:
+
+- **It is per feed, not global.** The school calendar has no guests, and the global
+  `calendar_filter_emails` this replaced emptied it — which is why that key was dropped.
+- **It matches `ORGANIZER` as well as `ATTENDEE`, and any one address is enough.** An event the
+  partner arranged lists them as organiser, and a Google feed does not always list the organiser
+  as a guest of their own event. The old filter looked at `ATTENDEE` alone and required every
+  address, so it missed everything they had arranged.
+- **It runs before the event dict is built** (`calendars._events`), so a hidden event is never in
+  the payload, on the board or in the prompt — and the guest list itself is never stored. The
+  dict carries no addresses, and the log says how many addresses a feed has, never which.
+- **`describe_feed` counts before and after**, so **Check this link** can say a working link has
+  24 events and none of them match. A list that matches nobody looks exactly like an empty
+  calendar from the board, and that silent zero was the old filter's failure mode.
+- **Saving or removing a calendar forgets what it last said** (`runner.forget_calendar`, called
+  from the settings routes). The stored events under that label go, and the fetch stamp with
+  them, so the next tick owes a refresh and a calendar that is still on is back within one.
+  Without this, a guest list added after a fetch left the unfiltered events on the board and in
+  the next brief until a refresh happened to succeed — and because `_with_last_known` keeps a
+  failing feed's previous events, a feed that then went down kept them for as long as it was
+  down. Forgetting first means there is nothing old left to keep. The stored events cannot be
+  re-filtered instead: they carry no addresses, by design.
+
+`addresses()` is the one normaliser — list or comma-separated string in, lowercase list out, with
+`mailto:` stripped — and both the form and the engine go through it, so a hand-written
+`shared_with: jess@example.com` works the same as the list the settings UI writes.
+
 ## Config
 
 `config.yaml` is the single source of truth, and the settings UI writes it back. Loads and saves go
@@ -194,7 +226,8 @@ order and indentation all survive an edit made from a phone. There is a test ass
 changes exactly the lines it means to.
 
 `config.example.yaml` documents every key. Two are migrated on load: a single `calendar_url` becomes
-the first entry in `calendars`, and `calendar_filter_emails` is dropped with a warning.
+the first entry in `calendars`, and `calendar_filter_emails` becomes that entry's `shared_with` — or
+is dropped with a warning when there is no single URL to attach it to.
 
 Every item in the five edited lists — people, pets, recurring, special_dates, calendars — carries a
 short `id`. The settings UI addresses items by it, because a position is not an identity: delete the

--- a/dinkydash/calendars.py
+++ b/dinkydash/calendars.py
@@ -4,10 +4,16 @@ Several feeds go in (one per parent, plus a school calendar or two) and one
 chronologically-ordered agenda comes out. Events keep their real start time all
 the way through — the old code formatted them to a string too early and then
 sorted those strings, which ordered the day alphabetically by weekday name.
+
+A feed can carry a guest list (`shared_with`): a personal calendar full of work
+and private appointments then contributes only the events with the other
+parent on them. The filter runs at parse time, so a hidden event never exists
+as data anywhere downstream.
 """
 
 import ipaddress
 import logging
+import re
 import socket
 from datetime import date, datetime, time, timedelta
 from urllib.parse import urljoin, urlsplit, urlunsplit
@@ -91,17 +97,76 @@ def _localise(value, tzinfo):
     return datetime.combine(value, time.min, tzinfo=tzinfo)
 
 
-def parse_feed(ical_text, start, end, tzinfo, label=None):
-    """Parse iCal text into event dicts between `start` and `end` (dates)."""
+def addresses(value):
+    """A `shared_with` value as a list of lowercase email addresses.
+
+    Takes whatever config.yaml or a form might hold — a list, one string with
+    commas or spaces between the addresses, or nothing at all — and gives back
+    one shape, so the comparison in `_people_on` is exact. `mailto:` is
+    stripped because that is how an iCal file spells an address.
+    """
+    if not value:
+        return []
+    if isinstance(value, str):
+        value = re.split(r"[,;\s]+", value)
+    found = []
+    for item in value:
+        address = str(item or "").strip().lower()
+        if address.startswith("mailto:"):
+            address = address[len("mailto:"):]
+        if address and address not in found:
+            found.append(address)
+    return found
+
+
+def _people_on(component):
+    """Everyone on an event: the guests, and whoever organised it.
+
+    Both, because "shared with Jessica" runs in either direction. An event Sam
+    made and invited her to lists her as an ATTENDEE; one she made and invited
+    Sam to lists her as its ORGANIZER — and a Google feed does not always list
+    the organiser as a guest of their own event. The filter this replaced
+    looked at ATTENDEE alone, and so missed everything she had arranged.
+    """
+    people = set()
+    for key in ("ATTENDEE", "ORGANIZER"):
+        value = component.get(key)
+        if value is None:
+            continue
+        for entry in value if isinstance(value, list) else [value]:
+            people.update(addresses([str(entry)]))
+    return people
+
+
+def parse_feed(ical_text, start, end, tzinfo, label=None, shared_with=None):
+    """Parse iCal text into event dicts between `start` and `end` (dates).
+
+    `shared_with` is a list of email addresses. Given one, only the events with
+    one of those people on them — as a guest or as the organiser — come out.
+    The rest of the calendar is dropped here, before an event dict exists, so a
+    hidden appointment never reaches the payload, the board or the prompt. And
+    the dict carries no addresses: nobody's guest list is written anywhere.
+    """
+    return _events(_occurrences(ical_text, start, end), tzinfo, label, shared_with)
+
+
+def _occurrences(ical_text, start, end):
+    """Every event in the window, with recurrences expanded."""
     try:
         cal = Calendar.from_ical(ical_text)
     except Exception as exc:
         # Not `{exc}`: a parser error quotes the line it choked on, which is
         # somebody's appointment.
         raise FeedError(f"could not read the calendar data ({type(exc).__name__})") from exc
+    return list(recurring_events_of(cal).between(start, end + timedelta(days=1)))
 
+
+def _events(occurrences, tzinfo, label, shared_with):
+    wanted = set(addresses(shared_with))
     events = []
-    for component in recurring_events_of(cal).between(start, end + timedelta(days=1)):
+    for component in occurrences:
+        if wanted and not wanted & _people_on(component):
+            continue
         dtstart = component.get("DTSTART")
         if dtstart is None:
             continue
@@ -179,8 +244,19 @@ def _check_address(hostname):
             raise FeedRefused("that link points inside a private network")
 
 
-def fetch_feed(url, start, end, tzinfo, label=None, timeout=DEFAULT_TIMEOUT):
-    """Fetch one iCal URL and return its events.
+def fetch_feed(url, start, end, tzinfo, label=None, timeout=DEFAULT_TIMEOUT,
+               shared_with=None):
+    """Fetch one iCal URL and return its events — `fetch_text`, then `parse_feed`.
+
+    Raises FeedRefused if the URL is one we will not ask for, and FeedError if
+    asking went wrong.
+    """
+    return parse_feed(fetch_text(url, timeout=timeout), start, end, tzinfo,
+                      label=label, shared_with=shared_with)
+
+
+def fetch_text(url, timeout=DEFAULT_TIMEOUT):
+    """Fetch one iCal URL and return its body, unparsed.
 
     Raises FeedRefused if the URL is one we will not ask for, and FeedError if
     asking went wrong. Redirects are followed by hand rather than by requests,
@@ -214,7 +290,7 @@ def fetch_feed(url, start, end, tzinfo, label=None, timeout=DEFAULT_TIMEOUT):
         except Exception as exc:
             response.close()
             raise FeedError(f"could not fetch the calendar: {_why(exc)}") from exc
-        return parse_feed(_read_capped(response), start, end, tzinfo, label=label)
+        return _read_capped(response)
 
     raise FeedError("could not fetch the calendar: too many redirects")
 
@@ -248,6 +324,16 @@ def sort_key(event):
     return (event["date"], 0 if event["all_day"] else 1, event["start"])
 
 
+def feed_label(entry):
+    """The label a calendar entry's events are filed under.
+
+    One place for the fallback, because the label is the key that everything
+    downstream uses — `_with_last_known` keeps events by it, and the settings
+    UI forgets them by it — and the two have to agree about a nameless feed.
+    """
+    return entry.get("label") or "Calendar"
+
+
 def fetch_events(calendars, today, tzinfo, days_ahead=DEFAULT_DAYS_AHEAD,
                  timeout=DEFAULT_TIMEOUT):
     """Fetch every enabled feed and merge into one ordered agenda.
@@ -261,7 +347,7 @@ def fetch_events(calendars, today, tzinfo, days_ahead=DEFAULT_DAYS_AHEAD,
     statuses = []
 
     for entry in calendars or []:
-        label = entry.get("label") or "Calendar"
+        label = feed_label(entry)
         if not entry.get("enabled", True):
             statuses.append({"label": label, "ok": None, "detail": "paused", "count": 0})
             continue
@@ -269,15 +355,19 @@ def fetch_events(calendars, today, tzinfo, days_ahead=DEFAULT_DAYS_AHEAD,
         if not url:
             statuses.append({"label": label, "ok": False, "detail": "no URL set", "count": 0})
             continue
+        wanted = addresses(entry.get("shared_with"))
         try:
-            events = fetch_feed(url, today, end, tzinfo, label=label, timeout=timeout)
+            events = fetch_feed(url, today, end, tzinfo, label=label, timeout=timeout,
+                                shared_with=wanted)
         except FeedError as exc:
             log.warning("Calendar %r failed: %s", label, exc)
             statuses.append({"label": label, "ok": False, "detail": str(exc), "count": 0})
             continue
         merged.extend(events)
         statuses.append({"label": label, "ok": True, "detail": "", "count": len(events)})
-        log.info("Calendar %r: %d events", label, len(events))
+        # How many addresses, not which: they are people, and this is a log.
+        note = f" (only those shared with {len(wanted)} address(es))" if wanted else ""
+        log.info("Calendar %r: %d events%s", label, len(events), note)
 
     merged.sort(key=sort_key)
     return merged, statuses
@@ -290,18 +380,27 @@ def events_on(events, day):
 
 
 def describe_feed(url, tzinfo, today=None, days_ahead=DEFAULT_DAYS_AHEAD,
-                  timeout=DEFAULT_TIMEOUT):
+                  timeout=DEFAULT_TIMEOUT, shared_with=None):
     """Check a pasted URL and describe what came back.
 
     Used by the settings UI so pasting a link answers with a real event count
-    and the next thing in it, rather than a silent success.
+    and the next thing in it, rather than a silent success. With `shared_with`
+    set it also counts the events *before* the filter, because a guest list
+    that matches nobody looks exactly like an empty calendar from the board,
+    and telling the two apart is the whole point of pressing the button.
     """
     today = today or date.today()
-    events = fetch_feed(url, today, today + timedelta(days=days_ahead), tzinfo)
+    end = today + timedelta(days=days_ahead)
+    occurrences = _occurrences(fetch_text(url, timeout=timeout), today, end)
+    wanted = addresses(shared_with)
+    everything = _events(occurrences, tzinfo, None, None)
+    events = _events(occurrences, tzinfo, None, wanted) if wanted else everything
     events.sort(key=sort_key)
     upcoming = [e for e in events if e["date"] >= today.isoformat()]
     return {
         "count": len(events),
+        "total": len(everything),
+        "shared_with": wanted,
         "next": upcoming[0] if upcoming else None,
         "days_ahead": days_ahead,
     }

--- a/dinkydash/config.py
+++ b/dinkydash/config.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from ruamel.yaml import YAML
 from ruamel.yaml.scalarstring import DoubleQuotedScalarString
 
-from .calendars import zone
+from .calendars import addresses, zone
 
 log = logging.getLogger(__name__)
 
@@ -114,19 +114,23 @@ def with_defaults(raw):
         if config.get(key) is None:
             config[key] = [] if isinstance(value, list) else value
 
-    # A single calendar_url becomes the first entry in `calendars`.
+    # A single calendar_url becomes the first entry in `calendars`, and the
+    # global calendar_filter_emails that went with it becomes that entry's
+    # `shared_with`. The old key meant what the new one means — show me the
+    # events my partner is on — but it was one filter for the one URL, so it
+    # only has a home when that URL is what is being migrated.
     legacy_url = config.pop("calendar_url", None)
+    legacy_filter = addresses(config.pop("calendar_filter_emails", None))
     if legacy_url and not config["calendars"]:
-        config["calendars"] = [{"label": "Calendar", "url": legacy_url, "enabled": True}]
+        feed = {"label": "Calendar", "url": legacy_url, "enabled": True}
+        if legacy_filter:
+            feed["shared_with"] = legacy_filter
+        config["calendars"] = [feed]
         log.info("Migrated calendar_url into calendars[]")
-
-    # calendar_filter_emails required every listed address to appear as an
-    # ATTENDEE. Most personal Google Calendar events carry no ATTENDEE at all,
-    # so it silently matched nothing. Separate feeds replace it.
-    if config.pop("calendar_filter_emails", None):
+    elif legacy_filter:
         log.warning(
-            "Ignoring calendar_filter_emails — it silently hid every event on "
-            "calendars without ATTENDEE properties. Add one feed per person instead."
+            "Ignoring calendar_filter_emails: it was one filter for one calendar_url. "
+            "Put the addresses under `shared_with` on the calendar they were meant for."
         )
 
     if config.get("theme") not in THEMES:

--- a/dinkydash/runner.py
+++ b/dinkydash/runner.py
@@ -99,6 +99,34 @@ def _with_last_known(fresh, previous, failed_labels, start, end):
     return sorted(fresh + kept, key=sort_key)
 
 
+def forget_calendar(config, store, labels):
+    """Drop what a calendar last said, and make the next tick fetch again.
+
+    The settings UI calls this when a calendar is saved or removed. Events
+    fetched under the old entry cannot be trusted under the new one — a
+    changed URL is a different calendar, and a guest list added after the
+    fetch was never applied to it, nor can it be now, because the events
+    carry no addresses. So they go, rather than sit on the board and in the
+    next brief until a refresh happens to succeed. Only that calendar's go:
+    the rest of the agenda is still exactly what its feeds said.
+
+    The fetch stamp goes with them, which is what makes the next tick owe a
+    refresh (`schedule.refresh_due`), so a calendar that is still on is back
+    within a tick — and what stops `_with_last_known` bringing the old events
+    back if that first fetch fails: there is nothing left to keep. Written
+    through `save_agenda`, so the brief cannot be touched from here.
+    """
+    labels = set(labels)
+    payload = store.load_payload(config)
+    if not payload:
+        return
+    events = [e for e in payload.get("events") or [] if e.get("calendar") not in labels]
+    statuses = [s for s in payload.get("calendar_statuses") or []
+                if s.get("label") not in labels]
+    store.save_agenda(config, {"events": events, "calendar_statuses": statuses})
+    log.info("Forgot the stored events of %s; a refresh is due", ", ".join(sorted(labels)))
+
+
 def write_brief(config, store, today=None, client=None):
     """Ask Claude for today's headline and note, and store them. Costs one call.
 

--- a/doc/running-it.md
+++ b/doc/running-it.md
@@ -92,6 +92,14 @@ full steps and the gotchas.
 Add one feed per person. A feed that stops answering is reported on the settings home page and is
 skipped rather than emptying the board.
 
+A personal calendar with work and private appointments in it can still go on the board. Fill in
+**Only show events shared with** on that calendar with the other parent's email address — the one
+on the invitations — and only the events they are a guest at, or organised, get through. The rest
+is dropped as the feed is read, so it is never stored and never sent to Claude. **Check this link**
+says how many events get through out of how many, and warns you if none do. Saving a calendar
+clears what was fetched from it before, and the next tick fetches it afresh — or press **Refresh
+calendars**. In `config.yaml` the setting is `shared_with`, a list of addresses under that calendar.
+
 ## Costs
 
 One board a day on `claude-haiku-4-5` is roughly **$0.13 a month** — about 2,500 tokens in and 350

--- a/doc/upgrading.md
+++ b/doc/upgrading.md
@@ -6,9 +6,14 @@ Nothing to do to your config — it is migrated on load. But be aware:
   UI to write the config without destroying your comments.
 - **`calendar_url` becomes `calendars`.** A single URL is migrated into a one-entry list. The
   settings UI will write the new shape back the first time you save.
-- **`calendar_filter_emails` is gone.** It required every listed address to appear as an `ATTENDEE`
-  on an event, which most personal calendar entries do not have — so it silently returned zero
-  events. Add one feed per person instead. It is ignored with a warning in the log.
+- **`calendar_filter_emails` becomes `shared_with` on that calendar.** The old key was one filter
+  for the one `calendar_url`, so it moves onto the entry that URL is migrated into. It also works
+  differently now: any one listed address is enough rather than all of them, and the organiser of
+  an event counts as well as its guests — the old rule required every address as an `ATTENDEE`,
+  which most personal calendar entries do not have, so it silently returned zero events. If your
+  config already has a `calendars:` list, there is no way to tell which feed the old key meant, and
+  it is dropped with a warning in the log; set **Only show events shared with** on the right
+  calendar in the settings UI instead.
 - **Photos are no longer used.** The board shows an agenda rather than person cards, so the `image:`
   fields do nothing, and the root `static/` folder that held the JPEGs is gone. `avatar_emoji` and
   `avatar_color` replace them, and are used in the settings UI. Old keys are harmless if left in

--- a/tests/test_calendars.py
+++ b/tests/test_calendars.py
@@ -10,8 +10,8 @@ from zoneinfo import ZoneInfo
 
 import pytest
 
-from dinkydash.calendars import (FeedError, events_on, fetch_events, parse_feed,
-                                 sort_key, zone)
+from dinkydash.calendars import (FeedError, addresses, describe_feed, events_on,
+                                 fetch_events, parse_feed, sort_key, zone)
 
 BERLIN = ZoneInfo("Europe/Berlin")
 
@@ -30,6 +30,19 @@ def timed(uid, start, summary, tz="Europe/Berlin", location=None):
 def all_day(uid, day, summary):
     return (f"BEGIN:VEVENT\r\nUID:{uid}\r\nDTSTART;VALUE=DATE:{day}\r\n"
             f"SUMMARY:{summary}\r\nEND:VEVENT\r\n")
+
+
+def with_people(uid, start, summary, organizer=None, guests=()):
+    """A timed event with a guest list, written the way a Google feed writes one."""
+    lines = [f"BEGIN:VEVENT\r\nUID:{uid}\r\nDTSTART;TZID=Europe/Berlin:{start}\r\n"
+             f"SUMMARY:{summary}\r\n"]
+    if organizer:
+        lines.append(f"ORGANIZER;CN=Someone:mailto:{organizer}\r\n")
+    for guest in guests:
+        lines.append(f"ATTENDEE;CUTYPE=INDIVIDUAL;ROLE=REQ-PARTICIPANT;PARTSTAT=ACCEPTED;"
+                     f"CN=Someone;X-NUM-GUESTS=0:mailto:{guest}\r\n")
+    lines.append("END:VEVENT\r\n")
+    return "".join(lines)
 
 
 class TestParsing:
@@ -140,7 +153,7 @@ class TestMerging:
     def test_one_broken_feed_does_not_empty_the_board(self, monkeypatch):
         good = ical(timed("1", "20260903T082000", "School run"))
 
-        def fake_fetch(url, start, end, tzinfo, label=None, timeout=30):
+        def fake_fetch(url, start, end, tzinfo, label=None, timeout=30, shared_with=None):
             if url == "bad":
                 raise FeedError("404")
             return parse_feed(good, start, end, tzinfo, label=label)
@@ -171,6 +184,148 @@ class TestMerging:
 
     def test_no_calendars_at_all(self):
         assert fetch_events(None, date(2026, 9, 3), BERLIN) == ([], [])
+
+    def test_each_feed_carries_its_own_guest_list(self, monkeypatch):
+        # Per feed, not global: the school calendar has no guests, and a
+        # filter that applied to it would empty it — the old key's failure.
+        seen = []
+
+        def fake_fetch(url, start, end, tzinfo, label=None, timeout=30, shared_with=None):
+            seen.append((label, shared_with))
+            return []
+
+        monkeypatch.setattr("dinkydash.calendars.fetch_feed", fake_fetch)
+        fetch_events([
+            {"label": "Sam's", "url": "a", "shared_with": ["Jess@Example.com"]},
+            {"label": "School", "url": "b"},
+        ], date(2026, 9, 3), BERLIN)
+        assert seen == [("Sam's", ["jess@example.com"]), ("School", [])]
+
+
+class TestSharedWith:
+    """A personal calendar contributes only the events the other parent is on."""
+
+    WINDOW = (date(2026, 9, 3), date(2026, 9, 4))
+    JESS = "jess@example.com"
+
+    def titles(self, feed, shared_with):
+        events = parse_feed(feed, *self.WINDOW, BERLIN, shared_with=shared_with)
+        return [e["title"] for e in events]
+
+    def test_keeps_an_event_they_were_invited_to(self):
+        feed = ical(with_people("1", "20260903T082000", "Swimming",
+                                organizer="sam@example.com",
+                                guests=["sam@example.com", self.JESS]))
+        assert self.titles(feed, [self.JESS]) == ["Swimming"]
+
+    def test_keeps_an_event_they_organised(self):
+        # She sent the invitation, so she is the ORGANIZER — and a Google feed
+        # does not always list an organiser as a guest of their own event. The
+        # old filter looked at ATTENDEE alone and missed everything she arranged.
+        feed = ical(with_people("1", "20260903T082000", "Parents' evening",
+                                organizer=self.JESS, guests=["sam@example.com"]))
+        assert self.titles(feed, [self.JESS]) == ["Parents' evening"]
+
+    def test_hides_an_event_with_nobody_on_it(self):
+        # The private and the work things: no guest list at all.
+        feed = ical(
+            timed("1", "20260903T090000", "Therapy"),
+            with_people("2", "20260903T100000", "Dentist",
+                        organizer="sam@example.com", guests=[self.JESS]),
+        )
+        assert self.titles(feed, [self.JESS]) == ["Dentist"]
+
+    def test_hides_an_event_shared_with_somebody_else(self):
+        feed = ical(with_people("1", "20260903T090000", "1:1 with Priya",
+                                organizer="sam@example.com", guests=["priya@work.example"]))
+        assert self.titles(feed, [self.JESS]) == []
+
+    def test_case_and_mailto_do_not_matter(self):
+        feed = ical(with_people("1", "20260903T090000", "Lunch", guests=["Jess@Example.COM"]))
+        assert self.titles(feed, ["JESS@example.com"]) == ["Lunch"]
+
+    def test_any_one_of_several_addresses_is_enough(self):
+        # Two addresses for one person, or two people: either counts. The old
+        # key required every listed address on every event.
+        feed = ical(
+            with_people("1", "20260903T090000", "With her work address",
+                        guests=["jess@work.example"]),
+            with_people("2", "20260903T100000", "With the nanny", guests=["nanny@example.com"]),
+            with_people("3", "20260903T110000", "With neither", guests=["priya@work.example"]),
+        )
+        wanted = [self.JESS, "jess@work.example", "nanny@example.com"]
+        assert self.titles(feed, wanted) == ["With her work address", "With the nanny"]
+
+    @pytest.mark.parametrize("nobody", [None, [], "", "  "])
+    def test_no_list_means_everything(self, nobody):
+        feed = ical(
+            timed("1", "20260903T090000", "Therapy"),
+            with_people("2", "20260903T100000", "Dentist", guests=[self.JESS]),
+        )
+        assert self.titles(feed, nobody) == ["Therapy", "Dentist"]
+
+    def test_a_hand_written_string_works_like_the_list(self):
+        # config.yaml is edited by hand too: `shared_with: jess@example.com`.
+        feed = ical(with_people("1", "20260903T090000", "Lunch", guests=[self.JESS]))
+        assert self.titles(feed, "jess@example.com") == ["Lunch"]
+        assert self.titles(feed, "nanny@example.com, jess@example.com") == ["Lunch"]
+
+    def test_the_guest_list_stays_out_of_the_event(self):
+        # The addresses are other people's. They decide what is shown and are
+        # then forgotten: nothing in the payload can say who was invited.
+        feed = ical(with_people("1", "20260903T090000", "Lunch",
+                                organizer="sam@example.com", guests=[self.JESS]))
+        event = parse_feed(feed, *self.WINDOW, BERLIN, shared_with=[self.JESS])[0]
+        assert "example.com" not in str(event)
+
+
+class TestAddresses:
+    def test_splits_on_commas_spaces_and_newlines(self):
+        assert addresses("a@x.example, b@x.example c@x.example\nd@x.example") == [
+            "a@x.example", "b@x.example", "c@x.example", "d@x.example",
+        ]
+
+    def test_lowercases_trims_and_drops_mailto_and_duplicates(self):
+        assert addresses(["  A@X.example ", "mailto:a@x.example", None, ""]) == ["a@x.example"]
+
+    def test_nothing_is_an_empty_list(self):
+        assert addresses(None) == []
+        assert addresses("") == []
+        assert addresses([]) == []
+
+
+class TestDescribeFeed:
+    """What "Check this link" is told."""
+
+    FEED = ical(
+        timed("1", "20260903T090000", "Therapy"),
+        with_people("2", "20260903T100000", "Dentist", guests=["jess@example.com"]),
+        timed("3", "20260904T090000", "Standup"),
+    )
+
+    @pytest.fixture(autouse=True)
+    def served(self, monkeypatch):
+        monkeypatch.setattr("dinkydash.calendars.fetch_text",
+                            lambda url, timeout=30: self.FEED)
+
+    def describe(self, **kwargs):
+        return describe_feed("https://x.example/a.ics", BERLIN, today=date(2026, 9, 3), **kwargs)
+
+    def test_counts_everything_without_a_list(self):
+        found = self.describe()
+        assert (found["count"], found["total"]) == (3, 3)
+        assert found["next"]["title"] == "Therapy"
+
+    def test_counts_before_and_after_the_list(self):
+        found = self.describe(shared_with=["jess@example.com"])
+        assert (found["count"], found["total"]) == (1, 3)
+        assert found["next"]["title"] == "Dentist"
+        assert found["shared_with"] == ["jess@example.com"]
+
+    def test_a_list_that_matches_nobody_is_told_apart_from_an_empty_calendar(self):
+        found = self.describe(shared_with=["nobody@example.com"])
+        assert (found["count"], found["total"]) == (0, 3)
+        assert found["next"] is None
 
 
 class TestEventsOn:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -61,17 +61,31 @@ class TestMigration:
         ]
         assert "calendar_url" not in config
 
-    def test_the_broken_attendee_filter_is_dropped(self, tmp_path):
-        # It required every listed address to appear as an ATTENDEE, which most
-        # personal calendar events do not have — so it silently matched nothing.
+    def test_the_old_attendee_filter_moves_onto_the_migrated_feed(self, tmp_path):
+        # calendar_filter_emails was one filter for the one calendar_url, and it
+        # meant what `shared_with` means now. So it goes where that URL goes.
         path = tmp_path / "config.yaml"
         path.write_text(
             'calendar_url: "https://example.com/old.ics"\n'
-            'calendar_filter_emails:\n  - "spouse@example.com"\n'
+            'calendar_filter_emails:\n  - "Spouse@Example.com"\n'
         )
         config = config_module.load_config(path)
         assert "calendar_filter_emails" not in config
-        assert len(config["calendars"]) == 1
+        assert config["calendars"] == [{
+            "label": "Calendar", "url": "https://example.com/old.ics", "enabled": True,
+            "shared_with": ["spouse@example.com"],
+        }]
+
+    def test_the_old_attendee_filter_is_dropped_with_nowhere_to_go(self, tmp_path):
+        # An explicit calendars list gives no way to tell which feed it meant.
+        path = tmp_path / "config.yaml"
+        path.write_text(
+            'calendar_filter_emails:\n  - "spouse@example.com"\n'
+            'calendars:\n  - label: "New"\n    url: "https://example.com/new.ics"\n'
+        )
+        config = config_module.load_config(path)
+        assert "calendar_filter_emails" not in config
+        assert "shared_with" not in config["calendars"][0]
 
     def test_an_explicit_calendars_list_wins_over_the_legacy_key(self, tmp_path):
         path = tmp_path / "config.yaml"

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -14,6 +14,7 @@ import pytest
 import generate as cli
 from dinkydash import runner
 from dinkydash.claude_client import GenerationError
+from dinkydash.schedule import due
 from dinkydash.store import FileStore
 
 from test_generate import FakeClient  # the same stand-in the generator tests use
@@ -90,6 +91,48 @@ def fake_fetch(events, statuses, seen=None):
             seen.append({"calendars": calendars, "today": today, "days_ahead": days_ahead})
         return list(events), list(statuses)
     return _fetch
+
+
+class TestForgetCalendar:
+    """Saving a calendar in the settings UI forgets what it last said."""
+
+    BOTH = EVENTS + SCHOOL
+    BOTH_STATUS = [{"label": "Family", "ok": True, "detail": "", "count": 1},
+                   {"label": "School", "ok": True, "detail": "", "count": 1}]
+
+    def test_drops_only_that_calendars_events_and_the_stamp(self, home, store, config):
+        write_stored(home, {
+            "generated_for_date": "2026-09-03", "headline": "Hi", "note": "There",
+            "events": self.BOTH, "calendar_statuses": self.BOTH_STATUS,
+            "calendars_fetched_at": "2026-09-03T08:00:00+00:00",
+        })
+        runner.forget_calendar(config, store, {"Family"})
+        payload = stored(home)
+        assert payload["events"] == SCHOOL
+        assert payload["calendar_statuses"] == self.BOTH_STATUS[1:]
+        assert "calendars_fetched_at" not in payload
+        assert payload["headline"] == "Hi"  # the brief is not this half's to touch
+
+    def test_a_forgotten_calendar_is_due_at_the_next_tick(self, home, store, config):
+        write_stored(home, {"events": self.BOTH, "calendars_fetched_at": NOW.isoformat()})
+        assert due(config, stored(home), NOW)["refresh"] is False
+        runner.forget_calendar(config, store, {"Family"})
+        assert due(config, stored(home), NOW)["refresh"] is True
+
+    def test_the_last_known_fallback_cannot_bring_them_back(self, home, store, config,
+                                                            monkeypatch):
+        # The privacy case: a guest list added after the fetch. If the first
+        # fetch under the new entry fails, the old unfiltered events must not
+        # come back as "last known" — there has to be nothing left to keep.
+        write_stored(home, {"events": self.BOTH, "calendars_fetched_at": NOW.isoformat()})
+        runner.forget_calendar(config, store, {"Family"})
+        monkeypatch.setattr(runner, "fetch_events", fake_fetch(SCHOOL, MIXED_STATUS))
+        runner.refresh_calendars(config, store, now=NOW)
+        assert stored(home)["events"] == SCHOOL
+
+    def test_nothing_stored_is_nothing_to_do(self, home, store, config):
+        runner.forget_calendar(config, store, {"Family"})
+        assert not (home / "dashboard_data.json").exists()
 
 
 class TestRefreshCalendars:

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -368,6 +368,176 @@ class TestTheCadenceOnTheHomePage:
         assert "Calendars once a day · brief at 07:30" in page
 
 
+CALENDAR_CONFIG = """\
+family_name: "The Wilsons"
+timezone: "Europe/Berlin"
+
+calendars:
+  - id: school123
+    label: "School"
+    url: "https://school.example/term.ics"
+    enabled: true
+  - id: sams12345
+    label: "Sam's"
+    url: "https://calendar.google.com/calendar/ical/sam%40gmail.com/private-xxxx/basic.ics"
+    enabled: true
+    shared_with: ["jess@example.com"]
+"""
+
+
+class TestTheGuestList:
+    """A personal calendar can show only the events the other parent is on."""
+
+    @pytest.fixture
+    def config_path(self, tmp_path):
+        path = tmp_path / "config.yaml"
+        path.write_text(CALENDAR_CONFIG)
+        return path
+
+    def calendars(self, config_path):
+        return config_module.load_config(config_path)["calendars"]
+
+    def test_the_form_has_the_field(self, client):
+        page = client.get("/settings/calendars/school123").get_data(as_text=True)
+        assert "Only show events shared with" in page
+        assert 'name="shared_with"' in page
+
+    def test_the_form_shows_the_list_as_one_line(self, client):
+        page = client.get("/settings/calendars/sams12345").get_data(as_text=True)
+        assert 'value="jess@example.com"' in page
+
+    def test_saving_tidies_the_addresses_into_a_list(self, client, config_path):
+        client.post("/settings/calendars/school123", data={
+            "label": "School", "url": "https://school.example/term.ics", "enabled": "on",
+            "shared_with": " Jess@Example.com, nanny@example.com ",
+        })
+        assert self.calendars(config_path)[0]["shared_with"] == [
+            "jess@example.com", "nanny@example.com",
+        ]
+
+    def test_an_empty_field_means_everything(self, client, config_path):
+        client.post("/settings/calendars/sams12345", data={
+            "label": "Sam's", "enabled": "on", "shared_with": "",
+            "url": "https://calendar.google.com/calendar/ical/sam%40gmail.com/private-xxxx/basic.ics",
+        })
+        assert self.calendars(config_path)[1]["shared_with"] == []
+
+    def test_something_that_is_not_an_address_is_refused(self, client, config_path):
+        page = client.post("/settings/calendars/school123", data={
+            "label": "School", "url": "https://school.example/term.ics", "shared_with": "jess",
+        }).get_data(as_text=True)
+        assert "is not an email address" in page
+        assert "shared_with" not in self.calendars(config_path)[0]
+
+    def test_the_list_says_which_calendars_are_filtered(self, client):
+        page = client.get("/settings/calendars").get_data(as_text=True)
+        assert "Only events shared with jess@example.com" in page
+        assert page.count("Only events shared with") == 1
+
+    @pytest.fixture
+    def described(self, monkeypatch):
+        """Stub the fetch: the check is about the wording, not the network."""
+        def _serve(count, total, nxt=None):
+            def fake(url, tzinfo, today=None, days_ahead=14, shared_with=None, **kwargs):
+                return {"count": count, "total": total, "days_ahead": days_ahead,
+                        "shared_with": shared_with or [], "next": nxt}
+            monkeypatch.setattr("web.routes.settings.describe_feed", fake)
+        return _serve
+
+    def check(self, client, shared_with):
+        return client.post("/settings/calendars/new", data={
+            "action": "check", "label": "Sam's", "url": "https://x.example/a.ics",
+            "shared_with": shared_with,
+        }).get_data(as_text=True)
+
+    def test_checking_says_how_many_got_through(self, client, described):
+        described(3, 24, {"title": "Swimming", "date": "2026-09-04",
+                          "all_day": False, "time": "16:00"})
+        page = self.check(client, "jess@example.com")
+        assert ("3 of the 24 events over the next 14 days are shared with "
+                "jess@example.com.") in page
+        assert "Next up: Swimming, 2026-09-04 at 16:00." in page
+
+    def test_checking_warns_when_nothing_gets_through(self, client, described):
+        # The failure the old global filter hid: a working link, a full
+        # calendar, and a board with nothing on it.
+        described(0, 24)
+        page = self.check(client, "jess@example.com")
+        assert ("has 24 events in the next 14 days, but none of them is shared with "
+                "jess@example.com") in page
+        assert 'class="flash error"' in page
+
+    def test_checking_without_a_list_reads_as_before(self, client, described):
+        described(24, 24, {"title": "Swimming", "date": "2026-09-04",
+                           "all_day": True, "time": None})
+        page = self.check(client, "")
+        assert "24 events over the next 14 days. Next up: Swimming, 2026-09-04 at all day." in page
+
+
+class TestSavingACalendarForgetsWhatItFetched:
+    """A guest list added after a fetch was never applied to what is stored.
+
+    So the stored events of that calendar go when it is saved, and the fetch
+    stamp with them, which makes the next tick fetch afresh. Otherwise the
+    unfiltered events would stay on the board — and in the next brief — until
+    a refresh happened to succeed, and a failing feed would keep them for good.
+    """
+
+    @pytest.fixture
+    def config_path(self, tmp_path):
+        path = tmp_path / "config.yaml"
+        path.write_text(CALENDAR_CONFIG)
+        return path
+
+    @pytest.fixture
+    def board(self, tmp_path):
+        path = tmp_path / "dashboard_data.json"
+        path.write_text(json.dumps({
+            "generated_for_date": "2026-09-03", "headline": "Hi", "note": "There",
+            "calendars_fetched_at": "2026-09-03T08:00:00+00:00",
+            "calendar_statuses": [{"label": "School", "ok": True}, {"label": "Sam's", "ok": True}],
+            "events": [
+                {"title": "Sports day", "date": "2026-09-04", "calendar": "School"},
+                {"title": "Therapy", "date": "2026-09-03", "calendar": "Sam's"},
+            ],
+        }))
+        return lambda: json.loads(path.read_text())
+
+    SAMS = {"label": "Sam's", "enabled": "on",
+            "url": "https://calendar.google.com/calendar/ical/sam%40gmail.com/private-xxxx/basic.ics"}
+
+    def test_saving_drops_that_calendars_stored_events(self, client, board):
+        client.post("/settings/calendars/sams12345",
+                    data={**self.SAMS, "shared_with": "jess@example.com"})
+        payload = board()
+        assert [e["title"] for e in payload["events"]] == ["Sports day"]
+        assert [s["label"] for s in payload["calendar_statuses"]] == ["School"]
+        assert "calendars_fetched_at" not in payload  # so the next tick fetches again
+        assert payload["headline"] == "Hi"
+
+    def test_a_rename_forgets_under_the_old_name_too(self, client, board):
+        client.post("/settings/calendars/sams12345", data={**self.SAMS, "label": "Dad's"})
+        assert [e["title"] for e in board()["events"]] == ["Sports day"]
+
+    def test_removing_a_calendar_removes_its_events(self, client, board):
+        client.post("/settings/calendars/sams12345/delete")
+        assert [e["title"] for e in board()["events"]] == ["Sports day"]
+
+    def test_reordering_forgets_nothing(self, client, board):
+        client.post("/settings/calendars/sams12345/move", data={"direction": "up"})
+        assert len(board()["events"]) == 2
+        assert "calendars_fetched_at" in board()
+
+    def test_a_rejected_form_forgets_nothing(self, client, board):
+        client.post("/settings/calendars/sams12345", data={**self.SAMS, "shared_with": "jess"})
+        assert len(board()["events"]) == 2
+
+    def test_the_message_says_when_it_shows(self, client, board):
+        page = client.post("/settings/calendars/sams12345", data=self.SAMS,
+                           follow_redirects=True).get_data(as_text=True)
+        assert "picks up the change at the next refresh" in page
+
+
 class TestRefreshingTheCalendarsByHand:
     """The cheap half of "Rewrite now": fetch the feeds, ask Claude nothing."""
 

--- a/web/CLAUDE.md
+++ b/web/CLAUDE.md
@@ -9,8 +9,8 @@ file holds the ones that only bite here. Sizing conventions are in the root unde
 **Adding a field to a settings section.** Add a tuple to the section's `fields` list in
 `web/routes/settings.py` — `(name, label, kind, required, help)`. The list template and the edit
 form both render from it, and `parse_field` reads it back. `kind` is one of `text`, `url`, `date`,
-`monthday`, `textarea`, `checkbox`, `emoji`, `color`, `people`. A new `kind` needs a branch in
-`parse_field` and a branch in `web/templates/settings/edit.html`; nothing else.
+`monthday`, `textarea`, `checkbox`, `emoji`, `color`, `people`, `emails`. A new `kind` needs a
+branch in `parse_field` and a branch in `web/templates/settings/edit.html`; nothing else.
 
 **Adding a whole settings section.** Add an entry to `SECTIONS` and a row to
 `web/templates/settings/home.html`. The list, edit, delete and reorder routes are generic and need

--- a/web/routes/settings.py
+++ b/web/routes/settings.py
@@ -16,10 +16,10 @@ from flask import (Blueprint, abort, current_app, flash, redirect,
 
 from dinkydash import config as config_module
 from dinkydash import schedule
-from dinkydash.calendars import FeedError, describe_feed
+from dinkydash.calendars import FeedError, addresses, describe_feed, feed_label
 from dinkydash.claude_client import GenerationError
 from dinkydash.context import compute_birthday_info, upcoming_for
-from dinkydash.runner import refresh_calendars
+from dinkydash.runner import forget_calendar, refresh_calendars
 from dinkydash.runner import run as run_generation
 from web import manifest as manifest_module
 
@@ -88,7 +88,8 @@ SECTIONS = {
         "title": "Calendars",
         "singular": "calendar",
         "add_label": "Add a calendar",
-        "blurb": "Every calendar you switch on is merged into one agenda. Titles and times are sent to Claude each morning.",
+        "blurb": "Every calendar you switch on is merged into one agenda. Titles and times are "
+                 "sent to Claude each morning; an event kept off the board by a guest list is not.",
         "fields": [
             ("label", "Call it", "text", True, ""),
             ("url", "iCal link", "url", True,
@@ -96,6 +97,11 @@ SECTIONS = {
              "iCloud → share the calendar → Public Calendar → Copy Link (a webcal:// link is "
              "fine, it is converted for you). Outlook → Settings → Calendar → Shared calendars → "
              "Publish a calendar, then the ICS link. Links must be https."),
+            ("shared_with", "Only show events shared with", "emails", False,
+             "Email addresses, with commas between them. Only events with one of these people "
+             "on the guest list, or organised by them, go on the board — the rest of this "
+             "calendar stays private. Use the address on the invitation. Leave it empty to "
+             "show everything."),
             ("enabled", "Show on the board", "checkbox", False, ""),
         ],
     },
@@ -150,6 +156,9 @@ def parse_field(field, form, existing):
     if kind == "people":
         values = [v for v in form.getlist(name) if v]
         return values
+    if kind == "emails":
+        # One text box, stored as a list: what the engine compares against.
+        return addresses(form.get(name, ""))
     if kind == "monthday":
         month = form.get(f"{name}_month", "").strip()
         day = form.get(f"{name}_day", "").strip()
@@ -175,6 +184,11 @@ def validate(section, item):
                 datetime.strptime(str(value), "%Y-%m-%d")
             except ValueError:
                 problems.append(f"{label} should look like 2017-03-15.")
+        if kind == "emails":
+            for address in value or []:
+                if "@" not in address:
+                    problems.append(f"“{address}” is not an email address. Use the address "
+                                    f"on the invitation, like sam@example.com.")
     return problems
 
 
@@ -327,7 +341,18 @@ def section_edit(section_name, item_id):
                     submitted["id"] = item_id
                     items[index] = submitted
                 save(config)
-                flash(f"Saved {submitted.get('name') or submitted.get('title') or submitted.get('label') or 'it'}.", "ok")
+                if section_name == "calendars":
+                    # What this calendar last said was fetched under the old
+                    # entry — before a guest list, say — so it goes, and the
+                    # next tick fetches afresh. Under the old name as well as
+                    # the new, in case this was a rename.
+                    stale = {feed_label(submitted)} | ({feed_label(item)} if not is_new else set())
+                    forget_calendar(config, current_store(), stale)
+                    flash(f"Saved {feed_label(submitted)}. The board picks up the change at "
+                          f"the next refresh — press Refresh calendars if you don't want to wait.",
+                          "ok")
+                else:
+                    flash(f"Saved {submitted.get('name') or submitted.get('title') or 'it'}.", "ok")
                 return redirect(url_for("settings.section_list", section_name=section_name))
             item = submitted
 
@@ -341,27 +366,48 @@ def section_edit(section_name, item_id):
 
 
 def check_feed(item, config):
-    """Fetch a pasted iCal URL and describe what came back."""
+    """Fetch a pasted iCal URL and describe what came back.
+
+    With a guest list on the form, the answer is "3 of the 24" — and a red
+    "none of them" when the list matches nobody. That case is the failure the
+    old global filter hid: a working link, a full calendar, and a board with
+    nothing on it. Red, because that is exactly what saving would give.
+    """
     url = (item.get("url") or "").strip()
     if not url:
         return {"ok": False, "message": "Paste a link first."}
+    wanted = addresses(item.get("shared_with"))
     try:
         found = describe_feed(
             url, config_module.tzinfo_for(config),
             today=config_module.today_for(config),
             days_ahead=int(config.get("calendar_days_ahead") or 14),
+            shared_with=wanted,
         )
     except FeedError as exc:
         return {"ok": False, "message": str(exc)}
-    if not found["count"]:
+    days = found["days_ahead"]
+    if not found["total"]:
         return {"ok": True, "message":
-                f"That link works, but there is nothing on it in the next "
-                f"{found['days_ahead']} days."}
+                f"That link works, but there is nothing on it in the next {days} days."}
+    who = ", ".join(wanted)
+    if wanted and not found["count"]:
+        return {"ok": False, "message":
+                f"That link works and has {found['total']} events in the next {days} days, "
+                f"but none of them is shared with {who}. Check the address — it has to be "
+                f"the one on the invitation."}
+    if wanted:
+        count = found["count"]
+        lead = (f"{count} of the {found['total']} events over the next {days} days "
+                f"{'is' if count == 1 else 'are'} shared with {who}.")
+    else:
+        lead = f"{found['count']} events over the next {days} days."
     nxt = found["next"]
-    when = "all day" if nxt["all_day"] else nxt["time"]
-    return {"ok": True, "message":
-            f"{found['count']} events over the next {found['days_ahead']} days. "
-            f"Next up: {nxt['title']}, {nxt['date']} at {when}."}
+    tail = ""
+    if nxt:
+        when = "all day" if nxt["all_day"] else nxt["time"]
+        tail = f" Next up: {nxt['title']}, {nxt['date']} at {when}."
+    return {"ok": True, "message": lead + tail}
 
 
 @bp.route("/<section_name>/<item_id>/delete", methods=["POST"])
@@ -374,6 +420,8 @@ def section_delete(section_name, item_id):
         abort(404)
     items.pop(index)
     save(config)
+    if section_name == "calendars":
+        forget_calendar(config, current_store(), {feed_label(removed)})
     flash(f"Removed {removed.get('name') or removed.get('title') or removed.get('label') or 'it'}.", "ok")
     return redirect(url_for("settings.section_list", section_name=section_name))
 

--- a/web/templates/settings/edit.html
+++ b/web/templates/settings/edit.html
@@ -28,6 +28,14 @@
         {% elif kind == 'url' %}
             <input type="url" id="f-{{ name }}" name="{{ name }}" value="{{ item.get(name, '') }}" {{ 'required' if required }} placeholder="https://calendar.google.com/…/basic.ics">
 
+        {% elif kind == 'emails' %}
+            {# Stored as a list, typed as one line. A hand-edited file may hold a string; show it as it is. #}
+            {% set current = item.get(name) %}
+            <input type="text" id="f-{{ name }}" name="{{ name }}"
+                   value="{{ current if current is string else (current or []) | join(', ') }}"
+                   inputmode="email" autocapitalize="none" autocorrect="off" spellcheck="false"
+                   placeholder="sam@example.com">
+
         {% elif kind == 'date' %}
             <input type="date" id="f-{{ name }}" name="{{ name }}" value="{{ item.get(name, '') }}" {{ 'required' if required }}>
 

--- a/web/templates/settings/list.html
+++ b/web/templates/settings/list.html
@@ -31,7 +31,11 @@
                 {% elif section_name == 'special_dates' %}
                     {{ item.date }}
                 {% elif section_name == 'calendars' %}
+                    {% if item.shared_with %}
+                    Only events shared with {{ item.shared_with if item.shared_with is string else item.shared_with | join(', ') }}
+                    {% else %}
                     {{ item.url | truncate(38, true) }}
+                    {% endif %}
                 {% endif %}
             </div>
         </a>

--- a/website/content/getting-started.md
+++ b/website/content/getting-started.md
@@ -54,6 +54,17 @@ Put the link in `config.yaml` under `calendars:` (step 2 below), or add it later
 
 Whichever provider it came from, treat the link like a password. Anyone who has it can read that calendar, for as long as it exists, and there is no way to see who has.
 
+<h3 id="personal-calendar">A personal calendar with work in it</h3>
+
+You do not need a separate family calendar. If your own calendar also holds work meetings and private appointments, paste it anyway, then fill in **Only show events shared with** on that calendar with the other parent's email address. Only the events they are invited to, or that they organised, reach the board. Everything else stays off it, and is never sent to Claude.
+
+Two things to get right:
+
+- **Use the address on the invitation.** Google, Apple and Outlook all record guests by email address, so it has to be the one you actually invite them with. If they have two, list both with a comma between them.
+- **Press Check this link before you save.** With a guest list filled in, it says how many events get through out of how many, and warns you if none do. That usually means the address is not the one on the invitations, or that nothing in the next fortnight has been shared yet.
+
+Each calendar has its own list, so the school calendar, which has no guests, is left alone. Saving a calendar clears whatever was fetched from it before, so nothing from before the guest list lingers; the board picks it up again at the next refresh, or straight away if you press **Refresh calendars**. In `config.yaml` the same setting is `shared_with`, a list of addresses under that calendar.
+
 ---
 
 ## Part 1 — Run it on your computer
@@ -172,7 +183,7 @@ Now these three pages are live:
 | `timezone` | An IANA name like `Europe/Berlin`. Decides when "today" rolls over and how event times read. Set it even on a Pi whose clock is already local — the engine works from this, not the machine clock. |
 | `location` | Your city and country. Optional; gives the daily line local flavour. |
 | `theme` | `light` or `dark`. |
-| `calendars` | One entry per iCal feed: a `label`, a `url` (the secret iCal address) and `enabled`. Merged into one agenda. |
+| `calendars` | One entry per iCal feed: a `label`, a `url` (the secret iCal address) and `enabled`. Merged into one agenda. An optional `shared_with` list of email addresses shows only the events with one of those people as a guest or organiser. |
 | `people` | `name`, `date_of_birth` (YYYY-MM-DD), an `avatar_emoji`, an `avatar_color`, and `interests` that feed the daily line. |
 | `pets` | `name`, `type` and an `avatar_emoji`. |
 | `recurring` | Chores that rotate one person per day, in the order you list under `choices`. |
@@ -182,7 +193,7 @@ Now these three pages are live:
 
 The settings page adds a short `id` to each person, pet, chore, date and calendar the first time you open it. Leave those alone — they are how the page tells one entry from another.
 
-**Upgrading an old config?** A single `calendar_url` becomes the first entry in `calendars` automatically. `calendar_filter_emails` is dropped, because it needed every listed address to appear as an event guest and most personal events have none — use one feed per person instead. Photos are gone; the board uses an emoji and a colour.
+**Upgrading an old config?** A single `calendar_url` becomes the first entry in `calendars` automatically, and a `calendar_filter_emails` list moves onto that entry as its `shared_with`. Photos are gone; the board uses an emoji and a colour.
 
 #### Editing from your phone
 
@@ -190,6 +201,7 @@ Everything on the board is editable at `/settings`. Two things worth knowing:
 
 - **A saved board is from this morning.** Editing a chore or a person shows up on the next page load, but the headline and daily line are only rewritten each morning. Press **Rewrite now** on the settings home page to get fresh copy immediately. Each press is one API call.
 - **Adding a calendar checks the link.** Paste an iCal address and press **Check this link**. It tells you how many events it found and what the next one is, so you are not left guessing whether the URL works.
+- **A personal calendar can keep its private side.** Fill in **Only show events shared with** on that calendar, and only the events the other parent is on reach the board. See [a personal calendar with work in it](#personal-calendar) above.
 
 The board can be in one of three states: the normal board, a first-run "waiting" screen before anything is generated, or a stale state after a failed or missing run. When stale, the times, turns and countdowns are still today's — only the written line is old, and the board says so.
 
@@ -433,7 +445,7 @@ The old `lcd_rotate` and `display_rotate` lines in `config.txt` no longer apply 
 
 **Times are off by an hour.** The timezone under Settings → Family & system is what the engine uses, not the machine clock. Set it even if the clock is already local.
 
-**A calendar shows nothing.** Check it under Settings → Calendars — a failed feed says so. Apple regenerates iCloud links when a calendar stops being shared, so a link that worked last month may need replacing.
+**A calendar shows nothing.** Check it under Settings → Calendars — a failed feed says so. Apple regenerates iCloud links when a calendar stops being shared, so a link that worked last month may need replacing. If the calendar has **Only show events shared with** filled in, open it and press **Check this link**: a working link with no events getting through means the address is not the one on the invitations.
 
 **A GNOME keyring password box appears.** The `--password-store=basic` flag in `run.sh` prevents this. Make sure it is present.
 

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -787,7 +787,7 @@
             </details>
             <details>
                 <summary>What happens to my family's calendar?</summary>
-                <p>Your events are read to build the day's agenda, and that agenda is sent to Anthropic so Claude can write the day's line. Nothing is sold, and there are no adverts. Self-hosting keeps everything else on your own machine, and the board still runs with no API key at all — you simply go without the written line.</p>
+                <p>Your events are read to build the day's agenda, and that agenda is sent to Anthropic so Claude can write the day's line. If your own calendar also holds work and private appointments, you can limit it to the events shared with your partner, and the rest is never stored and never sent to Anthropic. Nothing is sold, and there are no adverts. Self-hosting keeps everything else on your own machine, and the board still runs with no API key at all — you simply go without the written line.</p>
             </details>
             <details>
                 <summary>How is this different from a Skylight or Hearth?</summary>
@@ -859,7 +859,7 @@
     {
       "@type": "Question",
       "name": "What happens to my family's calendar?",
-      "acceptedAnswer": { "@type": "Answer", "text": "Your events are read to build the day's agenda, and that agenda is sent to Anthropic so Claude can write the day's line. Nothing is sold, and there are no adverts. Self-hosting keeps everything else on your own machine, and the board still runs with no API key at all — you simply go without the written line." }
+      "acceptedAnswer": { "@type": "Answer", "text": "Your events are read to build the day's agenda, and that agenda is sent to Anthropic so Claude can write the day's line. If your own calendar also holds work and private appointments, you can limit it to the events shared with your partner, and the rest is never stored and never sent to Anthropic. Nothing is sold, and there are no adverts. Self-hosting keeps everything else on your own machine, and the board still runs with no API key at all — you simply go without the written line." }
     },
     {
       "@type": "Question",


### PR DESCRIPTION
Each calendar entry can now carry a guest list (`shared_with`, edited as **Only show events shared with** in the settings UI), and only the events with one of those people as a guest or organiser reach the board, so a personal calendar keeps its work and private appointments to itself. The filter runs as the feed is parsed, so hidden events never reach the payload, the board or the prompt, and no addresses are stored; **Check this link** counts before and after the filter and warns when a working link matches nothing. Saving or removing a calendar now forgets its stored events and clears the fetch stamp, so the next tick fetches afresh and the last-known fallback cannot bring pre-filter events back. A legacy `calendar_filter_emails` migrates onto the migrated feed instead of being dropped. Documented in the getting-started guide, the example config, the homepage FAQ, both `doc/` guides, the engine and web guides and the README, with tests for parsing, migration, the form, the check message and the forget-on-save rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)