### PR TITLE
Correct two wrong claims about App Platform, both learned by deploying

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -1,7 +1,8 @@
 # DigitalOcean App Platform spec for dinkydash.co and app.dinkydash.co.
 #
-# Applied with:
-#   doctl apps update ed4158fc-fb49-4c10-bb1e-2c8491b06a86 --spec .do/app.yaml
+# App id: ed4158fc-fb49-4c10-bb1e-2c8491b06a86. **How to apply it is below, and
+# it is not `--spec .do/app.yaml`** — read the secrets note before running
+# anything.
 #
 # Infrastructure reviewed like code, which is why it is committed.
 #
@@ -11,14 +12,33 @@
 # 2026, and applying the file as documented above would have taken dinkydash.co
 # off its own domain.
 #
-# **Secrets are the one exception, and it was tested rather than assumed.** An
-# env var with `type: SECRET` and no `value:` keeps the value already set: this
-# was checked on 8 September with a throwaway variable, set to a value, then
-# re-applied without one, and it survived as `EV[...]`. So the values below can
-# stay out of a public repo without this file becoming a loaded gun. Set them
-# with `doctl apps update` from a spec assembled outside the working tree, or in
-# the dashboard. **Never commit an `EV[...]` blob here** — it is ciphertext of a
-# production credential, and this repo is world-readable.
+# **Do not apply this file as it stands. It will break the app.**
+#
+# The `type: SECRET` entries below carry no `value:`, because their values are
+# production credentials and this repo is world-readable. Applying a spec that
+# omits them looks like it works — `doctl apps spec get` still shows `EV[...]`
+# afterwards, so the secret appears to have been preserved — but **the container
+# receives an empty variable**, and the pre-deploy migration job dies with
+# `DATABASE_URL_DIRECT is not set`. That was learned by doing it: two deploys
+# failed that way on 8 September 2026, and the spec looked correct throughout.
+# A canary test that only checked `spec get` is what missed it; the display and
+# the runtime disagree.
+#
+# So this file is the **shape** of the app, reviewed like code, and the values
+# are merged in at apply time from outside the working tree:
+#
+#   python3 - <<'EOF'
+#   import os, yaml
+#   d = yaml.safe_load(open(".do/app.yaml"))
+#   for e in d["envs"]:
+#       if e.get("type") == "SECRET":
+#           e["value"] = os.environ[e["key"]]      # from .env, never committed
+#   yaml.safe_dump(d, open("/tmp/apply.yaml", "w"), sort_keys=False)
+#   EOF
+#   doctl apps update <APP_ID> --spec /tmp/apply.yaml && rm /tmp/apply.yaml
+#
+# **Never commit an `EV[...]` blob here either** — it is ciphertext of a
+# production credential, in a public repo.
 #
 # No Dockerfile: App Platform's Python buildpack reads .python-version and
 # installs what `build_command` says (DIN-30, reversed).

--- a/doc/operations.md
+++ b/doc/operations.md
@@ -84,16 +84,34 @@ One family exists, seeded from `config.example.yaml` — invented people, no cal
 `DINKYDASH_FAMILY_ID` points at it. Nothing outside `tests/conftest.py` creates a family, so that
 was done by hand and will be until the signup flow exists.
 
-**Omitting the value of a `type: SECRET` env var preserves it**, which was tested rather than
-assumed: a throwaway variable was set to a value, the spec re-applied without one, and it survived
-as `EV[...]`. That is what lets `.do/app.yaml` be committed to a public repo with the keys but not
-the values, and still be safe to apply. **Never commit an `EV[...]` blob** — encrypted or not, it is
-a production credential in a world-readable repo.
+**Omitting the value of a `type: SECRET` env var does NOT work, and the way it fails is the
+problem.** The earlier note here said it did, on the strength of a canary test: a throwaway
+variable was set to a value, the spec re-applied without one, and `doctl apps spec get` still
+showed `EV[...]`. That test was wrong — it checked the *display*, not the *runtime*. Applying a
+spec with `type: SECRET` and no `value:` leaves the spec looking correct and hands the container an
+**empty** variable. Two deploys died on `DATABASE_URL_DIRECT is not set` before this was understood,
+and at no point did the spec look wrong.
+
+So `.do/app.yaml` is the shape of the app, not something to apply directly. The values are merged
+in from `.env` at apply time, through a temp file outside the working tree, and the file's own
+header carries the snippet. **Never commit an `EV[...]` blob** either — encrypted or not, it is a
+production credential in a world-readable repo.
+
+**`deploy_on_push` does not apply the committed spec.** It rebuilds the components that already
+exist from the new code. Adding a *component* — the `worker`, when it first landed — needs an
+explicit `doctl apps update`. Merging a PR that adds both the code and the spec entry gets you the
+code and not the component, which is a quiet way to think something shipped when it did not.
 
 **The `worker` component and the `worker/` package have to land together.** Applying the spec from
 a checkout without the package gives a component whose `run_command` cannot import, and a failed
 deploy. The worker was held out of the first apply for exactly that reason, because the app deploys
 from `main` and the code was still on a branch.
+
+**The worker has been running since 8 September 2026, 10:58 UTC.** Its first pass refreshed the
+seeded family's (empty) calendars, called Claude, and wrote a board — `Tuesday with no plans means
+extra time together`, visible on app.dinkydash.co within seconds. A pass every 300 seconds after
+that. There is no dead-man's switch yet (PLAN.md Phase 6), so a worker that stops looks exactly
+like a quiet day: `doctl apps logs <id> worker --type run --follow` is the only check there is.
 
 
 


### PR DESCRIPTION
**Documentation only — no code changes.** The hosted board went live during this work, and getting there proved two claims in this repo's own docs wrong, both in the direction that looks fine until production disagrees.

**"A `type: SECRET` env var with no `value:` keeps its value" is false**, and the canary test behind that claim was the problem: it checked `doctl apps spec get`, which keeps showing `EV[...]` afterwards, so the spec reads perfectly while the container receives an **empty** variable — three deployments died on `DATABASE_URL_DIRECT is not set`, and the specs of a working and a failing deployment diffed byte-identical.

So `.do/app.yaml` is now documented as the *shape* of the app rather than something to apply directly: its header leads with "Do not apply this file as it stands", carries the snippet that merges values in from `.env` through a temp file outside the working tree, and drops the old `--spec .do/app.yaml` line that contradicted the warning three lines below it.

**"Merge the PR and the worker deploys itself" is also false** — `deploy_on_push` rebuilds components that already exist from new code and does not apply the committed spec, so adding a component needs an explicit `doctl apps update`, and merging a PR carrying both the code and the spec entry gets you the code and no component.

`doc/operations.md` records both, plus what the worker actually did at 10:58 UTC on 8 September (refreshed the seeded family's empty calendars, called Claude, wrote `Tuesday with no plans means extra time together` to a board serving it seconds later, a pass every 300 seconds since) and the fact that it has no dead-man's switch, so a worker that stops looks exactly like a quiet day.

🤖 Generated with [Claude Code](https://claude.com/claude-code)