### PR TITLE
Sign somebody in with one email, one link and one session (DIN-38)

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -128,7 +128,26 @@ services:
     # Markdown renderer.
     build_command: pip install -r requirements-cloud.txt
 
-    run_command: gunicorn --workers 2 --threads 4 --bind 0.0.0.0:8080 --access-logfile - "wsgi:application"
+    # **The access log format is a security control, not a preference.** A magic
+    # link is a bearer credential, and gunicorn's default `%(r)s` writes the whole
+    # request line — path *and* query string — to the platform's log, where it is
+    # kept and read. `%(U)s` is the path alone, so the sign-in link's `?t=` never
+    # lands there. That is why `web/routes/auth.py` puts the token in the query
+    # string rather than in the path, and why `tests/test_auth.py` fails if this
+    # line grows a `%(r)s` or a `%(q)s` back.
+    #
+    # `%(f)s` is the Referer, which cannot carry the token either: every response
+    # sets `Referrer-Policy: no-referrer` (DIN-32).
+    #
+    # `web.routes.auth.NoTokens` scrubs `?t=` from the `gunicorn.access` logger
+    # as well, which is what covers the window this file cannot: `deploy_on_push`
+    # rebuilds components from new code and does **not** apply a changed spec, so
+    # a merge without a `doctl apps update` leaves the default format running.
+    run_command: >-
+      gunicorn --workers 2 --threads 4 --bind 0.0.0.0:8080
+      --access-logfile -
+      --access-logformat '%(h)s %(l)s %(u)s %(t)s "%(m)s %(U)s %(H)s" %(s)s %(b)s "%(f)s" "%(a)s"'
+      "wsgi:application"
 
     instance_size_slug: apps-s-1vcpu-0.5gb
     instance_count: 1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,6 +140,18 @@ mode is a different product on the same code.
 - **`web/__init__.py` falls back to a hardcoded `app.secret_key`.** Harmless with no auth; in cloud
   mode the session *is* the authentication, so cloud mode must refuse to start without a real
   `DINKYDASH_SECRET_KEY`.
+- **A magic link is a bearer credential, and so is everything it touches.** `dinkydash/accounts.py`
+  holds the lifecycle — 32 bytes from `secrets`, only the SHA-256 stored, fifteen minutes, spent by
+  a single `UPDATE ... WHERE used_at IS NULL RETURNING`. **A login link in a log is a login in a
+  log**, which is why the token rides in the query string, `.do/app.yaml` sets a gunicorn access
+  log format built from `%(U)s` (path, no query) rather than the default `%(r)s`, and
+  `auth.NoTokens` scrubs `?t=` from both request loggers regardless. All three are asserted in
+  `tests/test_auth.py`; none of them is a preference.
+- **A login request answers identically whether or not the address has an account**, including when
+  it is rate-limited and when the send fails. Anything else enumerates accounts, and the accounts
+  are families.
+- **Every form that writes carries a CSRF token**, in *both* modes — `web/session.py`, with no
+  switch to turn it off. A test walks the templates and fails on a form without one.
 - **Screen tokens are bearer credentials.** Rate-limited, `noindex`, no referrer leakage, rotatable,
   and never written to a log or an error page.
 - **Spend caps are a security control.** The per-family and global breaker (PLAN.md phase 2) is what
@@ -238,13 +250,18 @@ dinkydash/
 ├── store.py           the six storage operations; FileStore, the single-mode one
 ├── pgstore.py         PostgresStore, the cloud one. Imports psycopg; single mode never does
 ├── db.py              the connection pool and the migration runner (cloud only)
+├── mail.py            one transactional email, over SendGrid (cloud only)
+├── accounts.py        users, and the magic links that sign them in (cloud only)
 └── runner.py          the two halves of the day, reading and writing through a store
 
 web/
 ├── __init__.py        create_app()
+├── session.py         what the cookie carries: who is signed in, and CSRF
+├── ratelimit.py       a per-key counter, in this process (the per-IP half)
 ├── routes/board.py    the board and the preview harness
 ├── routes/settings.py the settings UI (one table drives every list section)
-└── templates/         board.html, preview.html, settings/*.html
+├── routes/auth.py     /login, /login/link, /logout — cloud mode only
+└── templates/         board.html, preview.html, auth/*.html, settings/*.html
 ```
 
 ### The storage seam

--- a/PLAN.md
+++ b/PLAN.md
@@ -2,6 +2,8 @@
 
 *Last updated: September 8, 2026. Supersedes `HOSTING_ANALYSIS.md` (deleted — it predated both the AI generation feature and the July 2026 calendar-display repositioning, and its recommended stack and data model no longer matched the product).*
 
+*September 8, later still: **magic-link auth is built** (DIN-38). `dinkydash/accounts.py` is the token lifecycle — 32 bytes from `secrets`, only the SHA-256 stored, fifteen minutes, spent by one `UPDATE ... WHERE used_at IS NULL RETURNING`; `web/routes/auth.py` is `/login`, `/login/link` and `/logout`; `web/session.py` is the cookie and a CSRF token on every form that writes, in both modes. `/settings` in cloud mode is behind a session. What is deliberately still missing is the **scoping**: cloud mode still serves `DINKYDASH_FAMILY_ID` rather than the family on the session, which is the actual "done when" of this phase and its own issue. The token rides in the query string rather than the path because the app runs `gunicorn --access-logfile -` and a login link in a log is a login in a log — see the access log format in `.do/app.yaml`, which is now a security control.*
+
 *September 8, later: **one service, not two.** The board joins the marketing site in the existing `dinkydash-site` app rather than getting its own, because that is how `qrpage.co` and `abc-league` already run in this account — one container, one gunicorn, everything in it. Staging is dropped until there is a paying family to protect. The `worker` is the one genuine addition, because the tick has no lock and two web instances would tick twice. See [Hosting and deployment](#hosting-and-deployment).*
 
 *September 8: the transactional email provider is settled — decision 13, **SendGrid**, on the account KeepTheScore already sends from. The open question is closed. `dinkydash.co` is an authenticated sending domain on that account (DKIM and a monitor-only DMARC record are live in Cloudflare), and this repo has its own send-only API key. What is not built is the sending itself — that arrives with magic links in Phase 1.*
@@ -273,7 +275,9 @@ The board template is shared; only the route that reaches it differs.
 ```
                         single                  cloud
 /                       the board               → /settings if signed in, else /login
-/login                  —                       magic-link request and landing
+/login                  —                       ask for a link; `?t=` is the landing
+/login/link?t=<token>   —                       spend the token, start the session
+/logout                 —                       throw the session away
 /settings/…             as today                as today, scoped to the session's family
 /s/<token>              —                       the board
 /preview                three sizes of /        under /settings, framing /s/<token>
@@ -674,8 +678,8 @@ timezone, family name and location under `/system`. The boxes below stay unticke
 missing is the multi-tenant half — a schema, auth, and scoping every read and write to a `family_id`.
 
 - [x] Schema + migrations per the sketch above; `PostgresStore` behind the seam *(DIN-31)*
-- [ ] Magic-link auth: token hashed at rest, single use, 15-minute expiry, request endpoint rate-limited. Signing in through the link *is* email verification — there is no second step.
-- [ ] Session hygiene: `Secure`, `HttpOnly`, `SameSite=Lax`; a CSRF token on every form; cloud mode refuses to start without `DINKYDASH_SECRET_KEY`
+- [x] Magic-link auth: token hashed at rest, single use, 15-minute expiry, request endpoint rate-limited per address and per caller. Signing in through the link *is* email verification — there is no second step. *(DIN-38)*
+- [x] Session hygiene: `Secure` (cloud only — a Pi serves plain HTTP), `HttpOnly`, `SameSite=Lax`; a CSRF token on every form, in **both** modes and with no switch to turn it off; cloud mode refuses to start without `DINKYDASH_SECRET_KEY` *(DIN-38)*
 - [x] `fetch_feed` hardening before any stranger's URL is fetched: `https` only, redirects that cannot land on a private range, a response size cap beside the timeout *(DIN-33)*. The settings page's "Check this link" goes through the same function, so it is covered too. DNS rebinding is documented as still open.
 - [ ] Family setup wizard: people + DOBs, emoji/color avatars, pets, chores, special dates
 - [ ] Multi-calendar management: add/label/enable/remove iCal feeds, with live validation on paste
@@ -738,7 +742,7 @@ missing is the multi-tenant half — a schema, auth, and scoping every read and 
 - [ ] Sentry (already connected) in both processes; uptime check on `/healthz`
 - [ ] Generation-success dashboard; alerts on failure rate, calendar-fetch failures, spend breaker, Stripe webhook failures, and the dead-man's switch
 - [ ] **The restore drill.** DigitalOcean takes daily backups and keeps 7 days of point-in-time recovery, so the *dump* is no longer a job. Restoring into a scratch database on a schedule still is, and an untested backup is a hope. Script it; run it monthly.
-- [ ] SendGrid wired up in the app *(decision 13)*. The account, the authenticated sending domain and a send-only API key already exist; what is missing is the code that calls them, and it lands with magic links in Phase 1 rather than here.
+- [x] SendGrid wired up in the app *(decision 13)*. `dinkydash/mail.py` is the send (DIN-36) and `web/routes/auth.py` is its first caller (DIN-38), so this landed in Phase 1 as planned rather than here.
 - [ ] Support inbox and a basic admin view (find family, inspect last generation, re-run)
 
 **Done when:** you'd be comfortable going away for a weekend.

--- a/dinkydash/CLAUDE.md
+++ b/dinkydash/CLAUDE.md
@@ -25,7 +25,8 @@ Four rules keep it a seam rather than a name:
 - **`store.py` and `config.py` are the only files under `dinkydash/` that open a file**, and
   `pgstore.py` and `db.py` are the only ones that import psycopg. `grep -rn "open(" dinkydash web`
   is the check, and it should stay that short. A new file read anywhere else is a caller that cloud
-  mode will have to fork.
+  mode will have to fork. `accounts.py` queries Postgres and still imports no driver: it is handed
+  a pool and asks it for connections, which is the shape anything cloud-only should copy.
 - **`data_file` and `content_history_file` are storage-layer keys.** They stay in `DEFAULTS` and in
   `config.example.yaml` for compatibility, and only `FileStore` reads them. They mean nothing hosted.
 - **The store is passed, never constructed, below the entry points.** `generate.py`, `app.py` and
@@ -51,6 +52,34 @@ Four rules keep it a seam rather than a name:
 **Every `PostgresStore` query is scoped to `self.family_id`.** There is no unscoped read and no
 unscoped write in that file, and there must never be one. An id arriving in a URL is a claim, not a
 fact, and the place to check it is before it reaches a store.
+
+Two things are unscoped, both deliberately outside the store rather than weakening it:
+`worker.family_ids`, whose whole job is to walk every family, and `dinkydash/accounts.py`, which
+resolves an email address to a user before there is a family to scope to. A magic link has to find
+exactly one person without being told which family they belong to, which is why `users.email` is
+globally unique.
+
+## Signing somebody in
+
+`accounts.py` is the token lifecycle and nothing else: mint, hash, spend, sweep. Four things in it
+are load-bearing, and each is asserted in `tests/test_auth.py`:
+
+- **Only the hash is stored.** The plaintext exists for the length of one email. SHA-256 rather
+  than a slow KDF, because 32 bytes from `secrets` has nothing to guess and bcrypt would only make
+  every login slower.
+- **Single use is one statement.** `UPDATE ... WHERE token_hash = %s AND used_at IS NULL AND
+  expires_at > now() RETURNING user_id` decides and marks together, so two clicks — or a mail
+  scanner arriving a second before the person — cannot both come back with a user. A read-then-write
+  would pass every test that ran the two in order.
+- **Time comes from Postgres.** `now()` is the transaction clock, one clock for however many web
+  instances, and it cannot drift out of step with the row it is compared to.
+- **Expired, spent and never-issued are one answer.** `consume_link` returns `None` for all three,
+  so there is nothing for a caller to leak by accident.
+
+The per-address rate limit lives in the same `INSERT` — at most `MOST_LIVE_LINKS` unexpired tokens
+per user — so two requests arriving together cannot both read "two live links" and both make a
+third. The per-IP half is in `web/ratelimit.py` and is in-process, because a database write on
+every unauthenticated request is itself something to flood.
 
 ## Cloud mode: schema, migrations, connections
 

--- a/dinkydash/accounts.py
+++ b/dinkydash/accounts.py
@@ -1,0 +1,177 @@
+"""Users, and the links that sign them in. Cloud mode only.
+
+    normalise(email)             -> the address as it is compared
+    user_for(pool, email)        -> (user_id, family_id), or None
+    issue_link(pool, user_id)    -> the plaintext token, or None if rate-limited
+    consume_link(pool, token)    -> (user_id, family_id), or None
+    sweep(pool)                  -> how many dead tokens were deleted
+
+One email in, one link out, one session (PLAN.md phase 1). Signing in through
+the link *is* email verification: there is no second step, no password, and
+nothing to reset.
+
+**Only the hash is stored.** The plaintext exists for the length of one email
+and is never written anywhere else — not to a row, not to a log line, not into
+an exception message. Whoever reads the database gets 64 characters of SHA-256
+and no way back to a working link.
+
+**SHA-256, not a slow KDF.** A password is low-entropy and needs bcrypt or
+argon2 to make guessing expensive. This token is 32 random bytes from
+`secrets`, so there is nothing to guess and a slow hash would only make every
+login slower. What matters instead is that the lookup cannot be walked, and it
+cannot: an attacker would have to invert SHA-256 to control the value being
+matched.
+
+**Single use is one statement.** `UPDATE ... WHERE used_at IS NULL AND
+expires_at > now() RETURNING` decides and marks in the same breath, so two
+clicks on one link — or a mail scanner following it a second before the person
+does — cannot both come back with a user. A read-then-write would let both
+through, and it would look correct in every test that ran them in order.
+
+**Time comes from Postgres, never from Python.** `now()` is the transaction's
+clock, one clock for however many web instances, and it cannot drift out of
+step with the row it is being compared to.
+
+This module imports no psycopg — it is handed a pool and asks it for
+connections — so the rule that `pgstore.py` and `db.py` are the only files
+importing the driver still holds. It is not part of the engine either: nothing
+under the `generate()` boundary knows that users exist.
+"""
+
+import hashlib
+import logging
+import secrets
+from datetime import timedelta
+
+log = logging.getLogger(__name__)
+
+# How long a link works. Short because a link is a bearer credential and its
+# whole defence is not being around long.
+TOKEN_TTL = timedelta(minutes=15)
+
+# 32 bytes of entropy, url-safe, which is 43 characters. Long enough that
+# enumeration is not a thing; short enough to survive a mail client wrapping
+# a line.
+TOKEN_BYTES = 32
+
+# The per-person rate limit, and it is a spend control as much as a security
+# one: every request sends an email on an account whose sender reputation is
+# shared with KeepTheScore. Counted as "unexpired links", so it is exactly
+# "at most three live links at a time" and the sweep below cannot affect it.
+MOST_LIVE_LINKS = 3
+
+# Anything longer than a real token is not one, and there is no reason to hash
+# it to find that out. A URL can carry a great deal.
+LONGEST_TOKEN = 200
+
+
+def normalise(email):
+    """The address as it is compared and stored: trimmed and lower-cased.
+
+    Email local parts are case-sensitive to the letter of the RFC and to
+    nobody's mail server. A parent who types their address with a capital on
+    Tuesday has to get in on Wednesday.
+    """
+    return (email or "").strip().lower()
+
+
+def new_token():
+    return secrets.token_urlsafe(TOKEN_BYTES)
+
+
+def hash_token(token):
+    """What the row holds. Hex, so it fits the column's TEXT and its length check."""
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+def user_for(pool, email):
+    """Who that address belongs to, or None.
+
+    Compared with `lower()` on both sides rather than trusting how the row was
+    written, because a user created by hand or by an import is not this
+    module's doing. `users` holds one row per family, so the scan this costs is
+    not worth a functional index yet — when it is, the index is
+    `(lower(email))` and this query is already shaped for it.
+    """
+    address = normalise(email)
+    if not address:
+        return None
+    with pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            "SELECT id, family_id FROM users WHERE lower(email) = %s",
+            (address,),
+        )
+        return cur.fetchone()
+
+
+def issue_link(pool, user_id, ttl=TOKEN_TTL, most=MOST_LIVE_LINKS):
+    """Mint one token for that user. Returns the plaintext, or None if limited.
+
+    The limit is inside the INSERT rather than a SELECT before it, so two
+    requests arriving together cannot both read "two live links" and both make
+    a third. The caller must answer identically either way — a request that is
+    silently dropped and one that sends an email have to look the same from
+    outside, or the rate limit becomes the account-enumeration oracle that the
+    identical wording exists to prevent.
+    """
+    token = new_token()
+    with pool.connection() as conn, conn.transaction():
+        with conn.cursor() as cur:
+            cur.execute(
+                """INSERT INTO login_tokens (user_id, token_hash, expires_at)
+                   SELECT %s, %s, now() + %s
+                   WHERE (SELECT count(*) FROM login_tokens
+                          WHERE user_id = %s AND expires_at > now()) < %s
+                   RETURNING id""",
+                (user_id, hash_token(token), ttl, user_id, most),
+            )
+            if cur.fetchone() is None:
+                # Not an error and not logged as one: asking twice is what a
+                # person does when the first email is slow.
+                return None
+    return token
+
+
+def consume_link(pool, token):
+    """Spend a token. Returns (user_id, family_id), or None for anything wrong.
+
+    Expired, already used, and never issued are one answer on purpose. The
+    caller shows one page for all three, so there is nothing here for a caller
+    to leak by accident.
+    """
+    if not token or len(token) > LONGEST_TOKEN:
+        return None
+    with pool.connection() as conn, conn.transaction():
+        with conn.cursor() as cur:
+            cur.execute(
+                """UPDATE login_tokens
+                   SET used_at = now()
+                   WHERE token_hash = %s
+                     AND used_at IS NULL
+                     AND expires_at > now()
+                   RETURNING user_id""",
+                (hash_token(token),),
+            )
+            row = cur.fetchone()
+            if row is None:
+                return None
+            cur.execute(
+                "UPDATE users SET last_login_at = now() WHERE id = %s "
+                "RETURNING id, family_id",
+                (row[0],),
+            )
+            return cur.fetchone()
+
+
+def sweep(pool):
+    """Delete every token that has expired. Returns how many went.
+
+    A used token is deleted by the same rule, once its fifteen minutes are up:
+    there is nothing to learn from keeping it, and a table of hashes of dead
+    credentials is a table somebody has to think about in the privacy policy.
+    Walks `login_tokens_expires_idx`, which exists for this.
+    """
+    with pool.connection() as conn, conn.transaction():
+        with conn.cursor() as cur:
+            cur.execute("DELETE FROM login_tokens WHERE expires_at < now()")
+            return cur.rowcount

--- a/doc/operations.md
+++ b/doc/operations.md
@@ -114,6 +114,34 @@ that. There is no dead-man's switch yet (PLAN.md Phase 6), so a worker that stop
 like a quiet day: `doctl apps logs <id> worker --type run --follow` is the only check there is.
 
 
+## Magic links, 8 September 2026 (DIN-38)
+
+`/login`, `/login/link` and `/logout` exist in cloud mode. **Nothing creates a user yet** — sign-up
+is a later issue — so the one family seeded from `config.example.yaml` needs a row inserted by hand
+before anybody can sign in:
+
+```sql
+INSERT INTO users (family_id, email) VALUES ('<DINKYDASH_FAMILY_ID>', 'you@example.com');
+```
+
+One outstanding action, and it is a security one. **`.do/app.yaml` now sets a gunicorn
+`--access-logformat`** built from `%(U)s`, so the sign-in link's `?t=` is not written to the
+platform's log. `deploy_on_push` rebuilds components from new code and does **not** apply a changed
+spec, so **until somebody runs `doctl apps update` the running service is still on gunicorn's
+default `%(r)s`**, which is the whole request line. Applying it is the same merge-values-from-`.env`
+dance as every other change to this file — see the header of the spec.
+
+Meanwhile the code covers the gap: `web.routes.auth.NoTokens` is attached to both the `werkzeug` and
+`gunicorn.access` loggers and replaces `?t=<token>` with `?t=[redacted]` in the message. That was
+written after watching real tokens scroll past a local terminal, not from theory. DigitalOcean's own
+edge logs are outside all of this and always will be; single use and fifteen minutes are what covers
+them.
+
+`SENDGRID_API_KEY` is already in the app's environment (DIN-36) and is the send-only key. The
+per-address rate limit is three live links; the per-caller-address one is twenty an hour **per
+process**, and the service runs `--workers 2`, so the real ceiling is forty and a redeploy resets
+it. That is a bound on abuse, not a quota.
+
 
 ## GitHub's own secret scanning
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,3 +69,47 @@ def pg_family(pg_pool):
     with pg_pool.connection() as conn, conn.transaction():
         with conn.cursor() as cur:
             cur.execute("DELETE FROM families WHERE id = %s", (family_id,))
+
+
+# -- a test client that behaves like a browser ------------------------------
+#
+# Every form the settings UI renders carries a CSRF token, and `web.session`
+# refuses a write without one. There is deliberately no switch to turn that off
+# — see the note in `check_csrf` — so the client below fills the field in the
+# way a browser filling in a rendered form would.
+#
+# The effect is that all ~30 existing POSTs in the suite now go *through* the
+# CSRF check rather than around it, which is the whole reason for doing it this
+# way. A test that wants to see the check refuse something passes its own
+# `csrf_token` (a wrong one, or none at all, via a plain `app.test_client()`).
+
+from flask.testing import FlaskClient  # noqa: E402
+
+CSRF_KEY = "csrf"
+CSRF_FIELD = "csrf_token"
+
+
+class SigningClient(FlaskClient):
+    """A client that carries this session's CSRF token on every write."""
+
+    WRITES = {"POST", "PUT", "PATCH", "DELETE"}
+
+    def open(self, *args, **kwargs):
+        if kwargs.get("method", "GET").upper() in self.WRITES:
+            with self.session_transaction() as stored:
+                token = stored.get(CSRF_KEY)
+                if not token:
+                    token = stored[CSRF_KEY] = "a-test-csrf-token"
+            data = kwargs.get("data")
+            if data is None:
+                kwargs["data"] = {CSRF_FIELD: token}
+            elif isinstance(data, dict):
+                data.setdefault(CSRF_FIELD, token)
+        return super().open(*args, **kwargs)
+
+
+def client_for(app):
+    """`app.test_client()`, signing its writes. What every fixture here uses."""
+    app.test_client_class = SigningClient
+    app.config["TESTING"] = True
+    return app.test_client()

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,732 @@
+"""Magic-link auth: one email, one link, one session.
+
+Four claims, and each of them is invisible until it is not:
+
+* **the link is the whole credential**, so it is hashed at rest, spent once,
+  short-lived, and never written to a page, a log or a row in plaintext;
+* **the answer is the same whether or not the address has an account**,
+  because anything else is an enumeration oracle against a product whose
+  users are families;
+* **no form can be submitted from somebody else's page**, in either mode;
+* **cloud mode's `/settings` is behind all of it**, and single mode's is not
+  and must not be — a self-hoster has no account to sign in to.
+
+The Postgres half skips unless `DINKYDASH_TEST_DATABASE_URL` is set, like the
+rest of the suite. What can be tested without a database — the token shapes,
+the cookie flags, CSRF, the rate limiter — is tested without one.
+"""
+
+import pathlib
+import re
+
+import pytest
+import yaml
+
+from dinkydash import accounts, mail
+from dinkydash.store import FileStore
+from tests.conftest import client_for
+from web import create_app
+from web.ratelimit import Limiter, client_ip
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+
+CONFIG = '''\
+family_name: "The Wilsons"
+timezone: "Europe/Berlin"
+people:
+  - id: mia12345
+    name: "Mia"
+    date_of_birth: "2017-03-15"
+'''
+
+ADDRESS = "parent@example.com"
+
+
+@pytest.fixture
+def single(tmp_path):
+    """A self-hosted app: no accounts, no login, no Secure cookie."""
+    (tmp_path / "config.yaml").write_text(CONFIG)
+    return create_app(FileStore(tmp_path / "config.yaml"))
+
+
+@pytest.fixture
+def pg_user(pg_pool, pg_family):
+    """One parent on that family, and the id of their row."""
+    with pg_pool.connection() as conn, conn.transaction():
+        with conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO users (family_id, email) VALUES (%s, %s) RETURNING id",
+                (pg_family, ADDRESS),
+            )
+            return cur.fetchone()[0]
+
+
+@pytest.fixture
+def sent(monkeypatch):
+    """Every email the app tried to send, instead of sending it."""
+    outbox = []
+
+    def _send(to, subject, text, html=None, **kwargs):
+        outbox.append({"to": to, "subject": subject, "text": text, "html": html})
+
+    monkeypatch.setattr(mail, "send", _send)
+    return outbox
+
+
+@pytest.fixture
+def cloud(pg_pool, pg_family, monkeypatch):
+    """A cloud app over that family, with a store and therefore a pool."""
+    from dinkydash.pgstore import PostgresStore
+
+    store = PostgresStore(pg_pool, pg_family)
+    store.save_config(yaml.safe_load(CONFIG))
+    monkeypatch.setenv("DINKYDASH_MODE", "cloud")
+    monkeypatch.setenv("DINKYDASH_SECRET_KEY", "a-real-one")
+    return create_app(store)
+
+
+@pytest.fixture
+def client(cloud):
+    return client_for(cloud)
+
+
+def link_in(message):
+    """The sign-in URL out of an email body."""
+    found = re.search(r"https?://\S+/login/link\?t=[\w\-]+", message["text"])
+    assert found, message["text"]
+    return found.group(0)
+
+
+def token_in(message):
+    return link_in(message).split("t=")[1]
+
+
+# -- the token itself, with no database in sight ----------------------------
+
+class TestTheTokenShape:
+    def test_a_token_is_32_bytes_of_entropy(self):
+        # url-safe base64 of 32 bytes, with the padding stripped.
+        assert len(accounts.new_token()) == 43
+
+    def test_two_tokens_are_never_the_same(self):
+        assert len({accounts.new_token() for _ in range(100)}) == 100
+
+    def test_the_hash_is_not_the_token(self):
+        token = accounts.new_token()
+        assert accounts.hash_token(token) != token
+
+    def test_the_same_token_always_hashes_the_same(self):
+        token = accounts.new_token()
+        assert accounts.hash_token(token) == accounts.hash_token(token)
+
+    def test_the_hash_fits_the_column(self):
+        # login_tokens.token_hash is TEXT with CHECK (length <= 128).
+        assert len(accounts.hash_token(accounts.new_token())) <= 128
+
+    @pytest.mark.parametrize("typed,stored", [
+        ("Parent@Example.COM", "parent@example.com"),
+        ("  parent@example.com  ", "parent@example.com"),
+        (None, ""),
+    ])
+    def test_an_address_is_compared_lower_cased_and_trimmed(self, typed, stored):
+        assert accounts.normalise(typed) == stored
+
+
+# -- what the cookie says about itself --------------------------------------
+
+class TestTheSessionCookie:
+    def test_cloud_mode_marks_it_secure(self, cloud):
+        assert cloud.config["SESSION_COOKIE_SECURE"] is True
+
+    def test_single_mode_does_not(self, single):
+        # A Pi serves plain HTTP on a LAN. A Secure cookie there is a cookie
+        # the browser never sends, which is every flash message lost.
+        assert single.config["SESSION_COOKIE_SECURE"] is False
+
+    @pytest.mark.parametrize("key,value", [
+        ("SESSION_COOKIE_HTTPONLY", True),
+        ("SESSION_COOKIE_SAMESITE", "Lax"),
+    ])
+    def test_the_other_two_are_the_same_in_both_modes(self, single, key, value):
+        assert single.config[key] == value
+
+    def test_cloud_agrees(self, cloud):
+        assert cloud.config["SESSION_COOKIE_HTTPONLY"] is True
+        assert cloud.config["SESSION_COOKIE_SAMESITE"] == "Lax"
+
+
+# -- CSRF, in both modes ----------------------------------------------------
+
+class TestCsrf:
+    """On in single mode too. A page in another tab can POST to
+    `http://raspberrypi.local:5123/settings/...` without it."""
+
+    @pytest.fixture
+    def plain(self, single):
+        """A client that does *not* fill the token in for itself."""
+        single.config["TESTING"] = True
+        return single.test_client()
+
+    def test_a_write_with_no_token_is_refused(self, plain):
+        response = plain.post("/settings/system", data={"family_name": "The Bakers"})
+        assert response.status_code == 400
+
+    def test_a_write_with_the_wrong_token_is_refused(self, plain):
+        plain.get("/settings/system")  # mints a real one into the session
+        response = plain.post("/settings/system",
+                              data={"family_name": "The Bakers",
+                                    "csrf_token": "not-the-one"})
+        assert response.status_code == 400
+
+    def test_the_right_token_goes_through(self, single):
+        client = client_for(single)
+        assert client.post("/settings/system",
+                           data={"family_name": "The Bakers",
+                                 "timezone": "UTC"}).status_code == 302
+
+    def test_a_token_full_of_emoji_is_a_400_not_a_500(self, plain):
+        # `hmac.compare_digest` raises TypeError on a non-ASCII `str`.
+        plain.get("/settings/system")
+        assert plain.post("/settings/system",
+                          data={"family_name": "The Bakers",
+                                "csrf_token": "🎈🎈🎈"}).status_code == 400
+
+    def test_a_read_needs_nothing(self, plain):
+        assert plain.get("/settings/").status_code == 200
+
+    def test_the_refusal_does_not_write_anything(self, plain, tmp_path):
+        before = (tmp_path / "config.yaml").read_text()
+        plain.post("/settings/system", data={"family_name": "The Bakers"})
+        assert (tmp_path / "config.yaml").read_text() == before
+
+    def test_every_form_that_writes_carries_the_field(self):
+        """A form added without one is a form that stops working, silently."""
+        missing, seen = [], 0
+        for path in (REPO / "web" / "templates").rglob("*.html"):
+            text = path.read_text()
+            for form in re.findall(r"<form\b.*?</form>", text, re.S):
+                if 'method="post"' not in form:
+                    continue
+                seen += 1
+                if "csrf_token" not in form:
+                    missing.append(str(path.relative_to(REPO)))
+        assert missing == []
+        # Or a regex that stopped matching would make this pass by finding none.
+        assert seen >= 9
+
+
+# -- the rate limiter -------------------------------------------------------
+
+class TestTheLimiter:
+    def test_it_allows_up_to_the_limit(self):
+        limiter = Limiter(most=3, per=60)
+        assert [limiter.allow("a", now=0) for _ in range(3)] == [True, True, True]
+
+    def test_and_refuses_the_next(self):
+        limiter = Limiter(most=3, per=60)
+        for _ in range(3):
+            limiter.allow("a", now=0)
+        assert limiter.allow("a", now=0) is False
+
+    def test_the_window_rolls(self):
+        limiter = Limiter(most=1, per=60)
+        assert limiter.allow("a", now=0) is True
+        assert limiter.allow("a", now=59) is False
+        assert limiter.allow("a", now=61) is True
+
+    def test_one_key_does_not_limit_another(self):
+        limiter = Limiter(most=1, per=60)
+        assert limiter.allow("a", now=0) is True
+        assert limiter.allow("b", now=0) is True
+
+    def test_it_forgets_the_oldest_rather_than_growing_forever(self):
+        limiter = Limiter(most=1, per=60, most_keys=2)
+        for key in ("a", "b", "c"):
+            limiter.allow(key, now=0)
+        # "a" was the least recently seen, so it is the one that went.
+        assert limiter.allow("a", now=0) is True
+        assert limiter.allow("c", now=0) is False
+
+
+class TestWhichAddressItCounts:
+    """`X-Forwarded-For` read from the right, stepping over private hops.
+
+    The addresses here are real public ones on purpose. Python's `ipaddress`
+    counts the documentation ranges — `203.0.113.0/24` and friends — as
+    *private*, so a test written with those would pass through the fallback
+    branch and prove nothing.
+    """
+
+    CLIENT = "93.184.216.34"      # what our proxy saw
+    CLAIMED = "8.8.8.8"           # what the caller put in the header
+    INTERNAL = "10.1.2.3"         # a hop inside the platform
+
+    class _Request:
+        def __init__(self, headers, remote_addr):
+            self.headers = headers
+            self.remote_addr = remote_addr
+
+    def _asking_from(self, forwarded, remote_addr="10.0.0.1"):
+        headers = {"X-Forwarded-For": forwarded} if forwarded else {}
+        return self._Request(headers, remote_addr)
+
+    def test_with_no_proxy_it_is_the_socket(self):
+        assert client_ip(self._asking_from(None, self.CLIENT)) == self.CLIENT
+
+    def test_the_last_public_hop_wins(self):
+        assert client_ip(
+            self._asking_from(f"{self.CLAIMED}, {self.CLIENT}")) == self.CLIENT
+
+    def test_a_caller_cannot_pretend_to_be_someone_else(self):
+        """Everything before the last hop is whatever the caller sent."""
+        assert client_ip(
+            self._asking_from(f"invented, {self.CLIENT}")) == self.CLIENT
+
+    def test_an_internal_hop_is_stepped_over(self):
+        """Otherwise a second proxy would put every family in one bucket."""
+        assert client_ip(self._asking_from(
+            f"{self.CLAIMED}, {self.CLIENT}, {self.INTERNAL}")) == self.CLIENT
+
+    def test_all_private_falls_back_to_the_last_hop(self):
+        assert client_ip(self._asking_from(self.INTERNAL)) == self.INTERNAL
+
+    def test_nonsense_is_not_an_address(self):
+        assert client_ip(self._asking_from("not-an-ip")) == "not-an-ip"
+
+
+# -- what single mode must not grow -----------------------------------------
+
+class TestSelfHostedHasNoLogin:
+    def test_there_is_no_login_page(self, single):
+        assert client_for(single).get("/login").status_code == 404
+
+    def test_there_is_nothing_to_log_out_of(self, single):
+        assert client_for(single).post("/logout").status_code == 404
+
+    def test_the_settings_are_not_behind_anything(self, single):
+        assert client_for(single).get("/settings/").status_code == 200
+
+    def test_and_the_page_offers_no_sign_out(self, single):
+        assert "Sign out" not in client_for(single).get("/settings/").get_data(as_text=True)
+
+
+# -- asking for a link ------------------------------------------------------
+
+class TestAskingForALink:
+    def test_the_form_is_there(self, client):
+        assert "Email me a link" in client.get("/login").get_data(as_text=True)
+
+    def test_a_known_address_gets_an_email(self, client, sent, pg_user):
+        client.post("/login", data={"email": ADDRESS})
+        assert len(sent) == 1
+        assert sent[0]["to"] == ADDRESS
+
+    def test_an_unknown_address_gets_none(self, client, sent, pg_user):
+        client.post("/login", data={"email": "stranger@example.com"})
+        assert sent == []
+
+    def test_but_the_two_pages_are_identical(self, client, sent, pg_user):
+        known = client.post("/login", data={"email": ADDRESS})
+        unknown = client.post("/login", data={"email": "stranger@example.com"})
+        assert known.status_code == unknown.status_code
+        assert known.get_data() == unknown.get_data()
+
+    def test_the_address_is_matched_whatever_case_it_is_typed_in(
+            self, client, sent, pg_user):
+        client.post("/login", data={"email": "Parent@EXAMPLE.com"})
+        assert len(sent) == 1
+
+    def test_something_that_is_not_an_address_says_so(self, client, sent):
+        page = client.post("/login", data={"email": "not-an-address"})
+        # About what was typed, not about who exists — so it gives nothing away.
+        assert "does not look like an email address" in page.get_data(as_text=True)
+        assert sent == []
+
+    def test_the_reply_never_names_the_address(self, client, sent, pg_user):
+        page = client.post("/login", data={"email": ADDRESS}).get_data(as_text=True)
+        assert ADDRESS not in page
+
+    def test_the_link_is_never_on_the_page(self, client, sent, pg_user):
+        page = client.post("/login", data={"email": ADDRESS}).get_data(as_text=True)
+        assert token_in(sent[0]) not in page
+
+
+class TestOnlyTheHashIsStored:
+    def test_the_plaintext_token_is_nowhere_in_the_table(
+            self, client, sent, pg_user, pg_pool):
+        client.post("/login", data={"email": ADDRESS})
+        token = token_in(sent[0])
+        with pg_pool.connection() as conn, conn.cursor() as cur:
+            cur.execute("SELECT token_hash FROM login_tokens WHERE user_id = %s",
+                        (pg_user,))
+            stored = [row[0] for row in cur.fetchall()]
+        assert stored == [accounts.hash_token(token)]
+        assert token not in stored
+
+
+class TestTheEmailItself:
+    def test_it_carries_a_link_to_the_landing_route(self, client, sent, pg_user):
+        client.post("/login", data={"email": ADDRESS})
+        assert "/login/link?t=" in link_in(sent[0])
+
+    def test_the_link_is_https_whatever_the_request_was(self, client, sent, pg_user):
+        # App Platform terminates TLS, so the request that reaches Flask is
+        # plain HTTP. A link built from it would put the credential on the wire.
+        client.post("/login", data={"email": ADDRESS})
+        assert link_in(sent[0]).startswith("https://")
+
+    def test_it_says_what_the_link_does(self, client, sent, pg_user):
+        client.post("/login", data={"email": ADDRESS})
+        assert "once" in sent[0]["text"]
+        assert "fifteen minutes" in sent[0]["text"]
+
+    def test_it_asks_nothing_of_a_third_party(self, client, sent, pg_user):
+        """No tracking pixel, no remote CSS. Either would publish the login."""
+        client.post("/login", data={"email": ADDRESS})
+        body = sent[0]["html"]
+        assert "<img" not in body
+        for host in ("googleapis", "gstatic", "sendgrid.net", "cdn."):
+            assert host not in body
+
+
+class TestWhereTheLinkPoints:
+    """The host comes from configuration, never from the `Host` header.
+
+    Otherwise somebody could POST this form with a victim's address and a
+    `Host` of their own, and have a working token mailed to the victim
+    pointing at their server.
+    """
+
+    @pytest.fixture
+    def hosted(self, pg_pool, pg_family, monkeypatch):
+        from dinkydash.pgstore import PostgresStore
+
+        store = PostgresStore(pg_pool, pg_family)
+        store.save_config(yaml.safe_load(CONFIG))
+        monkeypatch.setenv("DINKYDASH_MODE", "cloud")
+        monkeypatch.setenv("DINKYDASH_SECRET_KEY", "a-real-one")
+        monkeypatch.setenv("DINKYDASH_APP_HOST", "app.dinkydash.co")
+        return client_for(create_app(store))
+
+    def test_it_uses_the_configured_host(self, hosted, sent, pg_user):
+        hosted.post("/login", data={"email": ADDRESS})
+        assert link_in(sent[0]).startswith("https://app.dinkydash.co/login/link?t=")
+
+    def test_a_forged_host_header_changes_nothing(self, hosted):
+        from web.routes.auth import _link_for
+
+        with hosted.application.test_request_context(
+                "/login", headers={"Host": "evil.example"}):
+            assert _link_for("TOKEN") == "https://app.dinkydash.co/login/link?t=TOKEN"
+
+    def test_and_the_setting_is_doing_the_work(self, client):
+        """The same request with no `APP_HOST` *does* follow the header.
+
+        Which is what makes the assertion above mean something rather than
+        being true for some other reason.
+        """
+        from web.routes.auth import _link_for
+
+        with client.application.test_request_context(
+                "/login", headers={"Host": "evil.example"}):
+            assert _link_for("TOKEN") == "https://evil.example/login/link?t=TOKEN"
+
+    def test_without_one_it_falls_back_to_the_request(self, client, sent, pg_user):
+        # Local development and the tests, where there is no hostname to set.
+        client.post("/login", data={"email": ADDRESS})
+        assert link_in(sent[0]).startswith("https://localhost/login/link?t=")
+
+
+# -- spending it ------------------------------------------------------------
+
+class TestSigningIn:
+    def _link(self, client, sent):
+        client.post("/login", data={"email": ADDRESS})
+        return link_in(sent[0]).replace("https://localhost", "")
+
+    def test_the_link_signs_you_in(self, client, sent, pg_user):
+        response = client.get(self._link(client, sent))
+        assert response.status_code == 302
+        assert response.headers["Location"].endswith("/settings/")
+
+    def test_and_the_session_carries_the_family(self, client, sent, pg_user, pg_family):
+        client.get(self._link(client, sent))
+        with client.session_transaction() as stored:
+            assert stored["user_id"] == pg_user
+            assert stored["family_id"] == str(pg_family)
+
+    def test_the_session_never_carries_the_address(self, client, sent, pg_user):
+        """Flask signs the cookie, it does not encrypt it."""
+        client.get(self._link(client, sent))
+        with client.session_transaction() as stored:
+            assert ADDRESS not in str(dict(stored))
+
+    def test_it_records_when(self, client, sent, pg_user, pg_pool):
+        client.get(self._link(client, sent))
+        with pg_pool.connection() as conn, conn.cursor() as cur:
+            cur.execute("SELECT last_login_at FROM users WHERE id = %s", (pg_user,))
+            assert cur.fetchone()[0] is not None
+
+    def test_a_second_click_does_not_sign_anybody_in(self, client, sent, pg_user):
+        link = self._link(client, sent)
+        assert client.get(link).status_code == 302
+        second = client.get(link)
+        assert second.status_code == 200
+        assert "no longer works" in second.get_data(as_text=True)
+
+    def test_single_use_is_decided_in_the_database(self, client, sent, pg_user, pg_pool):
+        """Two callers, no request in between: only one may come back a user."""
+        client.post("/login", data={"email": ADDRESS})
+        token = token_in(sent[0])
+        first = accounts.consume_link(pg_pool, token)
+        second = accounts.consume_link(pg_pool, token)
+        assert first is not None
+        assert second is None
+
+
+class TestALinkThatDoesNotWork:
+    """Expired, spent and invented are one answer, and one page."""
+
+    def _dead(self, pg_pool, pg_user, ago="1 hour"):
+        token = accounts.new_token()
+        with pg_pool.connection() as conn, conn.transaction():
+            with conn.cursor() as cur:
+                cur.execute(
+                    "INSERT INTO login_tokens (user_id, token_hash, expires_at) "
+                    f"VALUES (%s, %s, now() - INTERVAL '{ago}')",
+                    (pg_user, accounts.hash_token(token)),
+                )
+        return token
+
+    def test_an_expired_one_is_refused(self, client, pg_pool, pg_user):
+        page = client.get(f"/login/link?t={self._dead(pg_pool, pg_user)}")
+        assert "no longer works" in page.get_data(as_text=True)
+
+    def test_an_invented_one_gets_the_same_page(self, client, pg_pool, pg_user):
+        expired = client.get(f"/login/link?t={self._dead(pg_pool, pg_user)}")
+        invented = client.get("/login/link?t=" + accounts.new_token())
+        assert expired.get_data() == invented.get_data()
+
+    def test_no_token_at_all_gets_it_too(self, client, pg_pool, pg_user):
+        expired = client.get(f"/login/link?t={self._dead(pg_pool, pg_user)}")
+        assert client.get("/login/link").get_data() == expired.get_data()
+
+    def test_an_absurdly_long_one_is_refused_without_being_hashed(self, pg_pool):
+        assert accounts.consume_link(pg_pool, "x" * 100_000) is None
+
+    def test_none_of_them_leaves_a_session(self, client, pg_pool, pg_user):
+        client.get(f"/login/link?t={self._dead(pg_pool, pg_user)}")
+        with client.session_transaction() as stored:
+            assert "user_id" not in stored
+
+
+# -- the two rate limits ----------------------------------------------------
+
+class TestTheLimitPerAddress:
+    def test_three_live_links_is_the_most(self, client, sent, pg_user):
+        for _ in range(5):
+            client.post("/login", data={"email": ADDRESS})
+        assert len(sent) == accounts.MOST_LIVE_LINKS
+
+    def test_and_the_page_never_says_so(self, client, sent, pg_user):
+        pages = [client.post("/login", data={"email": ADDRESS}).get_data()
+                 for _ in range(5)]
+        # If being limited looked different, it would say the address exists.
+        assert len(set(pages)) == 1
+
+    def test_the_links_already_sent_still_work(self, client, sent, pg_user):
+        for _ in range(5):
+            client.post("/login", data={"email": ADDRESS})
+        first = link_in(sent[0]).replace("https://localhost", "")
+        assert client.get(first).status_code == 302
+
+
+class TestTheLimitPerAddressOfTheCaller:
+    def test_a_flooding_caller_sends_no_more_email(self, cloud, sent, pg_user):
+        cloud.config["LOGIN_LIMITER"] = Limiter(most=1, per=3600)
+        client = client_for(cloud)
+        client.post("/login", data={"email": ADDRESS})
+        client.post("/login", data={"email": ADDRESS})
+        assert len(sent) == 1
+
+    def test_and_that_page_is_the_same_page_too(self, cloud, sent, pg_user):
+        cloud.config["LOGIN_LIMITER"] = Limiter(most=1, per=3600)
+        client = client_for(cloud)
+        first = client.post("/login", data={"email": ADDRESS})
+        second = client.post("/login", data={"email": ADDRESS})
+        assert first.get_data() == second.get_data()
+
+
+# -- the gate ---------------------------------------------------------------
+
+class TestTheSettingsAreBehindIt:
+    @pytest.mark.parametrize("path", ["/settings/", "/settings/people",
+                                      "/settings/system", "/settings/refresh"])
+    def test_a_stranger_is_sent_to_the_login(self, client, path):
+        response = client.get(path)
+        assert response.status_code == 302
+        assert response.headers["Location"].endswith("/login")
+
+    def test_a_write_is_refused_as_well(self, client):
+        response = client.post("/settings/system", data={"family_name": "The Bakers"})
+        assert response.status_code == 302
+        assert response.headers["Location"].endswith("/login")
+
+    def test_signing_in_opens_it(self, client, sent, pg_user):
+        client.post("/login", data={"email": ADDRESS})
+        client.get(link_in(sent[0]).replace("https://localhost", ""))
+        assert client.get("/settings/").status_code == 200
+
+    def test_the_login_page_itself_is_open(self, client):
+        assert client.get("/login").status_code == 200
+
+    def test_somebody_signed_in_is_not_asked_again(self, client, sent, pg_user):
+        client.post("/login", data={"email": ADDRESS})
+        client.get(link_in(sent[0]).replace("https://localhost", ""))
+        response = client.get("/login")
+        assert response.status_code == 302
+        assert response.headers["Location"].endswith("/settings/")
+
+
+class TestSigningOut:
+    def test_it_empties_the_session(self, client, sent, pg_user):
+        client.post("/login", data={"email": ADDRESS})
+        client.get(link_in(sent[0]).replace("https://localhost", ""))
+        client.post("/logout")
+        with client.session_transaction() as stored:
+            assert "user_id" not in stored
+
+    def test_and_the_settings_are_shut_again(self, client, sent, pg_user):
+        client.post("/login", data={"email": ADDRESS})
+        client.get(link_in(sent[0]).replace("https://localhost", ""))
+        client.post("/logout")
+        assert client.get("/settings/").status_code == 302
+
+    def test_it_cannot_be_done_from_somebody_elses_page(self, cloud):
+        cloud.config["TESTING"] = True
+        plain = cloud.test_client()
+        assert plain.post("/logout").status_code == 400
+
+
+# -- the sweep --------------------------------------------------------------
+
+class TestTheSweep:
+    def test_it_deletes_what_has_expired(self, pg_pool, pg_user):
+        with pg_pool.connection() as conn, conn.transaction():
+            with conn.cursor() as cur:
+                cur.execute(
+                    "INSERT INTO login_tokens (user_id, token_hash, expires_at) "
+                    "VALUES (%s, %s, now() - INTERVAL '1 hour')",
+                    (pg_user, accounts.hash_token(accounts.new_token())),
+                )
+        assert accounts.sweep(pg_pool) == 1
+
+    def test_it_leaves_a_live_one_alone(self, pg_pool, pg_user):
+        accounts.issue_link(pg_pool, pg_user)
+        assert accounts.sweep(pg_pool) == 0
+
+    def test_the_worker_calls_it_and_never_raises(self, pg_pool, pg_user):
+        from worker import sweep_logins
+        assert sweep_logins(pg_pool) == 0
+
+    def test_a_broken_sweep_does_not_stop_a_pass(self):
+        from worker import sweep_logins
+
+        class Broken:
+            def connection(self):
+                raise RuntimeError("no database today")
+
+        assert sweep_logins(Broken()) == 0
+
+
+class TestBothRequestLogsAreScrubbedAnyway:
+    """Neither server may write the token, whatever its format string says.
+
+    Flask's development server has no format to configure, and `deploy_on_push`
+    does not apply the committed app spec — so production can be running
+    gunicorn's default `%(r)s` between a merge and a `doctl apps update`. The
+    filter is what makes both of those safe.
+    """
+
+    @pytest.fixture
+    def record(self):
+        import logging
+        return logging.LogRecord(
+            "werkzeug", logging.INFO, __file__, 0,
+            '"%s" %s %s', ("GET /login/link?t=SECRETTOKEN HTTP/1.1", 302, "-"), None)
+
+    def test_the_token_is_taken_out(self, cloud, record):
+        from web.routes.auth import NoTokens
+        NoTokens().filter(record)
+        assert "SECRETTOKEN" not in record.getMessage()
+        assert "[redacted]" in record.getMessage()
+
+    def test_the_rest_of_the_line_survives(self, cloud, record):
+        from web.routes.auth import NoTokens
+        NoTokens().filter(record)
+        assert "GET /login/link" in record.getMessage()
+        assert "302" in record.getMessage()
+
+    def test_an_ordinary_line_is_left_alone(self, cloud):
+        import logging
+
+        from web.routes.auth import NoTokens
+        record = logging.LogRecord("werkzeug", logging.INFO, __file__, 0,
+                                   '"%s" %s', ("GET /settings/ HTTP/1.1", 200), None)
+        NoTokens().filter(record)
+        assert record.getMessage() == '"GET /settings/ HTTP/1.1" 200'
+
+    @pytest.mark.parametrize("name", ["werkzeug", "gunicorn.access"])
+    def test_building_a_cloud_app_attaches_it(self, cloud, name):
+        import logging
+
+        from web.routes.auth import NoTokens
+        assert any(isinstance(f, NoTokens)
+                   for f in logging.getLogger(name).filters)
+
+    def test_it_reaches_a_gunicorn_access_record(self, cloud):
+        """gunicorn logs a format string plus a mapping, not a finished line.
+
+        `%(r)s` is the request line, query string and all, and it is what the
+        default format uses — so the filter has to work on a record whose
+        message does not exist until it is formatted.
+        """
+        import logging
+
+        from web.routes.auth import NoTokens
+        record = logging.LogRecord(
+            "gunicorn.access", logging.INFO, __file__, 0,
+            '%(h)s "%(r)s" %(s)s',
+            {"h": "203.0.113.9",
+             "r": "GET /login/link?t=SECRETTOKEN HTTP/1.1",
+             "s": "302"},
+            None)
+        NoTokens().filter(record)
+        assert "SECRETTOKEN" not in record.getMessage()
+        assert "203.0.113.9" in record.getMessage()
+
+
+# -- the log the platform keeps ---------------------------------------------
+
+class TestTheLinkIsNotInTheAccessLog:
+    """A login link in a log is a login in a log.
+
+    The token rides in the query string precisely because gunicorn's `%(U)s`
+    is the path without one. If this format ever goes back to the default
+    `%(r)s`, every sign-in link is written to the platform's log.
+    """
+
+    @pytest.fixture
+    def run_command(self):
+        spec = yaml.safe_load((REPO / ".do" / "app.yaml").read_text())
+        return spec["services"][0]["run_command"]
+
+    def test_the_format_is_set_at_all(self, run_command):
+        assert "--access-logformat" in run_command
+
+    def test_it_logs_the_path_without_the_query_string(self, run_command):
+        assert "%(U)s" in run_command
+
+    @pytest.mark.parametrize("atom", ["%(r)s", "%(q)s"])
+    def test_and_never_the_query_string(self, run_command, atom):
+        assert atom not in run_command

--- a/tests/test_cloud_mode.py
+++ b/tests/test_cloud_mode.py
@@ -1,15 +1,17 @@
 """What `DINKYDASH_MODE=cloud` changes, and what it must not.
 
 Mode gates four things across the product — authentication, billing, where the
-config is stored, and what drives the scheduler. Two of them exist so far, and
-both are here: the storage backend, and the refusal to start on a fallback
-session key. Everything else is asserted to be identical, because a mode check
-anywhere else would mean the change went in the wrong layer.
+config is stored, and what drives the scheduler. Two of them are here: the
+storage backend, and the refusal to start on a fallback session key. The third,
+authentication, has its own file — `tests/test_auth.py`. Everything else is
+asserted to be identical, because a mode check anywhere else would mean the
+change went in the wrong layer.
 """
 
 import pytest
 
 from dinkydash import config as config_module
+from tests.conftest import client_for
 from web import create_app
 
 CONFIG = {
@@ -106,9 +108,14 @@ class TestABoardOutOfPostgres:
 
         monkeypatch.setenv("DINKYDASH_MODE", "cloud")
         monkeypatch.setenv("DINKYDASH_SECRET_KEY", "a-real-one")
-        app = create_app(store)
-        app.config["TESTING"] = True
-        return app.test_client()
+        client = client_for(create_app(store))
+        # These tests are about the rows, not the login. Signing in by hand is
+        # what keeps them that way; `tests/test_auth.py` is where the gate
+        # itself is tested.
+        with client.session_transaction() as stored:
+            stored["user_id"] = 1
+            stored["family_id"] = str(pg_family)
+        return client
 
     def test_the_board_renders_the_stored_brief(self, client):
         page = client.get("/").get_data(as_text=True)

--- a/tests/test_secrets_and_headers.py
+++ b/tests/test_secrets_and_headers.py
@@ -16,6 +16,7 @@ import requests
 
 from dinkydash.calendars import FeedError, fetch_feed, zone
 from dinkydash.store import FileStore
+from tests.conftest import client_for
 from web import create_app
 
 from datetime import date
@@ -36,9 +37,7 @@ people:
 @pytest.fixture
 def client(tmp_path):
     (tmp_path / "config.yaml").write_text(CONFIG)
-    app = create_app(FileStore(tmp_path / "config.yaml"))
-    app.config["TESTING"] = True
-    return app.test_client()
+    return client_for(create_app(FileStore(tmp_path / "config.yaml")))
 
 
 def _raising(exc):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -11,6 +11,7 @@ import pytest
 
 from dinkydash import config as config_module
 from dinkydash.store import FileStore
+from tests.conftest import client_for
 from web import create_app
 
 CONFIG = """\
@@ -43,9 +44,7 @@ def config_path(tmp_path):
 @pytest.fixture
 def client(config_path):
     """The app over that config, handed the store rather than finding one."""
-    app = create_app(FileStore(config_path))
-    app.config["TESTING"] = True
-    return app.test_client()
+    return client_for(create_app(FileStore(config_path)))
 
 
 def people(config_path):

--- a/web/CLAUDE.md
+++ b/web/CLAUDE.md
@@ -16,6 +16,22 @@ branch in `parse_field` and a branch in `web/templates/settings/edit.html`; noth
 `web/templates/settings/home.html`. The list, edit, delete and reorder routes are generic and need
 no changes.
 
+**Every form that writes needs one hidden field.** `<input type="hidden" name="csrf_token"
+value="{{ csrf_token() }}">`, right inside the `<form>`. `csrf_token()` is a Jinja global set up by
+`web/session.py`, so no route has to remember to pass anything — but a form without the field is a
+400, in both modes, and `tests/test_auth.py` walks the templates and fails on one. There is
+deliberately no switch to turn the check off; the test client in `tests/conftest.py` fills the field
+in the way a browser does.
+
+**Two chromes, one base.** `settings/base.html` is the phone-shaped shell for everything a person
+signs into — the settings pages and, in cloud mode, `auth/login.html` and `auth/sent.html`. The
+manifest link in its `<head>` is a `{% block manifest %}` so the login page can drop it: the
+manifest route is behind the login, and asking for it from outside would only ever be a redirect.
+
+**`cloud` is the template global for the mode**, not Flask's `config`. The settings pages pass the
+*family's* config dict under that name and shadow the app's, which is why `create_app` sets a
+separate `cloud` boolean — the Sign out button on the settings home is the first thing to use it.
+
 ## The board's layout
 
 **Changing the board layout.** Everything is sized in `rem` off one root value, so check all three

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -1,18 +1,25 @@
 """The Flask app: the board on one route, the settings UI on the rest.
 
-Two modes, and mode gates exactly two things here — where the config is stored,
-and whether the session key is allowed to be a fallback:
+Two modes, and mode gates four things here — where the config is stored,
+whether the session key is allowed to be a fallback, whether there is a login
+at all, and whether the session cookie is `Secure`:
 
     DINKYDASH_MODE=single   config.yaml, no accounts, no login (the default)
-    DINKYDASH_MODE=cloud    Postgres, and a real secret key or it will not start
+    DINKYDASH_MODE=cloud    Postgres, magic links, and a real secret key or it
+                            will not start
 
 Self-hosted mode has no accounts and no login — it serves one family on a home
 network. Anyone who can reach the port can edit the config, which is the same
 trust model as the config file it writes. Cloud mode cannot inherit that: there
-the session *is* the authentication.
+the session *is* the authentication, so `web/routes/auth.py` is registered and
+`/settings` is behind it.
 
-Everything below `create_app` is mode-blind. The routes take a store out of
-`app.config` and never learn which one they were given.
+`Secure` on the cookie is the fourth gate and the only one that is not a
+feature: a Pi serves plain HTTP on a LAN, and a `Secure` cookie is never sent
+over it. CSRF, by contrast, is on in **both** modes — see `web/session.py`.
+
+Everything else below `create_app` is mode-blind. The routes take a store out
+of `app.config` and never learn which one they were given.
 """
 
 import os
@@ -39,12 +46,41 @@ def create_app(store=None):
     # told what is behind it. Cloud mode hands in a different store and nothing
     # below this line changes (PLAN.md decision 10).
     app.config["STORE"] = store or _default_store(app.config["MODE"])
+    # The connection pool, for the two things that are not one family's rows:
+    # signing somebody in, and the login-token sweep. Taken off the store
+    # rather than built again, so a test that hands in a `PostgresStore` gets a
+    # working login with no second piece of wiring. `FileStore` has no pool,
+    # and single mode never asks for one.
+    app.config["POOL"] = getattr(app.config["STORE"], "pool", None)
+
+    # The hostname this board answers on, for the one URL that has to be built
+    # outside a browser: the sign-in link in an email. **Not `request.host`**,
+    # which is the `Host` header and is written by whoever is calling — an
+    # attacker who could set it would have a victim's link mailed to their own
+    # server. `wsgi.py` refusing to route an unknown host closes that too, but
+    # a credential should not depend on a rule in another file.
+    app.config["APP_HOST"] = os.environ.get("DINKYDASH_APP_HOST", "").strip()
+
+    # The templates need to know the mode too, and they cannot ask Flask's own
+    # `config` for it: the settings pages pass the *family's* config dict under
+    # that name and shadow it.
+    app.jinja_env.globals["cloud"] = app.config["MODE"] == CLOUD
+
+    from .session import configure as configure_session
+    configure_session(app)
 
     from .routes.board import bp as board_bp
     from .routes.settings import bp as settings_bp
 
     app.register_blueprint(board_bp)
     app.register_blueprint(settings_bp, url_prefix="/settings")
+
+    if app.config["MODE"] == CLOUD:
+        # Not registered in single mode, so `/login` is a 404 there rather than
+        # a page that exists and refuses. One family on their own network has
+        # nobody to sign in.
+        from .routes.auth import bp as auth_bp
+        app.register_blueprint(auth_bp)
 
     @app.after_request
     def no_referrer(response):

--- a/web/ratelimit.py
+++ b/web/ratelimit.py
@@ -1,0 +1,122 @@
+"""A counter of recent requests, per key, in this process and nowhere else.
+
+The login request endpoint is limited twice, and the two halves are limited in
+different places on purpose:
+
+    per email address   `accounts.issue_link`, counted in Postgres, so it holds
+                        across every web instance and survives a redeploy
+    per client IP       here, in memory, because the alternative is a database
+                        write on every unauthenticated request — which is
+                        itself something to flood
+
+**This is a spend control as much as a security one.** Every request that gets
+through sends an email on the SendGrid account KeepTheScore also sends from,
+and a bounce there costs a sender reputation that is not only ours.
+
+**It counts per process.** The app runs `gunicorn --workers 2`, so the real
+ceiling is twice what is written below, and a redeploy resets it. That is
+accepted rather than overlooked: the number is chosen to be a bound on abuse,
+not a precise quota, and PLAN.md phase 2's global spend breaker is what
+actually stops a bill running away.
+"""
+
+import ipaddress
+import threading
+import time
+from collections import OrderedDict, deque
+
+# How many distinct keys are tracked before the oldest are forgotten. A flood
+# wide enough to need more than this is a botnet rather than a nuisance, and
+# forgetting is the right failure: a rate limiter that starts refusing everyone
+# has turned an abusive account into an outage for every family.
+MOST_KEYS = 10_000
+
+
+class Limiter:
+    """At most `most` events per `per` seconds, for each key.
+
+    Thread-safe, because the service runs `--threads 4` and two requests from
+    one address really do arrive at once.
+    """
+
+    def __init__(self, most, per, most_keys=MOST_KEYS):
+        self.most = most
+        self.per = per
+        self.most_keys = most_keys
+        self._seen = OrderedDict()
+        self._lock = threading.Lock()
+
+    def allow(self, key, now=None):
+        """Record one event and say whether it was within the limit."""
+        if not key:
+            return True
+        now = time.monotonic() if now is None else now
+        with self._lock:
+            hits = self._seen.get(key)
+            if hits is None:
+                hits = self._seen[key] = deque()
+            self._seen.move_to_end(key)
+
+            cutoff = now - self.per
+            while hits and hits[0] <= cutoff:
+                hits.popleft()
+
+            if len(hits) >= self.most:
+                return False
+            hits.append(now)
+            self._forget_the_oldest()
+            return True
+
+    def _forget_the_oldest(self):
+        """Keep the map bounded. Called with the lock held."""
+        while len(self._seen) > self.most_keys:
+            self._seen.popitem(last=False)
+
+
+def client_ip(request):
+    """The address the request came from, as far as it can be known.
+
+    **Read `X-Forwarded-For` from the right, not the left.** A proxy appends
+    the address it saw, so entries near the end were written by our own
+    infrastructure and entries near the front are whatever the caller sent.
+    Trusting the leftmost — which is the obvious reading, and the wrong one —
+    would let one script claim a thousand addresses and walk straight past the
+    limit above.
+
+    **Skipping private addresses on the way is what makes it safe either way.**
+    If App Platform ever puts a second hop in front of the container, the last
+    entry becomes an internal `10.x` and every family in the world would share
+    one bucket — twenty sign-ins an hour, globally, and it would look like a
+    mail problem rather than a rate limit. An internal hop is always a private
+    address and a real client on the internet never is, so the first public
+    address from the right is the client under either arrangement.
+
+    Falls back to the socket address, which is what a Pi and a test see.
+    """
+    forwarded = request.headers.get("X-Forwarded-For", "")
+    hops = [hop.strip() for hop in forwarded.split(",") if hop.strip()]
+    for hop in reversed(hops):
+        if _is_public(hop):
+            return hop
+    # Everything was private or unparseable: local development, or a proxy
+    # arrangement nobody here anticipated. The rightmost is still the closest
+    # thing to the truth, and being over-strict is the safe direction.
+    if hops:
+        return hops[-1]
+    return request.remote_addr or ""
+
+
+def _is_public(address):
+    """Could this be a real client on the internet?
+
+    Note for anyone writing a test against this: `is_private` is true for the
+    documentation ranges too — `192.0.2.0/24`, `198.51.100.0/24` and
+    `203.0.113.0/24`, the ones examples are supposed to use. A test written
+    with those goes down the fallback branch above and proves nothing.
+    """
+    try:
+        parsed = ipaddress.ip_address(address)
+    except ValueError:
+        return False
+    return not (parsed.is_private or parsed.is_loopback or parsed.is_reserved
+                or parsed.is_link_local or parsed.is_unspecified)

--- a/web/routes/auth.py
+++ b/web/routes/auth.py
@@ -1,0 +1,278 @@
+"""One email in, one link out, one session. Cloud mode only.
+
+    GET  /login          ask for an email address
+    POST /login          send a link, and always say the same thing
+    GET  /login/link     spend the token, start the session, go to the settings
+    POST /logout         throw the session away
+
+Registered only when `DINKYDASH_MODE=cloud`. Self-hosted has no accounts by
+design — one family on their own network, and the same trust model as the
+config file the settings UI writes — so in single mode these routes do not
+exist rather than existing and refusing.
+
+**Answer identically whether or not the address has an account.** "No account
+with that address" is an enumeration oracle against a product whose users are
+families, and it would be one whichever way it was worded. So there is one
+message, and it is sent for an unknown address, a known one, a rate-limited one
+and a failed send alike.
+
+**A login link in a log is a login in a log**, and the app runs `gunicorn
+--access-logfile -`, which writes every request line to the platform's log.
+Three things keep the token out of it, and none of them is decoration:
+
+* **the token rides in the query string, not the path.** Gunicorn's `%(U)s` is
+  the path *without* one, so the access log format in `.do/app.yaml` is built
+  from it. `tests/test_auth.py` fails if that line grows a `%(r)s` or a
+  `%(q)s` back;
+* **`NoTokens` below scrubs `?t=` out of both request logs anyway**, because
+  the development server has no format to configure and `deploy_on_push` does
+  not apply the committed spec;
+* **`Referrer-Policy: no-referrer` on every response** (`web/__init__.py`),
+  which stops a browser handing the whole URL to the next site.
+
+What none of that reaches is DigitalOcean's own edge, whose logs we do not
+format. So the token's last defence is the one it was always going to be: it
+works once, and for fifteen minutes.
+
+**Known and not closed: a mail scanner can burn a link.** A GET spends the
+token, so a corporate mail filter that follows links before the person does
+leaves them with a dead one. Single use is worth more than that is worth
+avoiding — two clicks must not both sign in — and the family mail providers
+this launches on do not do it. If it ever bites, the fix is a confirm button
+that POSTs the token, at the cost of a click for everybody.
+"""
+
+import logging
+import re
+
+from flask import (Blueprint, current_app, redirect, render_template, request,
+                   url_for)
+
+from dinkydash import accounts, mail
+from web import ratelimit, session as user_session
+
+log = logging.getLogger(__name__)
+
+bp = Blueprint("auth", __name__)
+
+# A `?t=` in anything being logged, and what to put there instead.
+A_TOKEN = re.compile(r"([?&]t=)[^&\s\"']+")
+REDACTED = r"\1[redacted]"
+
+# The one answer a login request ever gets.
+SAME_ANSWER = ("If that address has an account, a link is on its way. "
+               "It works once, and for fifteen minutes.")
+
+# What a token that is expired, spent or invented all get.
+DEAD_LINK = ("That link no longer works — it has either been used already or "
+             "expired. Ask for a new one.")
+
+# Per client IP, per hour, in this process. Generous enough that a family
+# behind one address can all get in; small enough that a script cannot spend
+# our SendGrid quota. The per-address half of the limit is in Postgres, in
+# `accounts.issue_link`, where it holds across instances.
+MOST_PER_IP = 20
+PER_SECONDS = 3600
+
+SUBJECT = "Your DinkyDash sign-in link"
+
+
+# The two loggers that write a request line: Flask's development server, and
+# gunicorn's access log. Both get the filter below.
+REQUEST_LOGGERS = ("werkzeug", "gunicorn.access")
+
+
+class NoTokens(logging.Filter):
+    """Take the token out of anything a server writes about a request.
+
+    Belt to the access log format's braces, and it exists because both halves
+    of that format can be missing:
+
+    * **Flask's own development server logs the whole request line**, and no
+      `--access-logformat` reaches it. A developer running cloud mode locally
+      watches sign-in links scroll past their terminal. Observed, not imagined,
+      which is how this came to be written.
+    * **`deploy_on_push` does not apply the committed app spec** — it rebuilds
+      the components that already exist (doc/operations.md). So a commit that
+      changes the format in `.do/app.yaml` and is merged without somebody
+      running `doctl apps update` leaves production on gunicorn's default
+      `%(r)s`, which is the full request line. This filter is what makes that
+      window safe rather than silent.
+
+    A filter rather than a formatter, because it has to reach the message
+    whatever handler eventually prints it, and gunicorn's message is only
+    assembled when the record is formatted.
+    """
+
+    def filter(self, record):
+        message = record.getMessage()
+        if "t=" in message:
+            record.msg = A_TOKEN.sub(REDACTED, message)
+            record.args = ()
+        return True
+
+
+def quieten_the_request_log():
+    """Attach the filter above to both request loggers, once each."""
+    for name in REQUEST_LOGGERS:
+        logger = logging.getLogger(name)
+        if not any(isinstance(f, NoTokens) for f in logger.filters):
+            logger.addFilter(NoTokens())
+
+
+@bp.record_once
+def _quieten(state):
+    quieten_the_request_log()
+
+
+@bp.record_once
+def _build_the_limiter(state):
+    """One limiter per app, rather than one per process.
+
+    A module-level counter would be shared by every app built in a process,
+    which is fine in production and wrong in a test suite that builds several.
+    """
+    state.app.config.setdefault(
+        "LOGIN_LIMITER", ratelimit.Limiter(MOST_PER_IP, PER_SECONDS))
+
+
+def _pool():
+    pool = current_app.config.get("POOL")
+    if pool is None:
+        raise RuntimeError("Cloud mode needs a database to sign anybody in.")
+    return pool
+
+
+@bp.route("/login", methods=["GET", "POST"])
+def login():
+    if user_session.signed_in():
+        return redirect(url_for("settings.home"))
+    if request.method == "GET":
+        return render_template("auth/login.html")
+
+    address = request.form.get("email", "")
+    if "@" not in address:
+        # The one thing worth saying back, and it says nothing about accounts:
+        # this is about what was typed, not about who exists.
+        return render_template("auth/login.html", email=address,
+                               problem="That does not look like an email address.")
+
+    _send_a_link(address)
+    return render_template("auth/sent.html", message=SAME_ANSWER)
+
+
+def _send_a_link(address):
+    """Do whatever there is to do, and tell the caller nothing about it.
+
+    Every branch below returns the same None, and the page above is the same
+    page, because each of them is something an attacker would otherwise learn:
+    whether the address exists, whether it has asked recently, and whether our
+    mail provider is up.
+
+    **Known and not closed: this takes longer when the address exists**, by
+    roughly the time SendGrid takes to answer. Somebody timing the two could
+    tell them apart. Closing it means sending off the request thread, which is
+    a background worker's job rather than a login route's, and the enumeration
+    it would buy is a list of addresses somebody already had.
+    """
+    limiter = current_app.config["LOGIN_LIMITER"]
+    if not limiter.allow(ratelimit.client_ip(request)):
+        # The caller's address, never the one they typed. Which addresses were
+        # asked about is the thing this endpoint exists not to say.
+        log.warning("A sign-in request was rate-limited by caller address.")
+        return
+
+    pool = _pool()
+    user = accounts.user_for(pool, address)
+    if user is None:
+        return
+
+    token = accounts.issue_link(pool, user[0])
+    if token is None:
+        return
+
+    link = _link_for(token)
+    try:
+        mail.send(accounts.normalise(address), SUBJECT,
+                  _text(link), html=_html(link))
+    except mail.MailError as exc:
+        # `mail` messages carry no address, no key and no body, and this one
+        # must not add the link back. A failed send is a failed login, and the
+        # person will ask again.
+        log.warning("A sign-in link did not go out: %s", exc)
+
+
+def _link_for(token):
+    """The sign-in URL, built from configuration rather than from the request.
+
+    Two things here are deliberate and neither is cosmetic.
+
+    **The host is `APP_HOST`, not `request.host`.** `request.host` is the
+    `Host` header, which the caller writes. Building the link from it would let
+    somebody POST this form with a victim's address and a `Host` of their own,
+    and have a working token mailed to the victim pointing at their server.
+    `wsgi.py` already refuses to route an unknown host to this app, so the
+    attack does not land today — but a bearer credential should not rely on a
+    rule in a different file, and this app is also runnable on its own.
+
+    **The scheme is always https.** App Platform terminates TLS, so the request
+    that reaches Flask is plain HTTP and a link built from it would put the
+    credential on the wire in clear.
+
+    Falls back to `request.host` when `APP_HOST` is unset, which is local
+    development and the tests. Cloud mode sets it in `.do/app.yaml`.
+    """
+    host = current_app.config.get("APP_HOST") or request.host
+    return f"https://{host}{url_for('auth.landing', t=token)}"
+
+
+@bp.route("/login/link")
+def landing():
+    """Spend the token and start the session.
+
+    Nothing here distinguishes expired from spent from never-issued, because
+    `consume_link` does not either — one answer, one page.
+    """
+    user = accounts.consume_link(_pool(), request.args.get("t"))
+    if user is None:
+        return render_template("auth/login.html", problem=DEAD_LINK)
+    user_session.sign_in(user[0], user[1])
+    return redirect(url_for("settings.home"))
+
+
+@bp.route("/logout", methods=["POST"])
+def logout():
+    user_session.sign_out()
+    return redirect(url_for("auth.login"))
+
+
+def _text(link):
+    return f"""\
+Here is your link to sign in to DinkyDash:
+
+{link}
+
+It works once, and for fifteen minutes.
+
+If you did not ask for this, you can ignore it. Nobody can sign in without
+the link, and it stops working on its own.
+
+- DinkyDash
+https://dinkydash.co
+"""
+
+
+def _html(link):
+    """Deliberately plain. No images, no tracking pixel, no third-party CSS.
+
+    A login email that loads anything from anywhere else hands the fact of the
+    login, and often the URL, to whoever serves it.
+    """
+    return f"""\
+<p>Here is your link to sign in to DinkyDash:</p>
+<p><a href="{link}">Sign in to DinkyDash</a></p>
+<p>It works once, and for fifteen minutes.</p>
+<p>If you did not ask for this, you can ignore it. Nobody can sign in without
+the link, and it stops working on its own.</p>
+<p>— DinkyDash</p>
+"""

--- a/web/routes/settings.py
+++ b/web/routes/settings.py
@@ -22,10 +22,23 @@ from dinkydash.context import compute_birthday_info, upcoming_for
 from dinkydash.runner import forget_calendar, refresh_calendars
 from dinkydash.runner import run as run_generation
 from web import manifest as manifest_module
+from web.session import guard
 
 log = logging.getLogger(__name__)
 
 bp = Blueprint("settings", __name__)
+
+
+@bp.before_request
+def _needs_a_session():
+    """Cloud mode: everything under /settings is behind a magic link.
+
+    `guard()` reads the mode off `current_app` rather than being registered
+    conditionally, because this blueprint object is shared by every app built
+    in a process — attaching a cloud-mode hook to it would follow the next
+    single-mode app that imported it.
+    """
+    return guard()
 
 
 # Each field is (name, label, kind, required, help). `kind` decides both the

--- a/web/session.py
+++ b/web/session.py
@@ -1,0 +1,150 @@
+"""What the session cookie carries, and what it has to prove.
+
+Two things live in that cookie and both are authentication:
+
+    who is signed in     `user_id` and `family_id`, set by a magic link
+    a CSRF token         proof that a form that writes came from a page we sent
+
+Flask signs the cookie, it does not encrypt it. So what goes in is what we are
+happy for the holder to read: two ids, and no email address. In cloud mode the
+signature *is* the login, which is why `create_app` refuses to start on the
+self-hosted fallback key.
+
+**The cookie flags are stated, not left to their defaults.** `HttpOnly` is
+Flask's default and `SameSite` is not; a flag nobody writes down is a flag
+nobody notices when a default moves under it.
+
+**`Secure` is the one thing here that mode gates.** A Raspberry Pi serves plain
+HTTP on a home network, and a `Secure` cookie is never sent over it — the
+settings UI would lose every flash message, and every CSRF token with them.
+Cloud mode is HTTPS only and sets it.
+
+**CSRF is on in both modes**, and that is deliberate. Self-hosted has no
+accounts, but it does sit on a home network with a guessable address: a page
+in another tab can POST to `http://raspberrypi.local:5123/settings/...` and
+edit somebody's board. It costs a hidden field, and running the same code in
+both modes is what stops it being a check nobody exercises.
+"""
+
+import hmac
+import secrets
+from datetime import timedelta
+
+from flask import abort, current_app, redirect, request, session, url_for
+
+# What the session holds when somebody is signed in.
+USER_ID = "user_id"
+FAMILY_ID = "family_id"
+
+# The CSRF token: where it is kept, and what the form calls it.
+CSRF_KEY = "csrf"
+CSRF_FIELD = "csrf_token"
+
+# Everything that must not change anything. RFC 9110's safe methods.
+SAFE_METHODS = frozenset({"GET", "HEAD", "OPTIONS", "TRACE"})
+
+# How long a sign-in lasts. A board on a wall is furniture and its owner should
+# not be signed out of the settings for it every fortnight.
+SESSION_LIFETIME = timedelta(days=30)
+
+
+def configure(app):
+    """Cookie flags, the CSRF check, and `csrf_token()` for the templates."""
+    from . import CLOUD
+
+    app.config.update(
+        SESSION_COOKIE_HTTPONLY=True,
+        SESSION_COOKIE_SAMESITE="Lax",
+        SESSION_COOKIE_SECURE=app.config["MODE"] == CLOUD,
+        PERMANENT_SESSION_LIFETIME=SESSION_LIFETIME,
+    )
+    app.jinja_env.globals["csrf_token"] = csrf_token
+    app.before_request(check_csrf)
+
+
+# -- who is signed in -------------------------------------------------------
+
+def sign_in(user_id, family_id):
+    """Start a session for that user, throwing away whatever was there.
+
+    `session.clear()` first is the session-fixation defence: an attacker who
+    got a victim to carry their cookie must not still be holding it after the
+    victim signs in.
+    """
+    session.clear()
+    session.permanent = True
+    session[USER_ID] = user_id
+    session[FAMILY_ID] = str(family_id)
+
+
+def sign_out():
+    session.clear()
+
+
+def signed_in():
+    return bool(session.get(USER_ID))
+
+
+def guard():
+    """Cloud mode: no session, no settings. Returns a redirect, or None.
+
+    This is authentication and not yet authorisation. Cloud mode still serves
+    the one family in `DINKYDASH_FAMILY_ID`; scoping every read and write to
+    the family on the session is its own issue, and is the actual "done when"
+    of PLAN.md phase 1.
+
+    No `next` parameter. A redirect target taken from a URL is an open redirect
+    waiting to be written wrongly, and everything behind this gate is one page
+    away from `/settings/` anyway.
+    """
+    from . import CLOUD
+
+    if current_app.config["MODE"] != CLOUD or signed_in():
+        return None
+    return redirect(url_for("auth.login"))
+
+
+# -- proving a form came from us --------------------------------------------
+
+def csrf_token():
+    """The token for this session, minted on first use.
+
+    A template global, so a form gets it by calling it — there is no route that
+    has to remember to pass it, and therefore no form that quietly loses it.
+    """
+    token = session.get(CSRF_KEY)
+    if not token:
+        token = secrets.token_urlsafe(32)
+        session[CSRF_KEY] = token
+    return token
+
+
+def check_csrf():
+    """Refuse any write that did not carry this session's token.
+
+    Registered as an app-wide `before_request` rather than per blueprint, so a
+    route added later is covered by having been added. `compare_digest` because
+    this is the one comparison in the login path where both sides are known to
+    the attacker's browser and a timing difference would be real.
+
+    **There is no switch to turn this off**, and that is on purpose: a
+    `CSRF_ENABLED` flag is a flag somebody eventually sets wrongly in
+    production, and it would leave the accepting path untested everywhere else.
+    The test client in `tests/conftest.py` carries the token the way a browser
+    does, so every form POST in the suite goes through this function rather
+    than around it. A route that genuinely cannot carry one — a Stripe webhook
+    is the coming example — is exempted here, by path, in the open.
+    """
+    if request.method in SAFE_METHODS:
+        return None
+    held = session.get(CSRF_KEY) or ""
+    sent = request.form.get(CSRF_FIELD) or request.headers.get("X-CSRF-Token") or ""
+    # Compared as bytes, and not for tidiness: `compare_digest` raises
+    # `TypeError` on a `str` with a non-ASCII character in it, and the string
+    # being compared came out of a form somebody else filled in. A 500 where a
+    # 400 belongs is a bug anyone could trigger with one emoji.
+    if not held or not hmac.compare_digest(sent.encode("utf-8"), held.encode("utf-8")):
+        # 400 rather than 403: the usual cause is a page left open until the
+        # session behind it went, and the fix is to reload it.
+        abort(400, "That page was out of date. Go back, reload it and try again.")
+    return None

--- a/web/templates/auth/login.html
+++ b/web/templates/auth/login.html
@@ -1,0 +1,39 @@
+{# The only page cloud mode serves to somebody with no session. One field, one
+   button, and the same answer whatever is typed into it. #}
+{% extends "settings/base.html" %}
+{% block title %}Sign in{% endblock %}
+{% block manifest %}{% endblock %}
+
+{% block appbar %}
+<h1 style="padding-left:0.25rem;color:var(--accent);font-size:1.15rem;">DinkyDash</h1>
+{% endblock %}
+
+{% block content %}
+{% if problem %}
+<div class="flash error">{{ problem }}</div>
+{% endif %}
+
+<div class="card pad" style="display:flex;flex-direction:column;gap:0.875rem;">
+    <div>
+        <div style="font-size:1.125rem;font-weight:800;">Sign in</div>
+        <div class="hint" style="margin-top:0.1875rem;">
+            Type the address your board is under. We send a link that signs you in — there
+            is no password to remember and none to lose.
+        </div>
+    </div>
+    <form method="post" action="{{ url_for('auth.login') }}"
+          style="display:flex;flex-direction:column;gap:0.875rem;">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+        <div class="field">
+            <label for="email">Email address</label>
+            {# `type=email` so a phone offers the right keyboard, and so the
+               base stylesheet's `.field input` rules reach it. The check that
+               matters is on the server. #}
+            <input type="email" id="email" name="email" value="{{ email or '' }}"
+                   autocomplete="email" autocapitalize="off" autocorrect="off"
+                   spellcheck="false" inputmode="email" required>
+        </div>
+        <button class="btn" type="submit">Email me a link</button>
+    </form>
+</div>
+{% endblock %}

--- a/web/templates/auth/sent.html
+++ b/web/templates/auth/sent.html
@@ -1,0 +1,22 @@
+{# What every login request gets, whether or not the address has an account.
+   Wording it any other way would say who has one. #}
+{% extends "settings/base.html" %}
+{% block title %}Check your email{% endblock %}
+{% block manifest %}{% endblock %}
+
+{% block appbar %}
+<h1 style="padding-left:0.25rem;color:var(--accent);font-size:1.15rem;">DinkyDash</h1>
+{% endblock %}
+
+{% block content %}
+<div class="card pad" style="display:flex;flex-direction:column;gap:0.875rem;">
+    <div>
+        <div style="font-size:1.125rem;font-weight:800;">Check your email</div>
+        <div class="hint" style="margin-top:0.1875rem;">{{ message }}</div>
+    </div>
+    <div class="note-box">
+        Nothing arrived? Look in the spam folder, then
+        <a href="{{ url_for('auth.login') }}">ask for another link</a>.
+    </div>
+</div>
+{% endblock %}

--- a/web/templates/settings/base.html
+++ b/web/templates/settings/base.html
@@ -7,8 +7,10 @@
     <meta name="robots" content="noindex, nofollow">
     <link rel="icon" href="{{ url_for('static', filename='favicon.svg') }}" type="image/svg+xml">
     <!-- Saved to a phone's home screen this opens like an app. The manifest is
-         what Android reads; iOS ignores it and goes by the four lines below. -->
-    <link rel="manifest" href="{{ url_for('settings.manifest') }}">
+         what Android reads; iOS ignores it and goes by the four lines below.
+         A block, because the login page is behind no session and the manifest
+         is: fetching it there would only ever be a redirect. -->
+    {% block manifest %}<link rel="manifest" href="{{ url_for('settings.manifest') }}">{% endblock %}
     <link rel="apple-touch-icon" href="{{ url_for('static', filename='apple-touch-icon.png') }}">
     <meta name="apple-mobile-web-app-title" content="DinkyDash">
     <meta name="apple-mobile-web-app-capable" content="yes">
@@ -117,7 +119,8 @@
         .field { display: flex; flex-direction: column; gap: 0.375rem; }
         .field > label { font-size: 0.6875rem; font-weight: 800; letter-spacing: 0.07em; text-transform: uppercase; color: var(--text-muted); }
         .field input[type=text], .field input[type=url], .field input[type=date],
-        .field input[type=time], .field select, .field textarea {
+        .field input[type=time], .field input[type=email],
+        .field select, .field textarea {
             width: 100%; min-height: 3rem; padding: 0.75rem 0.875rem;
             border: 1.5px solid var(--border); border-radius: 0.75rem;
             background: var(--surface); color: var(--text);

--- a/web/templates/settings/edit.html
+++ b/web/templates/settings/edit.html
@@ -18,6 +18,7 @@
 {% endif %}
 
 <form id="edit-form" method="post" class="card pad" style="display:flex;flex-direction:column;gap:1rem;">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
     {% for name, label, kind, required, help in section.fields %}
     <div class="field">
         {% if kind != 'checkbox' %}<label for="f-{{ name }}">{{ label }}</label>{% endif %}
@@ -114,6 +115,7 @@
 {% if not is_new %}
 <form method="post" action="{{ url_for('settings.section_delete', section_name=section_name, item_id=item_id) }}"
       onsubmit="return confirm('Remove this for good?');">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
     <button class="btn danger" type="submit">Remove this {{ section.singular }}</button>
 </form>
 {% endif %}

--- a/web/templates/settings/home.html
+++ b/web/templates/settings/home.html
@@ -20,11 +20,13 @@
         {# The cheap half first: fetching the calendars costs a few requests,
            while rewriting the line costs a call to Claude. #}
         <form class="inline-form" method="post" action="{{ url_for('settings.refresh_now') }}">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
             <button class="btn" type="submit">{{ icons.refresh() }} Refresh calendars</button>
         </form>
         <div style="display:flex;gap:0.625rem;">
             <a class="btn outline" style="flex:1;" href="{{ url_for('board.index') }}">{{ icons.screen() }} View board</a>
             <form class="inline-form" method="post" action="{{ url_for('settings.generate_now') }}" style="flex:1;">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                 <button class="btn outline" type="submit">Rewrite now</button>
             </form>
         </div>
@@ -105,6 +107,14 @@
         </a>
     </div>
 </div>
+
+{# Only hosted. Self-hosted has no accounts, so there is nothing to sign out of. #}
+{% if cloud %}
+<form method="post" action="{{ url_for('auth.logout') }}">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+    <button class="btn outline" type="submit">Sign out</button>
+</form>
+{% endif %}
 
 {# Hidden until the script below decides it is worth showing: not already saved,
    and not waved away before. #}

--- a/web/templates/settings/list.html
+++ b/web/templates/settings/list.html
@@ -50,9 +50,11 @@
 
         <div class="move">
             <form class="inline-form" method="post" action="{{ url_for('settings.section_move', section_name=section_name, item_id=item.id) }}">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                 <input type="hidden" name="direction" value="up"><button type="submit" title="Move up">&#9650;</button>
             </form>
             <form class="inline-form" method="post" action="{{ url_for('settings.section_move', section_name=section_name, item_id=item.id) }}">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                 <input type="hidden" name="direction" value="down"><button type="submit" title="Move down">&#9660;</button>
             </form>
         </div>

--- a/web/templates/settings/refresh.html
+++ b/web/templates/settings/refresh.html
@@ -16,6 +16,7 @@
 {% endif %}
 
 <form id="refresh-form" method="post" class="card pad" style="display:flex;flex-direction:column;gap:1rem;">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
     <div class="field">
         <label for="refresh_minutes">Fetch the calendars</label>
         <select id="refresh_minutes" name="refresh_minutes">

--- a/web/templates/settings/screen.html
+++ b/web/templates/settings/screen.html
@@ -9,6 +9,7 @@
 
 {% block content %}
 <form method="post">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
     <div class="label">Board colours</div>
     <div style="display:flex;gap:0.625rem;">
         {% for theme in themes %}

--- a/web/templates/settings/system.html
+++ b/web/templates/settings/system.html
@@ -10,6 +10,7 @@
 
 {% block content %}
 <form id="system-form" method="post" class="card pad" style="display:flex;flex-direction:column;gap:1rem;">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
     <div class="field">
         <label for="family_name">Name on the board</label>
         <input type="text" id="family_name" name="family_name" value="{{ config.family_name or '' }}">

--- a/worker/__init__.py
+++ b/worker/__init__.py
@@ -18,6 +18,11 @@ container is what makes "how many web instances" a free decision.
 `generate.tick` is imported from the command-line module on purpose rather than
 copied. It is the shared orchestration over config, store and clock, and
 `tests/test_runner.py` already imports that module the same way.
+
+One thing here is *not* per family: `sweep_logins` deletes expired magic-link
+tokens once a pass. It is here because this is the only process in cloud mode
+with a loop, and doing it on somebody's page load would make one visitor pay
+for everybody's tidying.
 """
 
 import logging
@@ -104,6 +109,27 @@ def tick_all(pool, store_factory=None, tick=None, stopping=None):
     return done
 
 
+def sweep_logins(pool):
+    """Delete login tokens that have expired. Returns how many went.
+
+    Here rather than in `tick_all` because it is not per-family: one statement
+    over one table, once a pass. The web service could do it on a request
+    instead, but a sweep on somebody's page load is a slow page for whoever
+    happens to arrive at the wrong moment.
+
+    Never raises. A table of dead hashes growing for five more minutes is not
+    worth a pass of unwritten boards, and the next pass tries again — which is
+    how the whole tick handles failure already.
+    """
+    from dinkydash import accounts
+
+    try:
+        return accounts.sweep(pool)
+    except Exception:
+        log.exception("The login-token sweep failed; leaving it for the next pass.")
+        return 0
+
+
 def interval():
     """Seconds between passes. A knob for testing, not a per-family setting.
 
@@ -138,8 +164,9 @@ def main():  # pragma: no cover - the loop itself; tick_all is what is tested
     while not stopping:
         started = time.monotonic()
         ticked = tick_all(pool, stopping=stopping)
-        log.info("Pass complete: %s families ticked in %.1fs.",
-                 ticked, time.monotonic() - started)
+        swept = sweep_logins(pool)
+        log.info("Pass complete: %s families ticked in %.1fs; %s dead login "
+                 "token(s) deleted.", ticked, time.monotonic() - started, swept)
 
         # Sleep in slices so SIGTERM is noticed in seconds rather than minutes.
         # App Platform kills a container that ignores it for too long, and


### PR DESCRIPTION
Adds magic-link auth for cloud mode: `dinkydash/accounts.py` (32 bytes from `secrets`, only the SHA-256 stored, fifteen minutes, single use decided by one `UPDATE ... WHERE used_at IS NULL RETURNING`), `web/routes/auth.py` (`/login`, `/login/link`, `/logout`, registered only in cloud mode), `web/session.py` (the cookie, plus a CSRF token on every form that writes — in both modes, with no switch to turn it off), `web/ratelimit.py`, and a login-token sweep on the worker; `/settings` in cloud mode is now behind a session.

Every login request gets the same page whether the address exists, is rate-limited or the send failed, because anything else enumerates accounts and the accounts are families.

**A login link in a log is a login in a log, and it was** — the service runs `gunicorn --access-logfile -`, so the token now rides in the query string (`%(U)s` logs the path without one), `.do/app.yaml` sets that format, and `auth.NoTokens` scrubs `?t=` from both the `werkzeug` and `gunicorn.access` loggers because Flask's dev server has no format to configure and `deploy_on_push` does not apply a changed spec.

Three smaller calls are argued in the commit message: there is no constant-time compare of the login token because the hash is matched inside the atomic UPDATE and there is nowhere to put one; the link's host comes from `DINKYDASH_APP_HOST` rather than the caller's `Host` header; and `X-Forwarded-For` is read from the right, stepping over private hops.

Verified over real HTTP against Postgres — link mailed, session set, second click refused, sign out, a 400 on a form with no token, a redacted request log — and 602 tests pass with a database, 520 with 82 skipped without one; **nobody can sign in yet** (sign-up is a later issue, so the seeded family needs one `INSERT` by hand) and the new access log format needs a `doctl apps update` before it is live, both written down in `doc/operations.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)