### PR TITLE
Settle SendGrid, and put the board in the container that already runs

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -1,21 +1,60 @@
-# DigitalOcean App Platform spec for the DinkyDash marketing site.
+# DigitalOcean App Platform spec for dinkydash.co.
 #
 # Applied with:
-#   doctl apps update <APP_ID> --spec .do/app.yaml
+#   doctl apps update ed4158fc-fb49-4c10-bb1e-2c8491b06a86 --spec .do/app.yaml
 #
 # Infrastructure reviewed like code, which is why it is committed. **No secrets
-# here.** This app needs none — it renders Markdown and serves files, with no
-# database, no API key and no user data. The board is a separate app and will
-# get its own spec; keeping them apart is what lets this one hold nothing worth
-# stealing.
+# here.** App Platform's encrypted environment variables are set with `doctl`
+# or in the dashboard, and this file references them by name.
+#
+# **This spec is the whole app, not a patch.** `doctl apps update` replaces what
+# is there. Anything missing from this file is deleted from the running app,
+# which is why `domains` is written out below even though nothing here changes
+# it — it was absent until 8 September 2026, and applying the file as documented
+# above would have taken dinkydash.co off its own domain.
 #
 # No Dockerfile: App Platform's Python buildpack reads .python-version and
 # requirements.txt and runs the command below (DIN-30, reversed).
+#
+# --------------------------------------------------------------------------
+# Where this is going (DIN-26)
+#
+# The board joins this app rather than getting its own, because that is how
+# qrpage.co and abc-league already run in this account: one service, one
+# container, marketing and application together. `wsgi.py` routes on the `Host`
+# header — dinkydash.co to the marketing site, app.dinkydash.co to the board.
+#
+# Three things have to land before that switch, and none of them has:
+#
+#   1. The Managed Postgres cluster in FRA1. Cloud mode's `create_app()` builds
+#      a PostgresStore at import, so `wsgi:application` cannot boot without it.
+#   2. The app.dinkydash.co CNAME in Cloudflare, DNS-only. Listing a domain here
+#      before it resolves means App Platform fails to issue its certificate.
+#   3. The worker. There is no `worker/` directory yet; the tick loop is
+#      unwritten. It must be its own component — there is no lock on the tick,
+#      so two web instances would tick twice and pay Anthropic twice.
+#
+# When they have, this file gains: `app.dinkydash.co` in `domains`, a
+# `run_command` of `gunicorn "wsgi:application"`, a `build_command` of
+# `pip install -r requirements-cloud.txt`, `DINKYDASH_MODE=cloud`,
+# `DINKYDASH_APP_HOST`, the secret references, a `workers:` block and a
+# `PRE_DEPLOY` migration job. Until then this app serves the marketing site and
+# holds nothing worth stealing — a property it loses on that day, deliberately,
+# and this comment should be rewritten rather than left to mislead.
+# --------------------------------------------------------------------------
 
 name: dinkydash-site
 region: fra
 
+domains:
+  - domain: dinkydash.co
+    type: PRIMARY
+  - domain: www.dinkydash.co
+    type: ALIAS
+
 services:
+  # Named `site` rather than `web` because renaming a component destroys and
+  # recreates it, and the name is not worth an outage on the pages that rank.
   - name: site
     github:
       repo: caspii/dinkydash
@@ -47,7 +86,7 @@ services:
 
     envs:
       # What the canonical tags, og:url and the sitemap claim to be. Set
-      # explicitly so a staging copy never tells a search engine it is
+      # explicitly so a preview copy never tells a search engine it is
       # production.
       - key: DINKYDASH_SITE_URL
         scope: RUN_TIME

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,6 +1,10 @@
 # DinkyDash Hosted MVP — Plan
 
-*Last updated: September 7, 2026. Supersedes `HOSTING_ANALYSIS.md` (deleted — it predated both the AI generation feature and the July 2026 calendar-display repositioning, and its recommended stack and data model no longer matched the product).*
+*Last updated: September 8, 2026. Supersedes `HOSTING_ANALYSIS.md` (deleted — it predated both the AI generation feature and the July 2026 calendar-display repositioning, and its recommended stack and data model no longer matched the product).*
+
+*September 8, later: **one service, not two.** The board joins the marketing site in the existing `dinkydash-site` app rather than getting its own, because that is how `qrpage.co` and `abc-league` already run in this account — one container, one gunicorn, everything in it. Staging is dropped until there is a paying family to protect. The `worker` is the one genuine addition, because the tick has no lock and two web instances would tick twice. See [Hosting and deployment](#hosting-and-deployment).*
+
+*September 8: the transactional email provider is settled — decision 13, **SendGrid**, on the account KeepTheScore already sends from. The open question is closed. `dinkydash.co` is an authenticated sending domain on that account (DKIM and a monitor-only DMARC record are live in Cloudflare), and this repo has its own send-only API key. What is not built is the sending itself — that arrives with magic links in Phase 1.*
 
 *September 7, later still: the Postgres layer is built (DIN-31) — `migrations/001_initial_schema.sql`, `migrate.py`, `dinkydash/db.py`, `dinkydash/pgstore.py`, and a contract suite that runs the same assertions over both stores in CI. Connection pooling is settled above. What is deliberately still missing is the multi-tenancy: cloud mode serves one family from `DINKYDASH_FAMILY_ID`, because auth and scoping are Phase 1.*
 
@@ -40,6 +44,7 @@ Turn DinkyDash from a single-family Raspberry Pi app into a hosted product a non
 | 10 | **The config dict is the storage contract.** `config.yaml` in single mode, a `jsonb` column in cloud mode. Not SQLite on the Pi. | The engine already takes a plain dict, so both modes can produce the same one. Self-hosters expect a file they can edit and copy, and a Pi should not have to run migrations to gain a field. One shape means one settings UI. |
 | 11 | **The refresh cadence is a setting in the UI.** How often the calendars are re-fetched, and when the daily brief is written, are chosen by the family — not hard-coded in a cron line. | A calendar product whose board only learns about a new appointment the next morning is a support ticket waiting to happen. See [Three clocks, one setting](#three-clocks-one-setting). |
 | 12 | **DigitalOcean App Platform (Frankfurt) + DigitalOcean Managed Postgres, with Cloudflare in front.** Not Hetzner and a box, which is what this plan recommended until 7 September. | Quickest route to a deployed app: no SSH, no firewall, no container machinery, and the worker is a second component off the same checkout. A managed database deletes the backup, upgrade and failover work a box would have added. About $25 a month against roughly €5 for the box — the difference buys the ops. See [Hosting and deployment](#hosting-and-deployment). |
+| 13 | **SendGrid for transactional email**, on the same account KeepTheScore sends from. Not Postmark, and not the Customer.io connector. | Shared sender reputation from day one, which is the whole game for magic links — a link that lands in spam is a login that fails. It is one account, one bill and one set of suppression lists across six domains. Customer.io stays what it is: a marketing tool, right for the waitlist sequence, heavy for a login link. |
 
 ### On self-hosting (decision 9)
 
@@ -374,16 +379,53 @@ being able to write in the privacy policy.
 Postgres, and Cloudflare in front.**
 
 ```
-App Platform app                            Managed Postgres cluster (FRA1)
-├── web       service   gunicorn, HTTP      ├── dinkydash
-├── worker    worker    the 5-minute tick   └── dinkydash_staging
-└── migrate   pre-deploy job                Cloudflare — DNS, edge TLS, rate limits
+dinkydash-site app (exists)                 Managed Postgres cluster (FRA1)
+├── site      service   gunicorn, HTTP      └── dinkydash
+│              dinkydash.co     -> website.site
+│              app.dinkydash.co -> web.create_app()
+├── worker    worker    the 5-minute tick   Cloudflare — DNS, edge TLS, rate limits
+└── migrate   pre-deploy job
      all three from the same checkout, no image
 ```
 
+**One service, not two, and it is the one already running.** `dinkydash-site`
+serves `dinkydash.co` today on a $5 instance. The board becomes a second
+hostname on that same container, dispatched on the `Host` header, rather than a
+second app. Two reasons, and neither is architectural taste:
+
+- **It is the house pattern.** `qrpage.co` is one App Platform app, one `web`
+  service, one container, marketing pages and application together, with a
+  `PRE_DEPLOY` migration job. `abc-league` is one service answering on two
+  domains. Both work. A shape that is running in this account beats a shape
+  argued from first principles.
+- **The saving is real and the cost is not.** A second service is $5/month; a
+  second *app* for staging is another $10. What separation would buy — a
+  marketing container holding no secrets, and a board crash that cannot take
+  the ranked pages down — is worth having, but not worth $180 a year before
+  there is a single paying family. Revisit when there is revenue to protect.
+
+**`site`, not `web`.** Renaming an App Platform component destroys and recreates
+it, and the name is not worth an outage on the pages that rank. The component
+serving both hostnames keeps the name it has.
+
+**`wsgi.py` is the seam**, and it exists: it reads the `Host` header and hands the
+request to one app or the other. Unknown hostnames get the *site*, never the board —
+App Platform's health check arrives on an `.ondigitalocean.app` name that is in no
+spec, so it has to answer, and the site is the half that holds no family's data.
+`app.py` is untouched; a Pi never loads any of this.
+
+**The subdomain stays, and it is what makes merging easy.** `app.dinkydash.co`
+costs nothing: App Platform attaches many domains to one app, which is what
+`abc-league` already does. Keeping it means both Flask apps go on owning `/` —
+`website/site.py` says plainly why they are separate apps — so nothing in
+either URL map has to move. It also keeps the Cloudflare cache rule simple:
+cache the marketing host, never cache the board host. Sharing one hostname
+would make that a per-path allowlist, and a mistake there serves one family's
+board to another.
+
 **No Dockerfile, and no Compose file.** App Platform's Python buildpack reads
 `.python-version` and `requirements.txt` and runs whatever `run_command` each
-component declares, so `web`, `worker` and the migration job are one checkout
+component declares, so `site`, `worker` and the migration job are one checkout
 with three commands. That is decision 2's "one artefact" argument holding in
 the only form that ever mattered — one codebase — without a container runtime
 in the middle of it.
@@ -434,8 +476,10 @@ in the app:
   labour** — see [Connection pooling](#connection-pooling) below.
 - Daily backups and 7-day point-in-time recovery are on by default and are
   theirs. **The restore drill is still ours** — see Phase 6.
-- One cluster, two databases: `dinkydash` and `dinkydash_staging`. A second
-  cluster for staging is $15 a month to learn nothing.
+- **One database, `dinkydash`, and no staging** until there is a paying family to protect.
+  Staging was two more components and a second branch to keep green, for a product with no
+  customers. `dinkydash_staging` is a line to add to this file the day losing production
+  costs money, not before.
 
 #### Connection pooling
 
@@ -454,10 +498,10 @@ pool = ConnectionPool(
 )
 ```
 
-**Why not the app-side pool alone.** Production web, production worker, staging
-web and staging worker is four processes sharing one cluster from the first day
-DIN-26 stands staging up, before the migration job or a `psql` window. The
-arithmetic is tight enough that a third gunicorn worker tips it over. PgBouncer
+**Why not the app-side pool alone.** Web and worker is two processes, not the four
+the staging plan would have made — but 22 connections is still the whole cluster, and
+the migration job and a `psql` window both want one. The arithmetic is tight enough
+that a third gunicorn worker tips it over. PgBouncer
 turns "connection refused" into "wait a moment", and that change of failure mode
 is the whole reason it is there.
 
@@ -479,7 +523,7 @@ arithmetic above comes straight back.
 psycopg 3 prepares a statement server-side once it repeats, and under
 transaction-mode pooling the next execution can land on a different backend
 connection: `prepared statement "..." does not exist`, intermittently, under
-load, after staging looked fine. This is the one line that differs from
+load, after everything looked fine in testing. This is the one line that differs from
 KeepTheScore, which is on psycopg2 and never auto-prepares — their clean record
 does not transfer. Setting it unconditionally means one behaviour rather than
 two. The cost is nil at this query volume.
@@ -501,9 +545,12 @@ and rolls the components out with a health check on `/healthz`. Migrations run a
 **pre-deploy job** in the app spec, so the schema is always ahead of the code
 that needs it and a failed migration fails the deploy instead of half-updating
 a live app. GitHub Actions keeps running the test suite — App Platform deploys,
-it does not gate. Staging is a second App Platform app off the `staging` branch
-against `dinkydash_staging`. The Pi keeps `deploy_to_pi.sh`; a self-hoster is
-not a tenant.
+it does not gate. There is no staging app; see the database section. The Pi keeps
+`deploy_to_pi.sh`; a self-hoster is not a tenant.
+
+**Nothing here needs the dashboard.** The one thing `doctl` cannot do is create an app
+with a GitHub source, because an API token carries no GitHub OAuth session. `dinkydash-site` already has one, so adding the board's hostname, the `worker` and
+the migration job is `doctl apps update` against a spec in this repo.
 
 **The app spec lives in the repo** as `.do/app.yaml`, so the components,
 instance sizes, health checks and the pre-deploy job are reviewed like code.
@@ -614,10 +661,10 @@ Critical path is 0 → 1 → 2 → 3. Phases 4–6 can run alongside 3. Nothing 
 - [x] **Decision 11, single-mode half:** `refresh_minutes` and `brief_time` in `DEFAULTS`; `runner.run` split into `refresh_calendars` and `write_brief`; a pure `due()`; `generate.py --tick`; the settings page under *This screen*; the board's reload derived from the interval; README cron line updated. Ships to the Pi at once and needs no database. *(DIN-17 for the engine and cron, DIN-18 for the page)*
 - [x] Name the storage seam: `FileStore` gathering the six operations that exist today, and the settings routes, runner and board taking a store *(DIN-19)*
 - [x] Postgres + plain-SQL migrations; CI running the suite against a Postgres service container *(DIN-31)*
-- [x] Move DNS to Cloudflare and add the app records *(DIN-29)*. The apex now points at App Platform, not GitHub Pages — DIN-27 moved the marketing pages onto the app.
-- [ ] Stand up the App Platform app and the Managed Postgres cluster in Frankfurt; staging live on `staging.app.dinkydash.co` *(DIN-26)*
+- [x] Move DNS to Cloudflare and add the app records *(DIN-29)*. The apex now points at App Platform, not GitHub Pages — DIN-27 moved the marketing pages onto the app. The SendGrid records are in the same zone and validated: `em4199`, `s1._domainkey`, `s2._domainkey` and a `_dmarc` TXT at `p=none`. All four are **DNS-only** — a proxied CNAME answers as Cloudflare and domain authentication never passes.
+- [ ] Add the board to the existing `dinkydash-site` app and stand up Managed Postgres in Frankfurt; `app.dinkydash.co` live over TLS *(DIN-26)*. One service serving both hostnames, plus a `worker` and a `PRE_DEPLOY` migration job. No staging app — see the database section.
 
-**Done when:** the engine runs from a dict with an injected date, tests pass in CI on Postgres, a same-day calendar change reaches a Pi within its chosen interval, and staging serves a hardcoded family over TLS.
+**Done when:** the engine runs from a dict with an injected date, tests pass in CI on Postgres, a same-day calendar change reaches a Pi within its chosen interval, and `app.dinkydash.co` serves a hardcoded family over TLS.
 
 ### Phase 1 — Multi-tenant core
 
@@ -676,9 +723,10 @@ missing is the multi-tenant half — a schema, auth, and scoping every read and 
 ### Phase 5 — Legal & trust
 
 - [ ] Privacy policy and ToS, forked from KeepTheScore
-- [ ] Sub-processor list — Anthropic, DigitalOcean, Stripe, the email provider, Cloudflare. **Not Google Fonts**: self-hosted since DIN-32, and nothing on the board, the settings UI or the marketing site requests anything from them.
+- [ ] Sub-processor list — Anthropic, DigitalOcean, Stripe, **SendGrid** (decision 13), Cloudflare. **Not Google Fonts**: self-hosted since DIN-32, and nothing on the board, the settings UI or the marketing site requests anything from them.
 - [ ] **DigitalOcean's DPA signed, with standard contractual clauses.** They are a US company; the app and database sit in Frankfurt. Say both — where the data lives, and who the company is. Cloudflare needs the same treatment.
 - [ ] Plain statement that calendar contents are sent to Anthropic for generation
+- [ ] Say what SendGrid receives, which is **the email address and the login link, never the calendar**. The two disclosures are different in kind and should not be merged into one sentence: Anthropic sees a family's appointments, SendGrid sees only who is logging in.
 - [ ] Data export and hard delete — the delete cascades through users, tokens, agendas, generations, history and calendar health; the Stripe customer record stays, as accounting requires
 - [ ] Retention, with numbers: `agendas` is one overwritten row; `content_history` keeps 30 entries of the model's words; `generations` keeps token counts indefinitely and drops the `brief` column after 90 days; a lapsed family is deleted 90 days after lapse
 - [ ] Cookie/analytics review
@@ -690,7 +738,7 @@ missing is the multi-tenant half — a schema, auth, and scoping every read and 
 - [ ] Sentry (already connected) in both processes; uptime check on `/healthz`
 - [ ] Generation-success dashboard; alerts on failure rate, calendar-fetch failures, spend breaker, Stripe webhook failures, and the dead-man's switch
 - [ ] **The restore drill.** DigitalOcean takes daily backups and keeps 7 days of point-in-time recovery, so the *dump* is no longer a job. Restoring into a scratch database on a schedule still is, and an untested backup is a hope. Script it; run it monthly.
-- [ ] Transactional email provider wired up *(see open questions)*
+- [ ] SendGrid wired up in the app *(decision 13)*. The account, the authenticated sending domain and a send-only API key already exist; what is missing is the code that calls them, and it lands with magic links in Phase 1 rather than here.
 - [ ] Support inbox and a basic admin view (find family, inspect last generation, re-run)
 
 **Done when:** you'd be comfortable going away for a weekend.
@@ -719,7 +767,6 @@ Platform in Frankfurt, DigitalOcean Managed Postgres, Cloudflare in front.*
 
 | Question | Blocks | Recommendation |
 |---|---|---|
-| Transactional email provider? | Phase 1 (magic links) | Whatever KeepTheScore sends its transactional mail with, for the shared sender reputation. Failing that, Postmark. The Customer.io connector that is configured is a marketing tool wearing a transactional hat — right for the waitlist sequence, heavy for magic links. |
 | EU VAT handling with Stripe direct? | Phase 4 | Stripe Tax from the first charge, using KeepTheScore's registration. Consumer prices in the EU are displayed VAT-inclusive, so Checkout is configured with tax-inclusive prices; what that does to the margin is the strategy document's line to update. |
 | Lapse behaviour — blank, freeze on last-good, or degrade to a no-AI calendar? | Phase 4 | Freeze. The screen keeps its last board with a quiet "subscription ended" line; fetches and briefs stop. After 30 days the board is that line alone; after 90 the family is deleted, as the privacy policy will say. A blank kitchen screen is a bad churn experience, and a no-AI tier is a product decision for the strategy document, not a lapse state. |
 | Batch API? | Phase 2 | Not in the MVP. Revisit when the model moves to Sonnet, or when the strategy document's cost line says the discount is worth a second pipeline. |

--- a/requirements-cloud.txt
+++ b/requirements-cloud.txt
@@ -1,9 +1,15 @@
--r requirements.txt
+-r requirements-site.txt
 
-# Cloud mode only. Deliberately not in requirements.txt, which is what
-# deploy_to_pi.sh installs: a self-hosted board has no database and serves with
-# Flask's own server, so a Pi should carry neither a Postgres driver nor a
-# production WSGI server.
+# Cloud mode only, and a superset of the marketing site's list rather than a
+# sibling of it. One App Platform container serves both hostnames — `wsgi.py`
+# routes on the `Host` header — so the cloud build needs the site's Markdown
+# renderer as well as a Postgres driver. `requirements-site.txt` in turn pulls
+# in `requirements.txt`, so this one file installs everything the container
+# runs. `gunicorn` is inherited from it and is deliberately not repeated here.
+#
+# Deliberately not in requirements.txt, which is what deploy_to_pi.sh installs:
+# a self-hosted board has no database, serves with Flask's own server, and has
+# no business rendering landing pages.
 #
 # App Platform installs this file with a build_command in `.do/app.yaml` — its
 # Python buildpack installs requirements.txt on its own, which is deliberately
@@ -12,4 +18,3 @@
 # Pinned with == like the rest, so a clean build gets what CI passed on.
 psycopg[binary]==3.3.5
 psycopg-pool==3.3.1
-gunicorn==23.0.0

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -1,0 +1,115 @@
+"""One container, two hostnames: what `wsgi.py` must route where.
+
+The dispatcher is four lines of logic guarding a $5-a-month decision, and every
+way it can be wrong is quiet. A board served on the marketing hostname is a
+family's calendar on a page Google crawls. A marketing page served on the board
+hostname is a broken product. An unknown hostname that 404s takes the whole
+deploy down, because App Platform's health check arrives on a name nobody
+configured.
+
+`dispatch` takes both apps as arguments precisely so this file can use stubs:
+building the real board app in cloud mode wants a database, and none of these
+assertions is about a database.
+"""
+
+import pytest
+
+from wsgi import _board_host, _normalise, create_application, dispatch
+
+SITE, BOARD = "the site", "the board"
+
+
+def stub(name):
+    """A WSGI app that answers with its own name, so the route is the assertion."""
+    def application(environ, start_response):
+        start_response("200 OK", [("Content-Type", "text/plain")])
+        return [name.encode()]
+    return application
+
+
+def route(host, board_host="app.dinkydash.co"):
+    """Send a request carrying `host` through the dispatcher; return which app answered."""
+    application = dispatch(stub(SITE), stub(BOARD), board_host)
+    body = application({"HTTP_HOST": host}, lambda status, headers: None)
+    return b"".join(body).decode()
+
+
+class TestRouting:
+    def test_the_board_hostname_gets_the_board(self):
+        assert route("app.dinkydash.co") == BOARD
+
+    def test_the_marketing_hostname_gets_the_site(self):
+        assert route("dinkydash.co") == SITE
+
+    def test_www_gets_the_site(self):
+        """The site redirects www to the apex itself; the dispatcher must let it."""
+        assert route("www.dinkydash.co") == SITE
+
+    def test_an_unknown_hostname_gets_the_site_not_the_board(self):
+        """App Platform's own name is not in the spec, and its health check uses it.
+
+        Answering is not optional — a 404 here fails the health check and rolls
+        the deploy back. Answering *with the site* is the safe half of the
+        choice: it holds no family's data.
+        """
+        assert route("clownfish-app-7xt89.ondigitalocean.app") == SITE
+
+    def test_a_missing_host_header_gets_the_site(self):
+        application = dispatch(stub(SITE), stub(BOARD), "app.dinkydash.co")
+        body = application({}, lambda status, headers: None)
+        assert b"".join(body).decode() == SITE
+
+    def test_the_forwarded_host_header_cannot_choose_the_app(self):
+        """Upstream of App Platform is the public internet.
+
+        If `X-Forwarded-Host` picked the app, anyone could ask for the board by
+        setting a header. Only `Host` counts, and App Platform matches its
+        custom domains on that anyway.
+        """
+        application = dispatch(stub(SITE), stub(BOARD), "app.dinkydash.co")
+        environ = {"HTTP_HOST": "dinkydash.co",
+                   "HTTP_X_FORWARDED_HOST": "app.dinkydash.co"}
+        assert b"".join(application(environ, lambda s, h: None)).decode() == SITE
+
+
+class TestHostNormalisation:
+    def test_the_port_is_ignored(self):
+        """gunicorn listens on 8080 behind the proxy, so the port is often present."""
+        assert route("app.dinkydash.co:8080") == BOARD
+
+    def test_case_is_ignored(self):
+        assert route("App.DinkyDash.co") == BOARD
+
+    def test_surrounding_whitespace_is_ignored(self):
+        assert route(" app.dinkydash.co ") == BOARD
+
+    def test_the_configured_host_is_normalised_too(self):
+        """A stray capital or port in the app spec must not break routing."""
+        assert route("app.dinkydash.co", board_host="APP.DinkyDash.co:443") == BOARD
+
+    @pytest.mark.parametrize("host", ["", None, "   "])
+    def test_nothing_normalises_to_empty(self, host):
+        assert _normalise(host) == ""
+
+
+class TestRefusals:
+    def test_no_board_host_is_a_refusal_to_start(self, monkeypatch):
+        """Silently unreachable is the failure this prevents."""
+        monkeypatch.delenv("DINKYDASH_APP_HOST", raising=False)
+        with pytest.raises(RuntimeError, match="DINKYDASH_APP_HOST"):
+            _board_host()
+
+    def test_an_empty_board_host_is_the_same_refusal(self, monkeypatch):
+        monkeypatch.setenv("DINKYDASH_APP_HOST", "")
+        with pytest.raises(RuntimeError, match="DINKYDASH_APP_HOST"):
+            _board_host()
+
+    def test_the_board_host_is_read_from_the_environment(self, monkeypatch):
+        monkeypatch.setenv("DINKYDASH_APP_HOST", "app.example.test")
+        assert _board_host() == "app.example.test"
+
+    def test_single_mode_refuses_to_build_the_dispatcher(self, monkeypatch):
+        """A Pi runs app.py. Importing the site's renderer onto it is not a feature."""
+        monkeypatch.delenv("DINKYDASH_MODE", raising=False)
+        with pytest.raises(RuntimeError, match="app.py"):
+            create_application()

--- a/wsgi.py
+++ b/wsgi.py
@@ -1,0 +1,96 @@
+"""The cloud entry point: two Flask apps, one container, routed on the hostname.
+
+    gunicorn "wsgi:application"
+
+`dinkydash.co` is the marketing site; `app.dinkydash.co` is the board and the
+settings UI. They are separate Flask apps and stay that way — `website/site.py`
+explains why, and both of them want to own `/`. What this module adds is the
+one thing that lets them share a container: a look at the `Host` header, above
+both apps, before either sees the request.
+
+**Why one container.** `qrpage.co` and `abc-league` already run this way in the
+same DigitalOcean account — one App Platform service, one gunicorn, marketing
+and application together. A second service would be $5 a month to buy isolation
+that has no revenue behind it yet. See PLAN.md, Hosting and deployment.
+
+**This is routing, not a mode gate.** The rule that mode gates four things and
+no others still holds: neither app below knows this file exists, neither one
+checks a hostname, and single mode never loads it. `app.py` is untouched and is
+still what a Pi runs.
+
+**Unknown hostnames get the site, never the board.** App Platform always hands
+out an `.ondigitalocean.app` name whatever custom domains are configured, and
+its health check uses it — so an unknown host has to answer, or a deploy rolls
+itself back. Sending it to the site is also the safer of the two: the site
+holds no family's data, and it already marks any non-canonical hostname
+`noindex`.
+"""
+
+import os
+
+from web import CLOUD, mode
+
+
+def dispatch(site_app, board_app, board_host):
+    """Route by hostname: `board_host` gets the board, everything else the site.
+
+    Both apps are WSGI callables, so this is a WSGI callable too and gunicorn
+    cannot tell the difference.
+    """
+    board_host = _normalise(board_host)
+
+    def application(environ, start_response):
+        # `HTTP_HOST` and not `X-Forwarded-Host`. The forwarded header is
+        # written by whoever is upstream, and upstream of App Platform is the
+        # public internet — trusting it would let a stranger pick which app
+        # answers by setting a header. App Platform passes the real Host
+        # through, which is what the custom domains are matched on anyway.
+        host = _normalise(environ.get("HTTP_HOST", ""))
+        app = board_app if host == board_host else site_app
+        return app(environ, start_response)
+
+    return application
+
+
+def _normalise(host):
+    """Lower-cased and without the port: `App.Example.com:8080` -> `app.example.com`.
+
+    Hostnames are case-insensitive, and a `Host` header carries the port
+    whenever it is not the scheme's default — which it is not when gunicorn
+    listens on 8080 behind a proxy.
+    """
+    return (host or "").strip().lower().split(":")[0]
+
+
+def _board_host():
+    """The hostname the board answers on. Required, and only in cloud mode.
+
+    Defaulting this would be the wrong kind of helpful. A typo in the app spec
+    would leave the board silently unreachable while the marketing site served
+    every request with a 404 — a failure that looks like a routing bug for as
+    long as it takes somebody to think of the header.
+    """
+    host = os.environ.get("DINKYDASH_APP_HOST")
+    if not host:
+        raise RuntimeError(
+            "DINKYDASH_APP_HOST is not set. wsgi.py cannot route without it."
+        )
+    return host
+
+
+def create_application():
+    """Build the dispatcher from the environment. Cloud mode only."""
+    if mode() != CLOUD:
+        # Single mode has one app, no hostname to match on, and no reason to
+        # import the site's Markdown renderer onto a Raspberry Pi.
+        raise RuntimeError(
+            "wsgi.py is the cloud entry point. Single mode runs app.py."
+        )
+
+    from web import create_app
+    from website.site import create_site_app
+
+    return dispatch(create_site_app(), create_app(), _board_host())
+
+
+application = create_application() if mode() == CLOUD else None


### PR DESCRIPTION
**Decision 13 settles SendGrid** for transactional email, on the account KeepTheScore already sends from for the shared sender reputation — the authenticated sending domain, DKIM, a monitor-only DMARC record and a send-only API key are all live outside the repo, but no sending code exists yet and that arrives with magic links in Phase 1.

**The board will join the existing `dinkydash-site` container** rather than getting its own App Platform app, because that is how `qrpage.co` and `abc-league` already run in this account; staging is dropped until there is a paying family to protect, taking the plan from about $40/month to $25.15, and removing the one step that needed the dashboard.

**`wsgi.py` is the seam that makes that possible** — it routes on the `Host` header, deliberately ignores `X-Forwarded-Host` because upstream of App Platform is the public internet, and sends unknown hostnames to the marketing site rather than the board so App Platform's health check still answers from the half holding no family's data.

**A latent hazard is fixed:** `.do/app.yaml` had no `domains` block while the running app serves `dinkydash.co` and `www`, so the `doctl apps update` command written in that file's own header would have taken the site off its own domain — the committed spec now diffs clean against production.

Tests: 427 passed, 27 skipped, of which 17 are new; nothing here is applied to the live app, and the Postgres cluster, the `app.dinkydash.co` CNAME and the unwritten worker all remain outstanding for DIN-26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)