### PR TITLE
Send one email, and stand up the Postgres cluster behind it (DIN-36)

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -1,47 +1,37 @@
-# DigitalOcean App Platform spec for dinkydash.co.
+# DigitalOcean App Platform spec for dinkydash.co and app.dinkydash.co.
 #
 # Applied with:
 #   doctl apps update ed4158fc-fb49-4c10-bb1e-2c8491b06a86 --spec .do/app.yaml
 #
-# Infrastructure reviewed like code, which is why it is committed. **No secrets
-# here.** App Platform's encrypted environment variables are set with `doctl`
-# or in the dashboard, and this file references them by name.
+# Infrastructure reviewed like code, which is why it is committed.
 #
 # **This spec is the whole app, not a patch.** `doctl apps update` replaces what
-# is there. Anything missing from this file is deleted from the running app,
-# which is why `domains` is written out below even though nothing here changes
-# it — it was absent until 8 September 2026, and applying the file as documented
-# above would have taken dinkydash.co off its own domain.
+# is there, so anything missing from this file is deleted from the running app.
+# `domains` is written out for that reason — it was absent until 8 September
+# 2026, and applying the file as documented above would have taken dinkydash.co
+# off its own domain.
+#
+# **Secrets are the one exception, and it was tested rather than assumed.** An
+# env var with `type: SECRET` and no `value:` keeps the value already set: this
+# was checked on 8 September with a throwaway variable, set to a value, then
+# re-applied without one, and it survived as `EV[...]`. So the values below can
+# stay out of a public repo without this file becoming a loaded gun. Set them
+# with `doctl apps update` from a spec assembled outside the working tree, or in
+# the dashboard. **Never commit an `EV[...]` blob here** — it is ciphertext of a
+# production credential, and this repo is world-readable.
 #
 # No Dockerfile: App Platform's Python buildpack reads .python-version and
-# requirements.txt and runs the command below (DIN-30, reversed).
+# installs what `build_command` says (DIN-30, reversed).
 #
-# --------------------------------------------------------------------------
-# Where this is going (DIN-26)
+# One service serves both hostnames. `wsgi.py` routes on the `Host` header —
+# dinkydash.co to the marketing site, app.dinkydash.co to the board — because
+# qrpage.co and abc-league already run one container each in this account and a
+# second service is $5/month for isolation with no revenue behind it yet. See
+# PLAN.md, Hosting and deployment.
 #
-# The board joins this app rather than getting its own, because that is how
-# qrpage.co and abc-league already run in this account: one service, one
-# container, marketing and application together. `wsgi.py` routes on the `Host`
-# header — dinkydash.co to the marketing site, app.dinkydash.co to the board.
-#
-# Three things have to land before that switch, and none of them has:
-#
-#   1. The Managed Postgres cluster in FRA1. Cloud mode's `create_app()` builds
-#      a PostgresStore at import, so `wsgi:application` cannot boot without it.
-#   2. The app.dinkydash.co CNAME in Cloudflare, DNS-only. Listing a domain here
-#      before it resolves means App Platform fails to issue its certificate.
-#   3. The worker. There is no `worker/` directory yet; the tick loop is
-#      unwritten. It must be its own component — there is no lock on the tick,
-#      so two web instances would tick twice and pay Anthropic twice.
-#
-# When they have, this file gains: `app.dinkydash.co` in `domains`, a
-# `run_command` of `gunicorn "wsgi:application"`, a `build_command` of
-# `pip install -r requirements-cloud.txt`, `DINKYDASH_MODE=cloud`,
-# `DINKYDASH_APP_HOST`, the secret references, a `workers:` block and a
-# `PRE_DEPLOY` migration job. Until then this app serves the marketing site and
-# holds nothing worth stealing — a property it loses on that day, deliberately,
-# and this comment should be rewritten rather than left to mislead.
-# --------------------------------------------------------------------------
+# **The `worker` component and `worker/` land in the same commit.** Applying
+# this file from a checkout that predates the package gives a component whose
+# run_command cannot import, and a failed deploy.
 
 name: dinkydash-site
 region: fra
@@ -51,6 +41,54 @@ domains:
     type: PRIMARY
   - domain: www.dinkydash.co
     type: ALIAS
+  # The board. DNS-only in Cloudflare: a proxied CNAME answers as Cloudflare
+  # and App Platform's certificate never issues.
+  - domain: app.dinkydash.co
+    type: ALIAS
+
+# App-level, so the service, the worker and the migration job all see them
+# without three copies to keep in step.
+envs:
+  - key: DINKYDASH_MODE
+    scope: RUN_TIME
+    value: cloud
+  # Which hostname wsgi.py hands to the board. Not defaulted in code: a typo
+  # here would leave the board silently unreachable behind a 404 from the
+  # marketing site, so it refuses to start instead.
+  - key: DINKYDASH_APP_HOST
+    scope: RUN_TIME
+    value: app.dinkydash.co
+  # What the canonical tags, og:url and the sitemap claim to be.
+  - key: DINKYDASH_SITE_URL
+    scope: RUN_TIME
+    value: https://dinkydash.co
+  # In cloud mode the session is the login, so the app refuses to start on the
+  # self-hosted fallback key.
+  - key: DINKYDASH_SECRET_KEY
+    scope: RUN_TIME
+    type: SECRET
+  # One family until Phase 1 puts the family on the session. The worker does
+  # not read this — it walks every family itself.
+  - key: DINKYDASH_FAMILY_ID
+    scope: RUN_TIME
+    type: SECRET
+  # DigitalOcean's pool, transaction mode, port 25061.
+  - key: DATABASE_URL
+    scope: RUN_TIME
+    type: SECRET
+  # The cluster itself, port 25060. Migrations and pg_dump want a real session,
+  # not the far end of a transaction pooler.
+  - key: DATABASE_URL_DIRECT
+    scope: RUN_TIME
+    type: SECRET
+  # The worker's, for the daily brief. The web service never calls Anthropic.
+  - key: ANTHROPIC_API_KEY
+    scope: RUN_TIME
+    type: SECRET
+  # Send-only, scoped to mail.send and nothing else.
+  - key: SENDGRID_API_KEY
+    scope: RUN_TIME
+    type: SECRET
 
 services:
   # Named `site` rather than `web` because renaming a component destroys and
@@ -63,31 +101,60 @@ services:
     source_dir: /
     environment_slug: python
 
-    # The buildpack installs requirements.txt on its own, which is deliberately
-    # the smaller list — no markdown, no pyyaml, no production WSGI server,
-    # because a Raspberry Pi needs none of them.
-    build_command: pip install -r requirements-site.txt
+    # requirements-cloud.txt is the superset: it pulls in requirements-site.txt,
+    # which pulls in requirements.txt, so one file installs everything this
+    # container runs. The buildpack installs requirements.txt on its own, which
+    # is deliberately the smaller list — a Pi needs neither Postgres nor a
+    # Markdown renderer.
+    build_command: pip install -r requirements-cloud.txt
 
-    # Two workers with threads: the work is rendering cached Markdown and
-    # sending files, so it waits on the network far more than on the CPU.
-    run_command: gunicorn --workers 2 --threads 4 --bind 0.0.0.0:8080 --access-logfile - "website.site:app"
+    run_command: gunicorn --workers 2 --threads 4 --bind 0.0.0.0:8080 --access-logfile - "wsgi:application"
 
     instance_size_slug: apps-s-1vcpu-0.5gb
     instance_count: 1
     http_port: 8080
 
+    # The check arrives on the .ondigitalocean.app hostname, which is in no
+    # `domains` block above — so wsgi.py sends unknown hosts to the marketing
+    # site, which answers /healthz. A 404 here would roll every deploy back.
     health_check:
       http_path: /healthz
-      initial_delay_seconds: 10
+      initial_delay_seconds: 15
       period_seconds: 10
       timeout_seconds: 3
       success_threshold: 1
       failure_threshold: 3
 
-    envs:
-      # What the canonical tags, og:url and the sitemap claim to be. Set
-      # explicitly so a preview copy never tells a search engine it is
-      # production.
-      - key: DINKYDASH_SITE_URL
-        scope: RUN_TIME
-        value: https://dinkydash.co
+workers:
+  # The tick, once every five minutes, over every family that is due. Its own
+  # component rather than a thread in `site` because there is no lock on the
+  # tick in cloud mode: two processes would both refresh and both pay Anthropic
+  # for the same brief. One worker, however many web instances.
+  - name: worker
+    github:
+      repo: caspii/dinkydash
+      branch: main
+      deploy_on_push: true
+    source_dir: /
+    environment_slug: python
+    build_command: pip install -r requirements-cloud.txt
+    run_command: python -m worker
+    instance_size_slug: apps-s-1vcpu-0.5gb
+    instance_count: 1
+
+jobs:
+  # Runs before the new code is live, so the schema is always ahead of what
+  # needs it and a failed migration fails the deploy instead of half-updating a
+  # running app. `migrate.py` with no argument reads DATABASE_URL_DIRECT.
+  - name: migrate
+    kind: PRE_DEPLOY
+    github:
+      repo: caspii/dinkydash
+      branch: main
+      deploy_on_push: true
+    source_dir: /
+    environment_slug: python
+    build_command: pip install -r requirements-cloud.txt
+    run_command: python migrate.py
+    instance_size_slug: apps-s-1vcpu-0.5gb
+    instance_count: 1

--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,34 @@
 # Copy to .env and fill in. .env is gitignored and must never be committed.
 #
-# This is the whole file — ANTHROPIC_API_KEY and nothing else. Nothing in the
-# app reads FLASK_ENV, SECRET_KEY, DATABASE_URL or UPLOAD_FOLDER; the session
-# key comes from DINKYDASH_SECRET_KEY in the environment, not from here.
+# Nothing in the app reads FLASK_ENV, SECRET_KEY, DATABASE_URL or UPLOAD_FOLDER;
+# the session key comes from DINKYDASH_SECRET_KEY in the environment, not from
+# here.
 #
 # Get a key at https://console.anthropic.com/settings/keys. It is used once a
 # day, for the headline and the one written line. Everything else on the board
 # — the agenda, the chore turns, the countdowns — is computed locally and works
 # without one.
 ANTHROPIC_API_KEY=
+
+# ---------------------------------------------------------------------------
+# Cloud mode only. A self-hoster needs none of the below and can stop here:
+# one family on its own network has no logins to mail and no database.
+# ---------------------------------------------------------------------------
+
+# Signs the session cookie. In cloud mode the session *is* the login, so the
+# app refuses to start without one. Generate with:
+#   python3 -c "import secrets; print(secrets.token_hex(32))"
+# DINKYDASH_SECRET_KEY=
+
+# Which app answers on which hostname, for wsgi.py. One container serves both.
+# DINKYDASH_APP_HOST=app.dinkydash.co
+
+# Transactional email — magic links (decision 13). This must be a **send-only**
+# key: SendGrid → Create API Key → Restricted Access → Mail Send, everything
+# else No Access. A full-access key here could send as any of the six domains
+# on the account, read billing and mint further keys.
+# SENDGRID_API_KEY=
+
+# Who the mail comes from. Must be on the authenticated sending domain, or
+# DKIM does not sign it. Defaults to hello@dinkydash.co.
+# DINKYDASH_MAIL_FROM=

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,8 +17,17 @@ jobs:
     # ran against files would not notice the day the two drifted apart.
     services:
       postgres:
-        # Pinned to the major version DigitalOcean's managed cluster runs.
-        image: postgres:16
+        # Pinned to the major version DigitalOcean's managed cluster runs, which
+        # is **17** — the `dinkydash` cluster in fra1 is on 17.11 as of
+        # 8 September 2026. This said 16 until then, written before the cluster
+        # existed, so CI was proving migrations against a major the app does not
+        # run. Postgres 15 changed who may write to the `public` schema; a
+        # difference of that size passing here and failing in production is
+        # exactly what this service container exists to prevent.
+        #
+        # When the cluster is upgraded, this line moves with it. `doctl
+        # databases get <id> --format VersionSlug` is the check.
+        image: postgres:17
         env:
           POSTGRES_USER: dinkydash
           POSTGRES_PASSWORD: dinkydash

--- a/dinkydash/mail.py
+++ b/dinkydash/mail.py
@@ -71,7 +71,7 @@ def send(to, subject, text, html=None, transport=None, api_key=None,
     is literally `requests.post` rather than a wrapper around it.
     """
     recipient = _clean_address(to)
-    key = api_key if api_key is not None else _api_key()
+    key = _clean_key(api_key if api_key is not None else os.environ.get("SENDGRID_API_KEY"))
     post = transport or requests.post
 
     body = {
@@ -89,6 +89,18 @@ def send(to, subject, text, html=None, transport=None, api_key=None,
                      "Content-Type": "application/json"},
             timeout=timeout,
         )
+    except requests.exceptions.InvalidHeader:
+        # `from None`, and it is the whole point of this branch. `requests`
+        # puts the offending header *value* in this exception's message —
+        # "...in header value: 'Bearer SG.REALKEY\n'" — and the only variable
+        # header here is the Authorization one. Chaining it would print the key
+        # in every traceback that reaches a log or Sentry, past the sanitised
+        # message. `_clean_key` should mean this never fires; this is the belt
+        # to its braces, and it stays even if a future header makes it possible
+        # again.
+        raise MailError(
+            "could not send the email: the request headers were rejected"
+        ) from None
     except requests.RequestException as exc:
         raise MailError(f"could not send the email: {_why(exc)}") from exc
 
@@ -140,17 +152,32 @@ def _clean_address(to):
     return address
 
 
-def _api_key():
-    """The send-only key, from the environment. Never a literal, never per-family.
+def _clean_key(key):
+    """The send-only key, checked before it can reach an HTTP header.
 
     The key in `.env` is scoped to `mail.send` alone — it cannot read the
-    account, mint further keys or touch the other five domains on it. The
-    full-access keys in the sibling projects must never be used here.
+    account, mint further keys or touch the other five domains on it. It comes
+    from the environment: never a literal, never per-family.
+
+    **This exists to keep the key out of tracebacks.** `requests` validates
+    header values and quotes the bad one in `InvalidHeader`, so a key carrying
+    a stray newline — the usual shape of a copy-paste or an env var set from a
+    file — would put itself in an exception message. Catching it here means the
+    request is never built, and none of these messages names the value.
+
+    A trailing newline is repaired rather than refused, because it is almost
+    always the transport's fault rather than the operator's. Anything else
+    unusual is refused: a key with a space in the middle is a wrong key, and
+    guessing at what was meant would send mail on a credential nobody chose.
     """
-    key = os.environ.get("SENDGRID_API_KEY")
-    if not key:
+    if key is None or not key.strip():
         raise MailRefused("SENDGRID_API_KEY is not set")
-    return key
+    cleaned = key.strip()
+    if not cleaned.isascii() or any(c.isspace() for c in cleaned):
+        raise MailRefused(
+            "SENDGRID_API_KEY contains whitespace or non-ASCII characters"
+        )
+    return cleaned
 
 
 def _sender():

--- a/dinkydash/mail.py
+++ b/dinkydash/mail.py
@@ -1,0 +1,173 @@
+"""Sending one transactional email, and nothing else.
+
+    send(to, subject, text) -> None
+
+Magic links are what this exists for (PLAN.md Phase 1); dunning and the support
+inbox are later callers of the same function. Named `mail` rather than `email`
+because the standard library owns that name.
+
+**SendGrid, on the account KeepTheScore already sends from** (decision 13). The
+shared sender reputation is the whole point: a login link that lands in spam is
+a login that fails. `dinkydash.co` is an authenticated sending domain on that
+account, so DKIM signs whatever leaves here.
+
+**No SendGrid SDK.** Sending is one `POST` with a JSON body, and `requests` is
+already a dependency because `calendars.py` fetches feeds with it. A new
+package in an app holding other families' calendars is a supply-chain decision,
+and fifteen saved lines do not pay for one.
+
+**Single mode never calls this.** A self-hosted board has no accounts, so it has
+no logins to mail and no dunning to send. Nothing here is imported unless cloud
+mode asks for it, and `send` refuses rather than guessing if it is reached
+without a key.
+
+The shape follows `calendars.fetch_feed`: a typed error the caller decides
+about, a transport that tests replace, and a message that carries no secret.
+"""
+
+import logging
+import os
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+SEND_URL = "https://api.sendgrid.com/v3/mail/send"
+DEFAULT_TIMEOUT = 10
+
+# Who the mail comes from. A subdomain of the authenticated domain would need
+# its own DKIM records; the apex is what SendGrid validated.
+DEFAULT_FROM = "hello@dinkydash.co"
+DEFAULT_FROM_NAME = "DinkyDash"
+
+
+class MailError(Exception):
+    """A message did not go out.
+
+    Raised rather than swallowed, and swallowed rather than retried in a loop:
+    whether a failed magic link is worth a second attempt is the caller's
+    decision, not this module's. One bad send is a failed login, not a failed
+    process.
+    """
+
+
+class MailRefused(MailError):
+    """The message was never attempted, because it could not be.
+
+    A missing key or an address that is not an address is a configuration fault
+    and will fail identically on every retry. `FeedRefused` subclasses
+    `FeedError` for the same reason: a caller that only wants to know "did it
+    go" catches the parent, and one that wants to know "is it worth trying
+    again" checks the subclass.
+    """
+
+
+def send(to, subject, text, html=None, transport=None, api_key=None,
+         sender=None, sender_name=None, timeout=DEFAULT_TIMEOUT):
+    """Send one message. Returns None, raises `MailError` if it did not go.
+
+    `transport` is the seam the tests use. It takes the same arguments
+    `requests.post` does and must behave the same way, which is why the default
+    is literally `requests.post` rather than a wrapper around it.
+    """
+    recipient = _clean_address(to)
+    key = api_key if api_key is not None else _api_key()
+    post = transport or requests.post
+
+    body = {
+        "personalizations": [{"to": [{"email": recipient}]}],
+        "from": {"email": sender or _sender(), "name": sender_name or DEFAULT_FROM_NAME},
+        "subject": subject,
+        "content": _content(text, html),
+    }
+
+    try:
+        response = post(
+            SEND_URL,
+            json=body,
+            headers={"Authorization": f"Bearer {key}",
+                     "Content-Type": "application/json"},
+            timeout=timeout,
+        )
+    except requests.RequestException as exc:
+        raise MailError(f"could not send the email: {_why(exc)}") from exc
+
+    status = getattr(response, "status_code", None)
+    if status is None or not 200 <= status < 300:
+        raise MailError(f"could not send the email: the server said {status}")
+
+    # The address is personal data and the subject can name a person, so this
+    # says that a send happened and nothing about who or what. `calendars`
+    # logs the label rather than the URL for the same reason.
+    logger.info("Sent one email via SendGrid.")
+
+
+def _content(text, html):
+    """SendGrid wants plain text first when both are present, and wants one of them.
+
+    The order is not cosmetic: it decides which part a client shows when it can
+    render both, and getting it backwards means the plain-text fallback wins in
+    clients that should show the HTML.
+    """
+    if not (text or "").strip():
+        raise MailRefused("an email needs a plain-text body")
+    content = [{"type": "text/plain", "value": text}]
+    if html:
+        content.append({"type": "text/html", "value": html})
+    return content
+
+
+def _clean_address(to):
+    """The recipient, or a refusal. No validation beyond what protects the account.
+
+    Bounces and suppressions are shared across six domains on this account, so a
+    malformed address is worth catching here rather than discovering as a hard
+    bounce against KeepTheScore's reputation. This is not an attempt to validate
+    email addresses properly, which is not possible — it rejects what is
+    obviously not one, and lets SendGrid judge the rest.
+
+    A newline is the one that matters. Anything reaching a header is a header
+    injection, and although this sends JSON rather than SMTP, the rule holds
+    wherever the value ends up next.
+    """
+    address = (to or "").strip()
+    if not address:
+        raise MailRefused("no email address to send to")
+    if any(c in address for c in "\r\n"):
+        raise MailRefused("that email address contains a line break")
+    if address.count("@") != 1 or address.startswith("@") or address.endswith("@"):
+        raise MailRefused("that does not look like an email address")
+    return address
+
+
+def _api_key():
+    """The send-only key, from the environment. Never a literal, never per-family.
+
+    The key in `.env` is scoped to `mail.send` alone — it cannot read the
+    account, mint further keys or touch the other five domains on it. The
+    full-access keys in the sibling projects must never be used here.
+    """
+    key = os.environ.get("SENDGRID_API_KEY")
+    if not key:
+        raise MailRefused("SENDGRID_API_KEY is not set")
+    return key
+
+
+def _sender():
+    return os.environ.get("DINKYDASH_MAIL_FROM") or DEFAULT_FROM
+
+
+def _why(exc):
+    """Why a send failed, in words that carry no secret.
+
+    `requests` puts the full URL in the message of a connection error, and the
+    `Authorization` header can surface in a repr. Neither is something to write
+    to a log that a support person reads. The endpoint is not secret, but the
+    habit is what keeps `calendars._why` honest, and this module handles magic
+    links: **a login link in a log is a login in a log.**
+    """
+    if isinstance(exc, requests.Timeout):
+        return "the server did not answer in time"
+    if isinstance(exc, requests.ConnectionError):
+        return "could not reach the server"
+    return type(exc).__name__

--- a/doc/operations.md
+++ b/doc/operations.md
@@ -52,6 +52,13 @@ pool's user — both landed in a terminal and an agent transcript. Both were res
 `ALTER SCHEMA public OWNER TO dinkydash_app` was run as `doadmin` against each database. A fresh
 cluster will need it again; the migration runner does not do it and should not.
 
+**CI's Postgres was pinned to 16 and is now 17**, to match. `.github/workflows/test.yml` said
+`postgres:16` with a comment claiming it tracked the managed cluster — written before the cluster
+existed. Until 8 September 2026 CI was therefore proving migrations against a major the app does
+not run. Postgres 15 changed who may write to `public`; a difference of that size is exactly what
+the service container is there to catch. **When the cluster is upgraded, move that pin with it** —
+`doctl databases get <id> --format VersionSlug` is the check.
+
 **The cluster has no trusted sources set**, so it is reachable from any address that has the
 password. That is DigitalOcean's default and it is not good enough for a database holding other
 families' calendars. Restricting it to the App Platform app belongs with the deploy (DIN-26) —

--- a/doc/operations.md
+++ b/doc/operations.md
@@ -59,10 +59,43 @@ not run. Postgres 15 changed who may write to `public`; a difference of that siz
 the service container is there to catch. **When the cluster is upgraded, move that pin with it** —
 `doctl databases get <id> --format VersionSlug` is the check.
 
-**The cluster has no trusted sources set**, so it is reachable from any address that has the
-password. That is DigitalOcean's default and it is not good enough for a database holding other
-families' calendars. Restricting it to the App Platform app belongs with the deploy (DIN-26) —
-doing it before then locks this laptop out of the migrations it still has to run.
+**The cluster has no trusted sources, and that is a decision rather than an oversight.** It is
+reachable from any address holding the password. Restricting it to the App Platform app was
+proposed on 8 September 2026 and **declined by the owner: external tools need to reach the
+database.** The concern was raised, repeated, and overruled, which is the owner's call to make.
+Two things follow. Trusted sources accept a list, so a future middle ground is an allowlist rather
+than all-or-nothing. And the password is now the only thing between the internet and other
+families' calendars, which raises what a leak of `DATABASE_URL` costs — see the note above about
+`doctl` printing them.
+
+**App Platform's database binding (`${db.DATABASE_URL}`) is deliberately not used** for the same
+reason. Attaching a cluster to an app adds that app to the cluster's trusted sources, which would
+turn the open firewall into a restricted one as a side effect of a config change nobody read that
+way. The connection strings are plain `SECRET` env vars instead.
+
+## The deploy, 8 September 2026
+
+`dinkydash-site` now serves both hostnames from one container, `wsgi.py` routing on the `Host`
+header. `dinkydash.co` is the marketing site; `app.dinkydash.co` is the board, reading from
+Postgres in cloud mode. Both verified live over TLS, and the `PRE_DEPLOY` migration job reported
+`Schema is up to date`.
+
+One family exists, seeded from `config.example.yaml` — invented people, no calendar URL — and
+`DINKYDASH_FAMILY_ID` points at it. Nothing outside `tests/conftest.py` creates a family, so that
+was done by hand and will be until the signup flow exists.
+
+**Omitting the value of a `type: SECRET` env var preserves it**, which was tested rather than
+assumed: a throwaway variable was set to a value, the spec re-applied without one, and it survived
+as `EV[...]`. That is what lets `.do/app.yaml` be committed to a public repo with the keys but not
+the values, and still be safe to apply. **Never commit an `EV[...]` blob** — encrypted or not, it is
+a production credential in a world-readable repo.
+
+**The `worker` component and the `worker/` package have to land together.** Applying the spec from
+a checkout without the package gives a component whose `run_command` cannot import, and a failed
+deploy. The worker was held out of the first apply for exactly that reason, because the app deploys
+from `main` and the code was still on a branch.
+
+
 
 ## GitHub's own secret scanning
 

--- a/doc/operations.md
+++ b/doc/operations.md
@@ -23,6 +23,40 @@ and on the Pi, written in place. CI could not have done it, and a future rotatio
 job: revoke in the Anthropic console, then edit each copy where it lives. `deploy_to_pi.sh` excludes
 `.env`, so pushing one copy over the other is not an option and is not meant to be.
 
+## Managed Postgres, created 8 September 2026
+
+`dinkydash` — PostgreSQL 17.11, `db-s-1vcpu-1gb`, single node, **fra1**, $15.15/month. Cluster id
+`a65a8bae-ea6e-4d0b-a162-b6821e1ddc1a`. Same size `qrpage-db` already runs.
+
+What is on it:
+
+| | |
+|---|---|
+| Databases | `dinkydash` (the app), `dinkydash_test` (the contract suite), `defaultdb` (unused) |
+| Users | `doadmin` (primary), `dinkydash_app` (normal — what the app connects as) |
+| Pool | `dinkydash-pool`, **transaction mode**, size 15, on port 25061 |
+
+`migrations/001_initial_schema.sql` is applied: `families`, `users`, `login_tokens`, `agendas`,
+`generations`, `content_history`, `calendar_health`, `schema_migrations`. The whole suite was run
+against it with `DINKYDASH_TEST_DATABASE_URL` pointed at `dinkydash_test` — **490 passed, nothing
+skipped**, which is the first time the store contract has run against real managed Postgres rather
+than a CI service container.
+
+**Two passwords were rotated the same hour, because `doctl` printed them.** `doctl databases create`
+puts the full `doadmin` URI in its output, and `doctl databases pool create` does the same for the
+pool's user — both landed in a terminal and an agent transcript. Both were reset through
+`POST /v2/databases/{id}/users/{user}/reset_auth` within minutes and the printed ones are dead.
+**Filter `doctl` database output.** The credential is in the success message, not in an error.
+
+**Postgres 15 changed who may write to `public`.** The app user could not create tables until
+`ALTER SCHEMA public OWNER TO dinkydash_app` was run as `doadmin` against each database. A fresh
+cluster will need it again; the migration runner does not do it and should not.
+
+**The cluster has no trusted sources set**, so it is reachable from any address that has the
+password. That is DigitalOcean's default and it is not good enough for a database holding other
+families' calendars. Restricting it to the App Platform app belongs with the deploy (DIN-26) —
+doing it before then locks this laptop out of the migrations it still has to run.
+
 ## GitHub's own secret scanning
 
 **Do not rely on it yet.** Minutes after it was enabled, a correctly shaped fake

--- a/tests/test_mail.py
+++ b/tests/test_mail.py
@@ -1,0 +1,170 @@
+"""What `dinkydash.mail.send` must do, and what it must never do.
+
+No test here touches the network. `send` takes a `transport` argument precisely
+so the suite stays offline and free — it runs in under a second today, and a
+live API call would make it slow, flaky and billable at once.
+
+Two of these tests are about secrets rather than behaviour. This module is what
+magic links go out through, and **a login link in a log is a login in a log**;
+the recipient's address is personal data too. `tests/test_secrets_and_headers.py`
+guards the same promise on the calendar side.
+"""
+
+import logging
+
+import pytest
+import requests
+
+from dinkydash.mail import MailError, MailRefused, send
+
+
+class FakeResponse:
+    def __init__(self, status_code=202):
+        self.status_code = status_code
+
+
+class Recorder:
+    """A stand-in for `requests.post` that remembers what it was called with."""
+
+    def __init__(self, response=None, raises=None):
+        self.response, self.raises = response or FakeResponse(), raises
+        self.url = self.json = self.headers = self.timeout = None
+
+    def __call__(self, url, json=None, headers=None, timeout=None):
+        self.url, self.json, self.headers, self.timeout = url, json, headers, timeout
+        if self.raises:
+            raise self.raises
+        return self.response
+
+
+def send_ok(**kwargs):
+    """Send with a recorded transport and a key, returning the recorder."""
+    post = Recorder(**{k: kwargs.pop(k) for k in ("response", "raises") if k in kwargs})
+    kwargs.setdefault("to", "parent@example.test")
+    kwargs.setdefault("subject", "Your DinkyDash link")
+    kwargs.setdefault("text", "Tap to sign in.")
+    send(transport=post, api_key="SG.test", **kwargs)
+    return post
+
+
+class TestTheRequest:
+    def test_it_posts_to_sendgrid(self):
+        assert send_ok().url == "https://api.sendgrid.com/v3/mail/send"
+
+    def test_the_key_travels_as_a_bearer_token(self):
+        assert send_ok().headers["Authorization"] == "Bearer SG.test"
+
+    def test_the_recipient_is_in_the_personalisation(self):
+        body = send_ok(to="parent@example.test").json
+        assert body["personalizations"][0]["to"][0]["email"] == "parent@example.test"
+
+    def test_the_sender_is_on_the_authenticated_domain(self):
+        """DKIM only signs for the domain SendGrid validated."""
+        assert send_ok().json["from"]["email"].endswith("@dinkydash.co")
+
+    def test_the_sender_can_be_overridden_from_the_environment(self, monkeypatch):
+        monkeypatch.setenv("DINKYDASH_MAIL_FROM", "login@dinkydash.co")
+        assert send_ok().json["from"]["email"] == "login@dinkydash.co"
+
+    def test_there_is_a_timeout(self):
+        """A send that hangs forever would hang whatever asked for it."""
+        assert send_ok().timeout > 0
+
+
+class TestContent:
+    def test_plain_text_alone_is_enough(self):
+        content = send_ok(text="Tap to sign in.").json["content"]
+        assert [c["type"] for c in content] == ["text/plain"]
+
+    def test_plain_text_comes_before_html(self):
+        """The order decides which part a client shows when it can render both."""
+        content = send_ok(text="Tap to sign in.", html="<p>Tap</p>").json["content"]
+        assert [c["type"] for c in content] == ["text/plain", "text/html"]
+
+    @pytest.mark.parametrize("text", ["", "   ", None])
+    def test_an_empty_body_is_refused_before_any_request(self, text):
+        post = Recorder()
+        with pytest.raises(MailRefused, match="plain-text"):
+            send("parent@example.test", "Hello", text, transport=post, api_key="SG.test")
+        assert post.url is None
+
+
+class TestAddresses:
+    @pytest.mark.parametrize("address", ["", "   ", None])
+    def test_no_address_is_a_refusal(self, address):
+        with pytest.raises(MailRefused, match="no email address"):
+            send(address, "Hi", "Body", transport=Recorder(), api_key="SG.test")
+
+    @pytest.mark.parametrize("address", ["notanemail", "two@@example.test",
+                                         "@example.test", "parent@"])
+    def test_an_obvious_non_address_is_a_refusal(self, address):
+        """Bounces are shared across six domains on this account."""
+        with pytest.raises(MailRefused, match="email address"):
+            send(address, "Hi", "Body", transport=Recorder(), api_key="SG.test")
+
+    @pytest.mark.parametrize("address", ["a@b.test\nbcc: x@y.test",
+                                         "a@b.test\r\nSubject: nope"])
+    def test_a_line_break_is_a_refusal(self, address):
+        """Header injection, wherever the value ends up next."""
+        with pytest.raises(MailRefused, match="line break"):
+            send(address, "Hi", "Body", transport=Recorder(), api_key="SG.test")
+
+    def test_surrounding_whitespace_is_trimmed(self):
+        body = send_ok(to="  parent@example.test  ").json
+        assert body["personalizations"][0]["to"][0]["email"] == "parent@example.test"
+
+
+class TestFailures:
+    def test_a_refused_send_is_a_mail_error_too(self):
+        """One `except MailError` catches both; the subclass is for retry decisions."""
+        assert issubclass(MailRefused, MailError)
+
+    @pytest.mark.parametrize("status", [400, 401, 403, 429, 500, 503])
+    def test_a_non_2xx_status_raises(self, status):
+        with pytest.raises(MailError, match=str(status)):
+            send_ok(response=FakeResponse(status))
+
+    @pytest.mark.parametrize("status", [200, 202])
+    def test_a_2xx_status_is_success(self, status):
+        send_ok(response=FakeResponse(status))
+
+    def test_a_timeout_says_so_in_words(self):
+        with pytest.raises(MailError, match="did not answer in time"):
+            send_ok(raises=requests.Timeout())
+
+    def test_an_unreachable_server_says_so_in_words(self):
+        with pytest.raises(MailError, match="could not reach"):
+            send_ok(raises=requests.ConnectionError())
+
+    def test_a_missing_key_is_a_refusal_not_a_crash(self, monkeypatch):
+        monkeypatch.delenv("SENDGRID_API_KEY", raising=False)
+        with pytest.raises(MailRefused, match="SENDGRID_API_KEY"):
+            send("parent@example.test", "Hi", "Body", transport=Recorder())
+
+    def test_the_key_is_read_from_the_environment_when_not_passed(self, monkeypatch):
+        monkeypatch.setenv("SENDGRID_API_KEY", "SG.from-env")
+        post = Recorder()
+        send("parent@example.test", "Hi", "Body", transport=post)
+        assert post.headers["Authorization"] == "Bearer SG.from-env"
+
+
+class TestNothingSecretIsLogged:
+    """The two things that must never reach a log line: the key, and the link."""
+
+    def test_the_log_line_names_neither_recipient_nor_body_nor_key(self, caplog):
+        link = "https://app.dinkydash.co/login/abc123secrettoken"
+        with caplog.at_level(logging.DEBUG):
+            send_ok(to="parent@example.test", subject="Your link",
+                    text=f"Sign in: {link}")
+        logged = " ".join(r.getMessage() for r in caplog.records)
+        assert "abc123secrettoken" not in logged
+        assert "parent@example.test" not in logged
+        assert "SG.test" not in logged
+
+    def test_a_failure_message_carries_no_key_and_no_link(self):
+        link = "https://app.dinkydash.co/login/abc123secrettoken"
+        with pytest.raises(MailError) as caught:
+            send_ok(text=f"Sign in: {link}", raises=requests.ConnectionError(
+                f"Failed to establish a connection to {link}"))
+        assert "abc123secrettoken" not in str(caught.value)
+        assert "SG.test" not in str(caught.value)

--- a/tests/test_mail.py
+++ b/tests/test_mail.py
@@ -11,6 +11,7 @@ guards the same promise on the calendar side.
 """
 
 import logging
+import traceback
 
 import pytest
 import requests
@@ -160,6 +161,43 @@ class TestNothingSecretIsLogged:
         assert "abc123secrettoken" not in logged
         assert "parent@example.test" not in logged
         assert "SG.test" not in logged
+
+    def test_the_key_is_not_in_the_traceback_of_a_rejected_header(self):
+        """The sanitised message is not enough on its own.
+
+        `requests` quotes the offending header value in `InvalidHeader`, and
+        `raise ... from exc` keeps that exception as `__cause__` — so the key
+        would print in any traceback, past a message that carefully omits it.
+        This asserts on the *rendered chain*, which is what reaches a log.
+        """
+        key = "SG.REALKEYVALUE123"
+        bad = requests.exceptions.InvalidHeader(
+            f"Invalid ... in header value: 'Bearer {key}\\n'")
+        with pytest.raises(MailError) as caught:
+            send_ok(raises=bad)
+        rendered = "".join(traceback.format_exception(caught.value))
+        assert key not in rendered
+
+    def test_a_malformed_key_is_refused_before_any_request(self):
+        """The layer that means the traceback case should never fire at all."""
+        post = Recorder()
+        with pytest.raises(MailRefused, match="whitespace or non-ASCII"):
+            send("parent@example.test", "Hi", "Body",
+                 transport=post, api_key="SG.has a space")
+        assert post.url is None
+
+    def test_a_refusal_message_never_quotes_the_key(self):
+        with pytest.raises(MailRefused) as caught:
+            send("parent@example.test", "Hi", "Body",
+                 transport=Recorder(), api_key="SG.SECRET VALUE")
+        assert "SG.SECRET" not in str(caught.value)
+
+    def test_a_stray_newline_on_the_key_is_repaired_not_refused(self, monkeypatch):
+        """An env var read from a file usually arrives with one."""
+        monkeypatch.setenv("SENDGRID_API_KEY", "SG.from-env\n")
+        post = Recorder()
+        send("parent@example.test", "Hi", "Body", transport=post)
+        assert post.headers["Authorization"] == "Bearer SG.from-env"
 
     def test_a_failure_message_carries_no_key_and_no_link(self):
         link = "https://app.dinkydash.co/login/abc123secrettoken"

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1,0 +1,150 @@
+"""What the cloud tick loop must do, and what one bad family must not do to the rest.
+
+The loop itself is not tested — a `while True` with a sleep in it is not worth
+a fake clock. `tick_all` is, because it holds the decisions: which families are
+walked, what happens when one of them raises, and what reaches a log when it
+does.
+
+Nothing here needs Postgres. `tick_all` takes its store factory and its tick
+function as arguments, so the fakes below are the whole test rig.
+"""
+
+import logging
+
+import pytest
+
+from worker import DEFAULT_INTERVAL, Stopping, interval, tick_all
+
+
+class FakePool:
+    """A psycopg-shaped pool returning fixed rows for the family query."""
+
+    def __init__(self, ids):
+        self.ids, self.sql = ids, []
+
+    def connection(self):
+        return self
+
+    def cursor(self):
+        return self
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def execute(self, sql, *args):
+        self.sql.append(sql)
+
+    def fetchall(self):
+        return [(i,) for i in self.ids]
+
+
+class FakeStore:
+    def __init__(self, family_id):
+        self.family_id = family_id
+
+    def load_config(self):
+        return {"family_id": self.family_id}
+
+
+def run(ids, tick, stopping=None):
+    return tick_all(FakePool(ids), store_factory=FakeStore, tick=tick, stopping=stopping)
+
+
+class TestWalkingTheFamilies:
+    def test_every_family_is_ticked(self):
+        seen = []
+        done = run(["a", "b", "c"], lambda config, store: seen.append(store.family_id))
+        assert seen == ["a", "b", "c"]
+        assert done == 3
+
+    def test_no_families_is_not_an_error(self):
+        assert run([], lambda config, store: None) == 0
+
+    def test_the_config_comes_from_that_family_s_store(self):
+        configs = []
+        run(["a", "b"], lambda config, store: configs.append(config))
+        assert configs == [{"family_id": "a"}, {"family_id": "b"}]
+
+    def test_lapsed_families_are_excluded_by_the_query(self):
+        """PLAN.md's freeze: the board keeps its last state, the ticking stops."""
+        pool = FakePool(["a"])
+        tick_all(pool, store_factory=FakeStore, tick=lambda c, s: None)
+        assert "status <> 'lapsed'" in " ".join(pool.sql)
+
+
+class TestOneBadFamily:
+    def test_a_raising_family_does_not_stop_the_others(self):
+        """A shared worker that dies on the noisiest tenant serves the quietest worst."""
+        seen = []
+
+        def tick(config, store):
+            seen.append(store.family_id)
+            if store.family_id == "b":
+                raise RuntimeError("their calendar feed is down")
+
+        done = run(["a", "b", "c"], tick)
+        assert seen == ["a", "b", "c"]
+        assert done == 2
+
+    def test_every_family_can_fail_without_raising(self):
+        def tick(config, store):
+            raise RuntimeError("everything is down")
+
+        assert run(["a", "b"], tick) == 0
+
+    def test_the_failure_log_names_the_id_and_not_the_config(self, caplog):
+        """A config holds children's names, and a calendar URL is a password."""
+        def tick(config, store):
+            raise RuntimeError("failed fetching https://cal.example/private-abc123/basic.ics")
+
+        with caplog.at_level(logging.DEBUG):
+            run(["fam-42"], tick)
+        logged = " ".join(r.getMessage() for r in caplog.records)
+        assert "fam-42" in logged
+        assert "private-abc123" not in logged
+
+
+class TestStopping:
+    def test_a_stop_request_ends_the_pass_between_families(self):
+        """SIGTERM during a redeploy must not cut a paid-for brief in half."""
+        stopping = Stopping()
+        seen = []
+
+        def tick(config, store):
+            seen.append(store.family_id)
+            stopping.request()
+
+        done = run(["a", "b", "c"], tick, stopping=stopping)
+        assert seen == ["a"]
+        assert done == 1
+
+    def test_a_fresh_stopping_is_falsey(self):
+        assert not Stopping()
+
+    def test_requesting_makes_it_truthy(self):
+        s = Stopping()
+        s.request()
+        assert s
+
+
+class TestInterval:
+    def test_it_defaults_to_five_minutes(self, monkeypatch):
+        monkeypatch.delenv("DINKYDASH_WORKER_INTERVAL", raising=False)
+        assert interval() == DEFAULT_INTERVAL == 300
+
+    def test_the_environment_overrides_it(self, monkeypatch):
+        monkeypatch.setenv("DINKYDASH_WORKER_INTERVAL", "30")
+        assert interval() == 30
+
+    def test_nonsense_falls_back_rather_than_crashing(self, monkeypatch):
+        """A typo in an app spec must not stop every family's board updating."""
+        monkeypatch.setenv("DINKYDASH_WORKER_INTERVAL", "five minutes")
+        assert interval() == DEFAULT_INTERVAL
+
+    @pytest.mark.parametrize("value", ["0", "-10"])
+    def test_it_never_busy_loops(self, monkeypatch, value):
+        monkeypatch.setenv("DINKYDASH_WORKER_INTERVAL", value)
+        assert interval() >= 1

--- a/worker/__init__.py
+++ b/worker/__init__.py
@@ -1,0 +1,152 @@
+"""The cloud tick loop: the same tick a Pi's cron runs, over every family.
+
+    python -m worker
+
+A Raspberry Pi gets this from `*/5 * * * * generate.py --tick`. There is no
+cron in an App Platform container, so cloud mode runs a process that sleeps
+instead — same `schedule.due`, same `runner.refresh_calendars` and
+`runner.write_brief`, same decisions. **Nothing about what is owed is decided
+here**, which is the point: a second implementation of "is a brief due" would
+be a second thing to get wrong.
+
+**Why this is a separate component from `web`.** There is no lock on the tick
+in cloud mode, so two processes running it would both refresh and both pay
+Anthropic for the same brief. Web instances are scaled by traffic and there may
+be several; there is exactly one worker. Keeping the loop out of the web
+container is what makes "how many web instances" a free decision.
+
+`generate.tick` is imported from the command-line module on purpose rather than
+copied. It is the shared orchestration over config, store and clock, and
+`tests/test_runner.py` already imports that module the same way.
+"""
+
+import logging
+import os
+import signal
+import time
+
+log = logging.getLogger("dinkydash.worker")
+
+DEFAULT_INTERVAL = 300  # five minutes, as PLAN.md's "three clocks" section says
+
+
+class Stopping:
+    """Set by SIGTERM, read between families.
+
+    App Platform sends SIGTERM before it replaces a container. Finishing the
+    family in hand and then stopping is the difference between a redeploy that
+    is invisible and one that leaves a half-written board — the brief has been
+    paid for by the time it is written, so being killed between the API call
+    and the save is the expensive way to lose.
+    """
+
+    def __init__(self):
+        self.requested = False
+
+    def request(self, *_args):
+        log.info("Stop requested; finishing the family in hand.")
+        self.requested = True
+
+    def __bool__(self):
+        return self.requested
+
+
+def family_ids(pool):
+    """Every family the worker should consider, oldest first.
+
+    **The one deliberately unscoped read in the product.** Every `PostgresStore`
+    query is scoped to a `family_id` and must stay that way, because there an id
+    arrives from a URL and is a claim rather than a fact. Here there is no
+    request and no user: the worker's whole job is to walk all of them, so the
+    query lives outside the store rather than weakening it.
+
+    Lapsed families are skipped. PLAN.md's freeze behaviour is that fetches and
+    briefs stop while the board keeps its last good state, and that is exactly
+    "the worker does not tick them".
+    """
+    with pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            """SELECT id FROM families
+               WHERE status <> 'lapsed'
+               ORDER BY created_at""")
+        return [row[0] for row in cur.fetchall()]
+
+
+def tick_all(pool, store_factory=None, tick=None, stopping=None):
+    """Tick every family once. Returns how many were ticked without raising.
+
+    One family's bad calendar feed, missing config or Anthropic outage must not
+    stop the others: a shared worker that dies on the noisiest tenant is a
+    worker that serves the quietest ones worst. Each family is therefore its
+    own try, and a failure is logged and left — the next pass simply finds the
+    same thing still due, which is how the whole tick handles failure already.
+    """
+    from dinkydash.pgstore import PostgresStore
+    store_factory = store_factory or (lambda fid: PostgresStore(pool, fid))
+    if tick is None:
+        from generate import tick
+
+    done = 0
+    for family_id in family_ids(pool):
+        if stopping:
+            log.info("Stopping before family %s.", family_id)
+            break
+        try:
+            store = store_factory(family_id)
+            tick(store.load_config(), store)
+            done += 1
+        except Exception:
+            # The id, never the config: a family's config holds children's
+            # names and a calendar URL is a password. `log.exception` writes
+            # the traceback, which is about our code rather than their data.
+            log.exception("Tick failed for family %s; leaving it for the next pass.",
+                          family_id)
+    return done
+
+
+def interval():
+    """Seconds between passes. A knob for testing, not a per-family setting.
+
+    How often a *family's* calendars are refreshed is `refresh_minutes` in
+    their own config, and `schedule.due` is what reads it. This only decides
+    how often the worker asks the question.
+    """
+    try:
+        return max(1, int(os.environ.get("DINKYDASH_WORKER_INTERVAL", DEFAULT_INTERVAL)))
+    except ValueError:
+        log.warning("DINKYDASH_WORKER_INTERVAL is not a number; using %s.",
+                    DEFAULT_INTERVAL)
+        return DEFAULT_INTERVAL
+
+
+def main():  # pragma: no cover - the loop itself; tick_all is what is tested
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+    )
+
+    from dinkydash import db
+
+    stopping = Stopping()
+    signal.signal(signal.SIGTERM, stopping.request)
+    signal.signal(signal.SIGINT, stopping.request)
+
+    pool = db.pool()
+    every = interval()
+    log.info("Worker started; a pass every %s seconds.", every)
+
+    while not stopping:
+        started = time.monotonic()
+        ticked = tick_all(pool, stopping=stopping)
+        log.info("Pass complete: %s families ticked in %.1fs.",
+                 ticked, time.monotonic() - started)
+
+        # Sleep in slices so SIGTERM is noticed in seconds rather than minutes.
+        # App Platform kills a container that ignores it for too long, and
+        # being killed is what the graceful stop exists to avoid.
+        deadline = time.monotonic() + every
+        while not stopping and time.monotonic() < deadline:
+            time.sleep(min(1, max(0, deadline - time.monotonic())))
+
+    log.info("Worker stopped.")
+    return 0

--- a/worker/__main__.py
+++ b/worker/__main__.py
@@ -1,0 +1,8 @@
+"""`python -m worker` — what the App Platform worker component runs."""
+
+import sys
+
+from . import main
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
**`dinkydash/mail.py` is the transactional email seam** — `send(to, subject, text)` raising `MailError`, over plain `requests` rather than the SendGrid SDK, because sending is one POST and a new package in an app holding other families' calendars needs a better reason than fifteen saved lines.

**`MailRefused` subclasses `MailError`** the way `FeedRefused` subclasses `FeedError`: a missing key, an empty body or a malformed address refuse before any request is made, since all three would fail identically on retry, and a line break in an address is rejected as header injection.

**Two promises are enforced by tests rather than hoped for** — a login link in a log is a login in a log, so the success line names neither the recipient, the body nor the key, and `_why` reduces a failure to a category instead of wrapping an exception that quotes the URL it was handed.

**`doc/operations.md` records the Managed Postgres cluster** created alongside this (`dinkydash`, PostgreSQL 17.11, fra1, $15.15/month, schema applied, transaction-mode pool), along with two things that bit: `doctl` prints database passwords in its *success* output — both printed credentials were rotated within minutes — and Postgres 15 requires `ALTER SCHEMA public OWNER TO` before the app user can create a table.

Tests are 463 passed / 27 skipped locally, and **490 passed with nothing skipped** against the real cluster, which is the first time the store contract has run on managed Postgres rather than a CI service container; the cluster still has no trusted sources and that is logged as outstanding on DIN-26, because restricting it before the App Platform migration job exists would lock out the machine that still has to run migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)