### PR TITLE
Serve each family their own rows, and delete the one the environment named (DIN-39)

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -37,6 +37,11 @@ venv/bin/python sample_board.py
 # the same code. The script above prints the exact command with this
 # workspace's port already in it.
 #
+# **Chrome or Firefox, not Safari.** The session cookie is `Secure` in cloud
+# mode, and Safari has no loopback exception for that — it silently drops the
+# cookie over `http://localhost`, so signing in fails and looks like a broken
+# form rather than a cookie policy. `web/CLAUDE.md` has the table.
+#
 # **This talks to the production database.** `DATABASE_URL` in `.env` is the
 # live cluster, so anything saved in /settings edits the real family. Export a
 # different DATABASE_URL before starting to point it somewhere safer — the
@@ -57,6 +62,8 @@ fi
 export DINKYDASH_MODE=cloud
 echo "The board is behind a sign-in. For a link without waiting on email:"
 echo "  venv/bin/python login_link.py you@example.com --base-url http://127.0.0.1:${CONDUCTOR_PORT:-5000}"
+echo "Open it in Chrome or Firefox. Safari will not send a Secure cookie over"
+echo "http://localhost, so signing in there fails and looks like a broken form."
 FLASK_APP=app.py venv/bin/flask run --port ${CONDUCTOR_PORT:-5000} --debug
 """
 default = true

--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -31,6 +31,12 @@ venv/bin/python sample_board.py
 # It refuses to start without a database, and says why. That is the right
 # failure: a fallback would be indistinguishable from success.
 #
+# **It opens on /login, because the board is one family's board and cloud mode
+# reads which family from the session.** `login_link.py` prints a working link
+# without waiting on email — the same token the email would carry, minted by
+# the same code. The script above prints the exact command with this
+# workspace's port already in it.
+#
 # **This talks to the production database.** `DATABASE_URL` in `.env` is the
 # live cluster, so anything saved in /settings edits the real family. Export a
 # different DATABASE_URL before starting to point it somewhere safer — the
@@ -43,12 +49,14 @@ venv/bin/python sample_board.py
 available_in = [ "local" ]
 command = """
 set -a; [ -f .env ] && . ./.env; set +a
-if [ -z "$DATABASE_URL" ] || [ -z "$DINKYDASH_FAMILY_ID" ]; then
-  echo "Cloud mode needs DATABASE_URL and DINKYDASH_FAMILY_ID in .env."
-  echo "They are gitignored, so a new workspace only gets them through Files to copy."
+if [ -z "$DATABASE_URL" ]; then
+  echo "Cloud mode needs DATABASE_URL in .env."
+  echo "It is gitignored, so a new workspace only gets it through Files to copy."
   exit 1
 fi
 export DINKYDASH_MODE=cloud
+echo "The board is behind a sign-in. For a link without waiting on email:"
+echo "  venv/bin/python login_link.py you@example.com --base-url http://127.0.0.1:${CONDUCTOR_PORT:-5000}"
 FLASK_APP=app.py venv/bin/flask run --port ${CONDUCTOR_PORT:-5000} --debug
 """
 default = true

--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -87,11 +87,6 @@ envs:
   - key: DINKYDASH_SECRET_KEY
     scope: RUN_TIME
     type: SECRET
-  # One family until Phase 1 puts the family on the session. The worker does
-  # not read this — it walks every family itself.
-  - key: DINKYDASH_FAMILY_ID
-    scope: RUN_TIME
-    type: SECRET
   # DigitalOcean's pool, transaction mode, port 25061.
   - key: DATABASE_URL
     scope: RUN_TIME

--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -63,6 +63,11 @@ domains:
     type: ALIAS
   # The board. DNS-only in Cloudflare: a proxied CNAME answers as Cloudflare
   # and App Platform's certificate never issues.
+  #
+  # A response from here still carries a `cf-ray`, and that is **not** evidence
+  # the proxy got switched on: App Platform is itself served through
+  # Cloudflare, and its own `.ondigitalocean.app` hostname resolves into
+  # Cloudflare's ranges. Check the zone's `proxied` flag, not the headers.
   - domain: app.dinkydash.co
     type: ALIAS
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,8 +135,14 @@ Self-hosted is one family on their own network and has **no authentication by de
 reaches the port can edit the config, which is the same trust model as the file it writes. Cloud
 mode is a different product on the same code.
 
-- **Every read and write is scoped to a `family_id`.** There is no unscoped query. An id arriving in
-  a URL or a form is a claim, not a fact — check it against the session before it reaches a query.
+- **Every read and write is scoped to a `family_id`, and that id comes from the session.**
+  `web/family.py` builds one `PostgresStore` per request out of it, over a pool built once per
+  process — never one pool per request, because the cluster has 22 connections and a PgBouncer in
+  front. Nothing a caller can send names a family: no path segment, no query parameter, no form
+  field, no header. That is stronger than checking an id, and it is why there is no "the" family
+  anywhere. When a route does one day take a family id — the admin view is the likely first — the
+  check goes in `family.py`, before the store is built, and **a mismatch is a 404 and never a 403**:
+  "forbidden" confirms the row exists, which tells one family that another one does.
 - **`web/__init__.py` falls back to a hardcoded `app.secret_key`.** Harmless with no auth; in cloud
   mode the session *is* the authentication, so cloud mode must refuse to start without a real
   `DINKYDASH_SECRET_KEY`.
@@ -255,7 +261,8 @@ dinkydash/
 └── runner.py          the two halves of the day, reading and writing through a store
 
 web/
-├── __init__.py        create_app()
+├── __init__.py        create_app(): the pool, the mode gates, the blueprints
+├── family.py          which family a request is for, and its store
 ├── session.py         what the cookie carries: who is signed in, and CSRF
 ├── ratelimit.py       a per-key counter, in this process (the per-IP half)
 ├── routes/board.py    the board and the preview harness

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,6 +160,11 @@ mode is a different product on the same code.
   switch to turn it off. A test walks the templates and fails on a form without one.
 - **Screen tokens are bearer credentials.** Rate-limited, `noindex`, no referrer leakage, rotatable,
   and never written to a log or an error page.
+- **The sign-in rate limits are ours, not an edge rule, so that a refusal is a line somebody can
+  read.** That is the trade being made — a Cloudflare rule would be sturdier and invisible. What
+  goes in the line is chosen: the caller's address in full, the *domain* of the address asked about
+  and never the address, and nothing at all for an address with no account. `tests/test_auth.py`
+  asserts each of those, because a log policy nobody tests is a log policy that drifts.
 - **Spend caps are a security control.** The per-family and global breaker (PLAN.md phase 2) is what
   stops a bug or an abusive account becoming an unbounded Anthropic bill.
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -2,13 +2,15 @@
 
 *Last updated: September 8, 2026. Supersedes `HOSTING_ANALYSIS.md` (deleted — it predated both the AI generation feature and the July 2026 calendar-display repositioning, and its recommended stack and data model no longer matched the product).*
 
-*September 8, later still: **magic-link auth is built** (DIN-38). `dinkydash/accounts.py` is the token lifecycle — 32 bytes from `secrets`, only the SHA-256 stored, fifteen minutes, spent by one `UPDATE ... WHERE used_at IS NULL RETURNING`; `web/routes/auth.py` is `/login`, `/login/link` and `/logout`; `web/session.py` is the cookie and a CSRF token on every form that writes, in both modes. `/settings` in cloud mode is behind a session. What is deliberately still missing is the **scoping**: cloud mode still serves `DINKYDASH_FAMILY_ID` rather than the family on the session, which is the actual "done when" of this phase and its own issue. The token rides in the query string rather than the path because the app runs `gunicorn --access-logfile -` and a login link in a log is a login in a log — see the access log format in `.do/app.yaml`, which is now a security control.*
+*September 8, last: **the multi-tenancy is real** (DIN-39). `web/family.py` builds one `PostgresStore` per request from the family on the session, over a pool built once per process; `create_app` holds no store at all in cloud mode, and the environment variable that used to name "the" family is deleted from the code, the app spec and the docs. Nothing a caller can send — path segment, query parameter, form field or header — reaches a query as a family selector, which is a stronger property than checking an id against the session. The ids that do appear in URLs are item ids inside one family's config document, and another family's is not in the list: `tests/test_tenancy.py` walks every section and every write route and asserts a 404, never a 403. **Phase 1's "done when" is met.** `login_link.py` prints a sign-in link without waiting on email, because the preview and the support inbox both need one.*
+
+*September 8, later still: **magic-link auth is built** (DIN-38). `dinkydash/accounts.py` is the token lifecycle — 32 bytes from `secrets`, only the SHA-256 stored, fifteen minutes, spent by one `UPDATE ... WHERE used_at IS NULL RETURNING`; `web/routes/auth.py` is `/login`, `/login/link` and `/logout`; `web/session.py` is the cookie and a CSRF token on every form that writes, in both modes. `/settings` in cloud mode is behind a session. What was deliberately still missing at that point was the **scoping**, which DIN-39 above then did. The token rides in the query string rather than the path because the app runs `gunicorn --access-logfile -` and a login link in a log is a login in a log — see the access log format in `.do/app.yaml`, which is now a security control.*
 
 *September 8, later: **one service, not two.** The board joins the marketing site in the existing `dinkydash-site` app rather than getting its own, because that is how `qrpage.co` and `abc-league` already run in this account — one container, one gunicorn, everything in it. Staging is dropped until there is a paying family to protect. The `worker` is the one genuine addition, because the tick has no lock and two web instances would tick twice. See [Hosting and deployment](#hosting-and-deployment).*
 
 *September 8: the transactional email provider is settled — decision 13, **SendGrid**, on the account KeepTheScore already sends from. The open question is closed. `dinkydash.co` is an authenticated sending domain on that account (DKIM and a monitor-only DMARC record are live in Cloudflare), and this repo has its own send-only API key. What is not built is the sending itself — that arrives with magic links in Phase 1.*
 
-*September 7, later still: the Postgres layer is built (DIN-31) — `migrations/001_initial_schema.sql`, `migrate.py`, `dinkydash/db.py`, `dinkydash/pgstore.py`, and a contract suite that runs the same assertions over both stores in CI. Connection pooling is settled above. What is deliberately still missing is the multi-tenancy: cloud mode serves one family from `DINKYDASH_FAMILY_ID`, because auth and scoping are Phase 1.*
+*September 7, later still: the Postgres layer is built (DIN-31) — `migrations/001_initial_schema.sql`, `migrate.py`, `dinkydash/db.py`, `dinkydash/pgstore.py`, and a contract suite that runs the same assertions over both stores in CI. Connection pooling is settled above. What is deliberately still missing is the multi-tenancy: cloud mode serves one family, named by an environment variable, because auth and scoping are Phase 1.*
 
 *September 7, later: the storage seam is built (DIN-19). `dinkydash/store.py` holds the six operations, `FileStore` is the one implementation, and the runner and both blueprints take a store rather than a path. The seam section below describes what exists; `PostgresStore` is now a constructor argument away.*
 
@@ -685,9 +687,10 @@ missing is the multi-tenant half — a schema, auth, and scoping every read and 
 - [ ] Multi-calendar management: add/label/enable/remove iCal feeds, with live validation on paste
 - [ ] Per-provider help content — Google, iCloud, Outlook each expose iCal URLs differently
 - [ ] Settings: timezone, family name, refresh cadence, screen URL display + rotation, account deletion. `claude_model` hidden in cloud mode.
+- [x] Every read and write scoped to the family on the session; the hardcoded family id deleted *(DIN-39)*
 - [ ] The URL map above: `/` redirects, `/login`, `/s/<token>`
 
-**Done when:** two different families can be configured independently through the UI, and a request carrying the wrong family's id in a URL gets a 404, never a row.
+**Done when:** two different families can be configured independently through the UI, and a request carrying the wrong family's id in a URL gets a 404, never a row. **Met by DIN-39**, and asserted in `tests/test_tenancy.py`.
 
 ### Phase 2 — Generation pipeline
 

--- a/dinkydash/CLAUDE.md
+++ b/dinkydash/CLAUDE.md
@@ -50,8 +50,15 @@ Four rules keep it a seam rather than a name:
   green suite — and CI runs the suite twice, once with the variable and once without.
 
 **Every `PostgresStore` query is scoped to `self.family_id`.** There is no unscoped read and no
-unscoped write in that file, and there must never be one. An id arriving in a URL is a claim, not a
-fact, and the place to check it is before it reaches a store.
+unscoped write in that file, and there must never be one. That only protects anybody if the id the
+store was *built* with is trustworthy, which is `web/family.py`'s job: in cloud mode it comes from
+the session and from nowhere else, and one store is built per request. `PostgresStore` is two
+attributes round a pool and costs nothing to build; the pool is process-wide and must stay that way.
+
+`load_config` raises **`NoSuchFamily`**, a named `LookupError`, because the web app handles it — a
+thirty-day session can outlive the account it names, and that should sign the holder out rather than
+500. Catching the bare parent would swallow `KeyError` and `IndexError` too, which is to say every
+real bug, and send it to the login page.
 
 Two things are unscoped, both deliberately outside the store rather than weakening it:
 `worker.family_ids`, whose whole job is to walk every family, and `dinkydash/accounts.py`, which

--- a/dinkydash/accounts.py
+++ b/dinkydash/accounts.py
@@ -56,8 +56,14 @@ TOKEN_BYTES = 32
 
 # The per-person rate limit, and it is a spend control as much as a security
 # one: every request sends an email on an account whose sender reputation is
-# shared with KeepTheScore. Counted as "unexpired links", so it is exactly
-# "at most three live links at a time" and the sweep below cannot affect it.
+# shared with KeepTheScore.
+#
+# Counted as "unexpired links", which has two consequences worth stating
+# because both have been misread:
+#
+# * the sweep cannot affect it — a row it deletes is one this no longer counts;
+# * **a used link still counts.** Spending one does not free a slot. The limit
+#   is on emails sent in a window, and the email went whatever happened next.
 MOST_LIVE_LINKS = 3
 
 # Anything longer than a real token is not one, and there is no reason to hash

--- a/dinkydash/pgstore.py
+++ b/dinkydash/pgstore.py
@@ -48,6 +48,17 @@ GENERATION_COLUMNS = ("generated_for_date", "generated_at", "model",
 BRIEF_KEYS = ("headline", "note", "note_kind")
 
 
+class NoSuchFamily(LookupError):
+    """That family id has no row.
+
+    Named rather than a bare `LookupError` because the web app handles it: a
+    session naming a family that has since been deleted should sign the holder
+    out, not 500. `KeyError` and `IndexError` are `LookupError`s too, and an
+    error handler catching the parent would swallow real bugs and send them to
+    the login page.
+    """
+
+
 class PostgresStore:
     """One family, as rows. Construct one per request or per worker iteration."""
 
@@ -62,7 +73,7 @@ class PostgresStore:
             cur.execute("SELECT config FROM families WHERE id = %s", (self.family_id,))
             row = cur.fetchone()
         if row is None:
-            raise LookupError(f"No family {self.family_id}")
+            raise NoSuchFamily(f"No family {self.family_id}")
         return config_module.with_defaults(dict(row[0] or {}))
 
     def save_config(self, config):

--- a/doc/operations.md
+++ b/doc/operations.md
@@ -161,13 +161,23 @@ working link without waiting on email. Same token, same fifteen minutes, same si
 per-address limit — the only thing it skips is SendGrid. **What it prints is a credential**, so it
 does not go in an issue or a screenshot. It does not create accounts; the `INSERT` above still does.
 
-**Unverified, and worth an eye.** The access log shows `%(h)s` as an internal `10.244.x` address
-that differs between requests, so App Platform is putting a hop in front of the container.
-`web/ratelimit.client_ip` reads `X-Forwarded-For` from the right and steps over private addresses,
-which is correct *if* the platform sets that header. Nothing has confirmed it does. If it does not,
-the per-caller rate limit is keyed on a value that changes every request and therefore never fires —
-the per-address limit in Postgres would still hold, so this is a weakened control rather than an
-open door.
+**The caller's address is in `DO-Connecting-IP`, and `X-Forwarded-For` is a trap here.** The access
+log showed `%(h)s` as an internal `10.244.x` that differs between requests, which prompted a look.
+DigitalOcean's own documentation: *"App Platform adds a `do-connecting-ip` HTTP header that contains
+the client's IP address... While the `x-forwarded-for` header is often used for this purpose, App
+Platform uses this header for the IP address of the DigitalOcean ingress server that forwarded the
+request to your app."* So the obvious code is wrong in a quiet way — a per-caller limit keyed on
+`X-Forwarded-For` is keyed on DigitalOcean, and every family in the world shares one bucket.
+`web/ratelimit.client_ip` reads `DO-Connecting-IP` first, `CF-Connecting-IP` second, and returns
+**no key at all** rather than falling back to something shared: an unidentifiable caller should mean
+"this limit does not fire", not "everybody is limited together".
+
+**`app.dinkydash.co` answers with a `cf-ray`, and that is not our Cloudflare.** Our zone is
+DNS-only for every record — checked against the API, not assumed. **App Platform itself is served
+through Cloudflare**: the CNAME target `clownfish-app-7xt89.ondigitalocean.app` resolves to
+`162.159.140.98` and `172.66.0.96`, both in Cloudflare's published ranges, and the DigitalOcean
+hostname carries a `cf-ray` too. So a Cloudflare header on a response says nothing about our proxy
+setting, and `CF-Connecting-IP` may well be present without us having put it there.
 
 
 ## GitHub's own secret scanning

--- a/doc/operations.md
+++ b/doc/operations.md
@@ -80,9 +80,10 @@ header. `dinkydash.co` is the marketing site; `app.dinkydash.co` is the board, r
 Postgres in cloud mode. Both verified live over TLS, and the `PRE_DEPLOY` migration job reported
 `Schema is up to date`.
 
-One family exists, seeded from `config.example.yaml` — invented people, no calendar URL — and
-`DINKYDASH_FAMILY_ID` points at it. Nothing outside `tests/conftest.py` creates a family, so that
-was done by hand and will be until the signup flow exists.
+One family exists, seeded from `config.example.yaml` — invented people, no calendar URL — and an
+app-level environment variable pointed at it. Nothing outside `tests/conftest.py` creates a family,
+so that was done by hand and will be until the signup flow exists. (That variable is gone as of
+DIN-39, below; the family it named is still the only one.)
 
 **Omitting the value of a `type: SECRET` env var does NOT work, and the way it fails is the
 problem.** The earlier note here said it did, on the strength of a canary test: a throwaway
@@ -121,7 +122,7 @@ is a later issue — so the one family seeded from `config.example.yaml` needs a
 before anybody can sign in:
 
 ```sql
-INSERT INTO users (family_id, email) VALUES ('<DINKYDASH_FAMILY_ID>', 'you@example.com');
+INSERT INTO users (family_id, email) VALUES ('<the family uuid>', 'you@example.com');
 ```
 
 One outstanding action, and it is a security one. **`.do/app.yaml` now sets a gunicorn
@@ -141,6 +142,32 @@ them.
 per-address rate limit is three live links; the per-caller-address one is twenty an hour **per
 process**, and the service runs `--workers 2`, so the real ceiling is forty and a redeploy resets
 it. That is a bound on abuse, not a quota.
+
+
+## Multi-tenancy, 8 September 2026 (DIN-39)
+
+**The environment variable that named "the" family is deleted**, from the code, from `.do/app.yaml`
+and from these notes. Cloud mode builds one `PostgresStore` per request from the family on the
+session, over one pool per process. A `git grep` for that variable's name returning nothing is
+itself a test (`tests/test_tenancy.py`), which is why the name no longer appears above either — the
+notes were corrected rather than left, because what they recorded stopped being true.
+
+**The app spec needs applying again.** Removing an env var is a spec change, and `deploy_on_push`
+does not apply one — same merge-values-from-`.env` dance as every other change to that file. Leaving
+it applied-late is harmless here: the variable is simply ignored by code that no longer reads it.
+
+**Signing in for development or support:** `venv/bin/python login_link.py you@example.com` prints a
+working link without waiting on email. Same token, same fifteen minutes, same single use, same
+per-address limit — the only thing it skips is SendGrid. **What it prints is a credential**, so it
+does not go in an issue or a screenshot. It does not create accounts; the `INSERT` above still does.
+
+**Unverified, and worth an eye.** The access log shows `%(h)s` as an internal `10.244.x` address
+that differs between requests, so App Platform is putting a hop in front of the container.
+`web/ratelimit.client_ip` reads `X-Forwarded-For` from the right and steps over private addresses,
+which is correct *if* the platform sets that header. Nothing has confirmed it does. If it does not,
+the per-caller rate limit is keyed on a value that changes every request and therefore never fires —
+the per-address limit in Postgres would still hold, so this is a weakened control rather than an
+open door.
 
 
 ## GitHub's own secret scanning

--- a/doc/operations.md
+++ b/doc/operations.md
@@ -161,6 +161,27 @@ working link without waiting on email. Same token, same fifteen minutes, same si
 per-address limit — the only thing it skips is SendGrid. **What it prints is a credential**, so it
 does not go in an issue or a screenshot. It does not create accounts; the `INSERT` above still does.
 
+**What the sign-in limits write to the log**, which is the reason for keeping them in the app
+rather than moving them to a Cloudflare rule. Grep `web.routes.auth`:
+
+```
+INFO    Sent a sign-in link to a @example.com address.
+WARNING Sign-in requests from 93.184.216.34 are over the limit (20 per 60 minutes, in this process).
+WARNING No sign-in link minted for a @example.com address from 93.184.216.42: 3 live links already.
+WARNING No caller address on this request: none of DO-Connecting-IP, CF-Connecting-IP was set ...
+```
+
+Three deliberate choices in there. **The caller's address appears in full** — without it a warning
+says only "something happened", and one script and a hundred parents look the same. **The address
+asked about never does, only its domain** — a flood of `@mailinator.com` is what you want to see,
+and the list of who has an account is what this endpoint exists not to publish, least of all into a
+third party's log. **An address with no account logs nothing at all**, so the log is not an
+enumeration oracle either.
+
+The last line fires once per process and means the per-caller limit has quietly stopped working —
+the platform stopped sending a header that identifies callers. The per-address limit in Postgres
+still holds, so it is a weakened control rather than an open door, but it is worth an alert.
+
 **The caller's address is in `DO-Connecting-IP`, and `X-Forwarded-For` is a trap here.** The access
 log showed `%(h)s` as an internal `10.244.x` that differs between requests, which prompted a look.
 DigitalOcean's own documentation: *"App Platform adds a `do-connecting-ip` HTTP header that contains

--- a/login_link.py
+++ b/login_link.py
@@ -75,8 +75,15 @@ def main(argv=None):
 
         token = accounts.issue_link(pool, user[0])
         if token is None:
+            minutes = int(accounts.TOKEN_TTL.total_seconds() // 60)
+            # **Spending one does not free a slot.** The limit counts every
+            # unexpired token, used or not, so clicking a link does not buy
+            # another. Saying otherwise sends somebody off to click a link that
+            # will not help.
             print(f"{args.email} already has {accounts.MOST_LIVE_LINKS} live links. "
-                  f"Wait for one to expire, or spend one.", file=sys.stderr)
+                  f"They are counted until they expire, whether or not they have "
+                  f"been used, so the wait is up to {minutes} minutes.",
+                  file=sys.stderr)
             return 1
 
         print(f"{base_url(args.base_url)}/login/link?t={token}")

--- a/login_link.py
+++ b/login_link.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Print a working sign-in link for an account that already exists. Cloud mode only.
+
+    python login_link.py you@example.com
+    python login_link.py you@example.com --base-url http://127.0.0.1:5173
+
+**Why this exists.** The settings UI is behind a magic link, and a magic link
+arrives by email. That is right for a parent and tedious for the person editing
+the page, who would otherwise wait on SendGrid to look at their own change. It
+is also what support needs on the day somebody's mail is bouncing.
+
+**There is no bypass here, and there must never be one.** It mints an ordinary
+token through `dinkydash.accounts`, subject to the same fifteen minutes, the
+same single use and the same per-address limit of three live links. The only
+thing it skips is the email.
+
+**What it prints is a credential.** Anyone holding that line can sign in as
+that person until it is spent. It grants nothing you did not already have —
+running it needs the database password — but pasting it into an issue, a chat
+or a screenshot hands it to somebody who has neither.
+
+It does not create accounts. Sign-up is the product's job (DIN-41); until that
+exists, a new family needs a row inserted by hand, and doc/operations.md has
+the statement.
+
+Reads `DATABASE_URL`, like the app.
+"""
+
+import argparse
+import os
+import sys
+
+from dotenv import load_dotenv
+
+from dinkydash import accounts, db
+
+load_dotenv()
+
+
+def base_url(given):
+    """Where the link should point. Explicit, then the app's hostname, then local.
+
+    https for a real hostname because the token is a bearer credential and a
+    plain-http link puts it on the wire; http for the fallback because that is
+    what `flask run` serves on a laptop.
+    """
+    if given:
+        return given.rstrip("/")
+    host = os.environ.get("DINKYDASH_APP_HOST", "").strip()
+    if host:
+        return f"https://{host}"
+    return "http://127.0.0.1:5000"
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Print a sign-in link for an existing DinkyDash account.")
+    parser.add_argument("email", help="the address on the account")
+    parser.add_argument("--base-url",
+                        help="where the link points (default: DINKYDASH_APP_HOST, "
+                             "else http://127.0.0.1:5000)")
+    parser.add_argument("--database-url", help="override DATABASE_URL")
+    args = parser.parse_args(argv)
+
+    pool = db.pool(args.database_url or db.require("DATABASE_URL"))
+    try:
+        user = accounts.user_for(pool, args.email)
+        if user is None:
+            # Said plainly here, unlike the web route: this is a local tool run
+            # by somebody holding the database password, so there is nobody to
+            # enumerate accounts for.
+            print(f"No account for {args.email}. Nothing creates one yet — see "
+                  f"doc/operations.md.", file=sys.stderr)
+            return 1
+
+        token = accounts.issue_link(pool, user[0])
+        if token is None:
+            print(f"{args.email} already has {accounts.MOST_LIVE_LINKS} live links. "
+                  f"Wait for one to expire, or spend one.", file=sys.stderr)
+            return 1
+
+        print(f"{base_url(args.base_url)}/login/link?t={token}")
+        print("Works once, for fifteen minutes. Do not paste it anywhere.",
+              file=sys.stderr)
+    finally:
+        pool.close()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -249,23 +249,25 @@ class TestTheLimiter:
 
 
 class TestWhichAddressItCounts:
-    """`DO-Connecting-IP` first, because that is what App Platform sets.
+    """`DO-Connecting-IP` first, and `X-Forwarded-For` never.
 
     DigitalOcean's documentation: "App Platform adds a do-connecting-ip HTTP
     header that contains the client's IP address... While the x-forwarded-for
     header is often used for this purpose, App Platform uses this header for
-    the IP address of the DigitalOcean ingress server." Keying a per-caller
-    limit on `X-Forwarded-For` there keys it on DigitalOcean.
+    the IP address of the DigitalOcean ingress server." So that header holds a
+    *public* address shared by every request that reaches us, and reading it
+    at all — even last, even from the right — is the shared-bucket bug.
 
     The addresses here are real public ones on purpose. Python's `ipaddress`
-    counts the documentation ranges — `203.0.113.0/24` and friends — as
-    *private*, so a test written with those proves nothing.
+    counts the documentation ranges as *private*, so a test written with those
+    would go down the fallback branch and prove nothing. That is exactly how
+    the bug above survived its first round of tests.
     """
 
     CLIENT = "93.184.216.34"      # the caller
     CLAIMED = "8.8.8.8"           # what the caller put in a header
-    INGRESS = "104.16.0.1"        # public, and not the caller: DO's ingress
-    INTERNAL = "10.1.2.3"         # a hop inside the platform
+    INGRESS = "104.16.0.1"        # public, shared, and not the caller
+    INTERNAL = "10.244.5.194"     # the socket, inside the platform
 
     class _Request:
         def __init__(self, headers=None, remote_addr=None):
@@ -288,40 +290,34 @@ class TestWhichAddressItCounts:
             {"DO-Connecting-IP": self.CLIENT,
              "CF-Connecting-IP": self.CLAIMED})) == self.CLIENT
 
-    def test_the_ingress_address_is_never_mistaken_for_the_caller(self):
-        """The bug this ordering exists to prevent: one bucket for everybody."""
-        alice = self._Request({"DO-Connecting-IP": self.CLIENT,
-                               "X-Forwarded-For": self.INGRESS})
-        bob = self._Request({"DO-Connecting-IP": self.CLAIMED,
-                             "X-Forwarded-For": self.INGRESS})
-        assert client_ip(alice) != client_ip(bob)
-
-    def test_with_no_platform_header_a_proxy_chain_is_read_from_the_right(self):
+    def test_forwarded_for_is_never_read(self):
+        """The regression test. A public value there is the *ingress*."""
+        assert client_ip(self._Request({"X-Forwarded-For": self.INGRESS})) == ""
         assert client_ip(self._Request(
-            {"X-Forwarded-For": f"{self.CLAIMED}, {self.CLIENT}"})) == self.CLIENT
+            {"X-Forwarded-For": f"{self.CLAIMED}, {self.CLIENT}"})) == ""
 
-    def test_a_caller_cannot_pretend_to_be_someone_else(self):
-        assert client_ip(self._Request(
-            {"X-Forwarded-For": f"invented, {self.CLIENT}"})) == self.CLIENT
-
-    def test_an_internal_hop_is_stepped_over(self):
-        assert client_ip(self._Request(
-            {"X-Forwarded-For":
-             f"{self.CLAIMED}, {self.CLIENT}, {self.INTERNAL}"})) == self.CLIENT
+    def test_two_callers_behind_one_ingress_do_not_share_a_key(self):
+        """The bug this ordering exists to prevent, stated as its symptom."""
+        first = self._Request({"X-Forwarded-For": self.INGRESS}, "10.244.5.194")
+        second = self._Request({"X-Forwarded-For": self.INGRESS}, "10.244.0.79")
+        assert client_ip(first) == client_ip(second) == ""
+        # Both empty, and an empty key is one the limiter always allows — so
+        # they are not one bucket, they are no bucket.
+        limiter = Limiter(most=1, per=60)
+        assert limiter.allow(client_ip(first)) is True
+        assert limiter.allow(client_ip(second)) is True
 
     def test_a_public_socket_address_is_the_last_resort(self):
+        """A plain deployment with nothing in front of it."""
         assert client_ip(self._Request({}, self.CLIENT)) == self.CLIENT
 
-    def test_an_unidentifiable_caller_is_no_key_at_all(self):
-        """Not the internal address, which differs per request on App Platform.
-
-        Empty is a key the limiter always allows. That is deliberate: "the
-        per-caller limit stops firing" is a better failure than "everybody
-        shares one bucket", which is an outage wearing a rate limit's clothes.
-        """
-        assert client_ip(self._Request({"X-Forwarded-For": self.INTERNAL},
-                                       self.INTERNAL)) == ""
+    def test_an_internal_socket_address_is_no_key_at_all(self):
+        """On App Platform it differs per request, so it is worse than nothing."""
+        assert client_ip(self._Request({}, self.INTERNAL)) == ""
         assert client_ip(self._Request({}, "127.0.0.1")) == ""
+
+    def test_nothing_at_all_is_no_key_either(self):
+        assert client_ip(self._Request()) == ""
 
     def test_and_an_empty_key_is_allowed_through(self):
         assert Limiter(most=1, per=60).allow("") is True
@@ -567,6 +563,17 @@ class TestTheLimitPerAddress:
                  for _ in range(5)]
         # If being limited looked different, it would say the address exists.
         assert len(set(pages)) == 1
+
+    def test_spending_one_does_not_free_a_slot(self, client, sent, pg_user, pg_pool):
+        """The limit is on emails sent in a window, and the email has gone.
+
+        Misread twice — once in `login_link.py`'s own error message, which
+        told people to click a link that would not help.
+        """
+        for _ in range(accounts.MOST_LIVE_LINKS):
+            client.post("/login", data={"email": ADDRESS})
+        assert accounts.consume_link(pg_pool, token_in(sent[0])) is not None
+        assert accounts.issue_link(pg_pool, pg_user) is None
 
     def test_the_links_already_sent_still_work(self, client, sent, pg_user):
         for _ in range(5):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -82,7 +82,7 @@ def cloud(pg_pool, pg_family, monkeypatch):
     store.save_config(yaml.safe_load(CONFIG))
     monkeypatch.setenv("DINKYDASH_MODE", "cloud")
     monkeypatch.setenv("DINKYDASH_SECRET_KEY", "a-real-one")
-    return create_app(store)
+    return create_app(pool=pg_pool)
 
 
 @pytest.fixture
@@ -406,7 +406,7 @@ class TestWhereTheLinkPoints:
         monkeypatch.setenv("DINKYDASH_MODE", "cloud")
         monkeypatch.setenv("DINKYDASH_SECRET_KEY", "a-real-one")
         monkeypatch.setenv("DINKYDASH_APP_HOST", "app.dinkydash.co")
-        return client_for(create_app(store))
+        return client_for(create_app(pool=pg_pool))
 
     def test_it_uses_the_configured_host(self, hosted, sent, pg_user):
         hosted.post("/login", data={"email": ADDRESS})

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -605,6 +605,84 @@ class TestTheLimitPerAddressOfTheCaller:
         assert len(sent) == 2
 
 
+class TestWhatTheLogSays:
+    """Rolling our own limits rather than using an edge rule buys exactly one
+    thing: a refusal is a line somebody can read. So the lines are tested.
+
+    What may appear and what may not is a decision, not an accident. The
+    caller's address, yes — without it a warning says only "something
+    happened". The address that was asked about, **no**: who has an account is
+    what this endpoint exists not to publish, and a platform log is not ours.
+    """
+
+    CALLER = {"DO-Connecting-IP": "93.184.216.34"}
+
+    @pytest.fixture(autouse=True)
+    def forget_the_once_only_warning(self):
+        from web.routes import auth
+        auth._warned_about_anonymous = False
+        yield
+        auth._warned_about_anonymous = False
+
+    def test_a_limited_caller_is_named(self, cloud, sent, pg_user, caplog):
+        cloud.config["LOGIN_LIMITER"] = Limiter(most=1, per=3600)
+        client = client_for(cloud)
+        client.post("/login", data={"email": ADDRESS}, headers=self.CALLER)
+        with caplog.at_level("WARNING"):
+            client.post("/login", data={"email": ADDRESS}, headers=self.CALLER)
+        assert "93.184.216.34" in caplog.text
+        assert "over the limit" in caplog.text
+
+    def test_the_per_address_limit_is_not_silent(self, cloud, sent, pg_user, caplog):
+        """It used to be. It is the one that caps the SendGrid bill."""
+        client = client_for(cloud)
+        for _ in range(accounts.MOST_LIVE_LINKS):
+            client.post("/login", data={"email": ADDRESS}, headers=self.CALLER)
+        with caplog.at_level("WARNING"):
+            client.post("/login", data={"email": ADDRESS}, headers=self.CALLER)
+        assert "live links already" in caplog.text
+        assert "@example.com" in caplog.text
+
+    def test_and_it_names_the_domain_rather_than_the_person(
+            self, cloud, sent, pg_user, caplog):
+        client = client_for(cloud)
+        for _ in range(accounts.MOST_LIVE_LINKS + 1):
+            with caplog.at_level("INFO"):
+                client.post("/login", data={"email": ADDRESS}, headers=self.CALLER)
+        assert "parent@" not in caplog.text
+        assert ADDRESS not in caplog.text
+
+    def test_an_ordinary_send_is_visible_too(self, cloud, sent, pg_user, caplog):
+        """Refusals alone tell you nothing about the shape of normal traffic."""
+        client = client_for(cloud)
+        with caplog.at_level("INFO"):
+            client.post("/login", data={"email": ADDRESS}, headers=self.CALLER)
+        assert "Sent a sign-in link to a @example.com address." in caplog.text
+        assert ADDRESS not in caplog.text
+
+    def test_nothing_is_logged_about_an_address_with_no_account(
+            self, cloud, sent, pg_user, caplog):
+        with caplog.at_level("INFO"):
+            client_for(cloud).post("/login", data={"email": "stranger@nowhere.test"},
+                                   headers=self.CALLER)
+        assert "nowhere.test" not in caplog.text
+
+    def test_a_caller_we_cannot_identify_says_so_once(self, cloud, sent, pg_user, caplog):
+        """A control that has stopped working silently is worse than none."""
+        client = client_for(cloud)  # no DO-Connecting-IP, loopback socket
+        with caplog.at_level("WARNING"):
+            client.post("/login", data={"email": ADDRESS})
+            client.post("/login", data={"email": ADDRESS})
+        assert caplog.text.count("No caller address on this request") == 1
+        assert "DO-Connecting-IP" in caplog.text
+
+    def test_no_log_line_anywhere_carries_a_token(self, cloud, sent, pg_user, caplog):
+        with caplog.at_level("INFO"):
+            client_for(cloud).post("/login", data={"email": ADDRESS},
+                                   headers=self.CALLER)
+        assert token_in(sent[0]) not in caplog.text
+
+
 # -- the gate ---------------------------------------------------------------
 
 class TestTheSettingsAreBehindIt:

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -249,49 +249,83 @@ class TestTheLimiter:
 
 
 class TestWhichAddressItCounts:
-    """`X-Forwarded-For` read from the right, stepping over private hops.
+    """`DO-Connecting-IP` first, because that is what App Platform sets.
+
+    DigitalOcean's documentation: "App Platform adds a do-connecting-ip HTTP
+    header that contains the client's IP address... While the x-forwarded-for
+    header is often used for this purpose, App Platform uses this header for
+    the IP address of the DigitalOcean ingress server." Keying a per-caller
+    limit on `X-Forwarded-For` there keys it on DigitalOcean.
 
     The addresses here are real public ones on purpose. Python's `ipaddress`
     counts the documentation ranges — `203.0.113.0/24` and friends — as
-    *private*, so a test written with those would pass through the fallback
-    branch and prove nothing.
+    *private*, so a test written with those proves nothing.
     """
 
-    CLIENT = "93.184.216.34"      # what our proxy saw
-    CLAIMED = "8.8.8.8"           # what the caller put in the header
+    CLIENT = "93.184.216.34"      # the caller
+    CLAIMED = "8.8.8.8"           # what the caller put in a header
+    INGRESS = "104.16.0.1"        # public, and not the caller: DO's ingress
     INTERNAL = "10.1.2.3"         # a hop inside the platform
 
     class _Request:
-        def __init__(self, headers, remote_addr):
-            self.headers = headers
+        def __init__(self, headers=None, remote_addr=None):
+            self.headers = headers or {}
             self.remote_addr = remote_addr
 
-    def _asking_from(self, forwarded, remote_addr="10.0.0.1"):
-        headers = {"X-Forwarded-For": forwarded} if forwarded else {}
-        return self._Request(headers, remote_addr)
+    def test_the_platforms_own_header_wins(self):
+        assert client_ip(self._Request(
+            {"DO-Connecting-IP": self.CLIENT,
+             "X-Forwarded-For": self.INGRESS},
+            self.INTERNAL)) == self.CLIENT
 
-    def test_with_no_proxy_it_is_the_socket(self):
-        assert client_ip(self._asking_from(None, self.CLIENT)) == self.CLIENT
+    def test_the_cloudflare_one_is_second(self):
+        assert client_ip(self._Request(
+            {"CF-Connecting-IP": self.CLIENT,
+             "X-Forwarded-For": self.INGRESS})) == self.CLIENT
 
-    def test_the_last_public_hop_wins(self):
-        assert client_ip(
-            self._asking_from(f"{self.CLAIMED}, {self.CLIENT}")) == self.CLIENT
+    def test_and_the_platforms_beats_cloudflares(self):
+        assert client_ip(self._Request(
+            {"DO-Connecting-IP": self.CLIENT,
+             "CF-Connecting-IP": self.CLAIMED})) == self.CLIENT
+
+    def test_the_ingress_address_is_never_mistaken_for_the_caller(self):
+        """The bug this ordering exists to prevent: one bucket for everybody."""
+        alice = self._Request({"DO-Connecting-IP": self.CLIENT,
+                               "X-Forwarded-For": self.INGRESS})
+        bob = self._Request({"DO-Connecting-IP": self.CLAIMED,
+                             "X-Forwarded-For": self.INGRESS})
+        assert client_ip(alice) != client_ip(bob)
+
+    def test_with_no_platform_header_a_proxy_chain_is_read_from_the_right(self):
+        assert client_ip(self._Request(
+            {"X-Forwarded-For": f"{self.CLAIMED}, {self.CLIENT}"})) == self.CLIENT
 
     def test_a_caller_cannot_pretend_to_be_someone_else(self):
-        """Everything before the last hop is whatever the caller sent."""
-        assert client_ip(
-            self._asking_from(f"invented, {self.CLIENT}")) == self.CLIENT
+        assert client_ip(self._Request(
+            {"X-Forwarded-For": f"invented, {self.CLIENT}"})) == self.CLIENT
 
     def test_an_internal_hop_is_stepped_over(self):
-        """Otherwise a second proxy would put every family in one bucket."""
-        assert client_ip(self._asking_from(
-            f"{self.CLAIMED}, {self.CLIENT}, {self.INTERNAL}")) == self.CLIENT
+        assert client_ip(self._Request(
+            {"X-Forwarded-For":
+             f"{self.CLAIMED}, {self.CLIENT}, {self.INTERNAL}"})) == self.CLIENT
 
-    def test_all_private_falls_back_to_the_last_hop(self):
-        assert client_ip(self._asking_from(self.INTERNAL)) == self.INTERNAL
+    def test_a_public_socket_address_is_the_last_resort(self):
+        assert client_ip(self._Request({}, self.CLIENT)) == self.CLIENT
 
-    def test_nonsense_is_not_an_address(self):
-        assert client_ip(self._asking_from("not-an-ip")) == "not-an-ip"
+    def test_an_unidentifiable_caller_is_no_key_at_all(self):
+        """Not the internal address, which differs per request on App Platform.
+
+        Empty is a key the limiter always allows. That is deliberate: "the
+        per-caller limit stops firing" is a better failure than "everybody
+        shares one bucket", which is an outage wearing a rate limit's clothes.
+        """
+        assert client_ip(self._Request({"X-Forwarded-For": self.INTERNAL},
+                                       self.INTERNAL)) == ""
+        assert client_ip(self._Request({}, "127.0.0.1")) == ""
+
+    def test_and_an_empty_key_is_allowed_through(self):
+        assert Limiter(most=1, per=60).allow("") is True
+        assert Limiter(most=1, per=60).allow("") is True
 
 
 # -- what single mode must not grow -----------------------------------------
@@ -542,19 +576,33 @@ class TestTheLimitPerAddress:
 
 
 class TestTheLimitPerAddressOfTheCaller:
+    """`DO-Connecting-IP` is what identifies a caller, so the tests send one —
+    a test client's socket address is loopback, which is deliberately no key."""
+
+    CALLER = {"DO-Connecting-IP": "93.184.216.34"}
+    SOMEBODY_ELSE = {"DO-Connecting-IP": "8.8.8.8"}
+
     def test_a_flooding_caller_sends_no_more_email(self, cloud, sent, pg_user):
         cloud.config["LOGIN_LIMITER"] = Limiter(most=1, per=3600)
         client = client_for(cloud)
-        client.post("/login", data={"email": ADDRESS})
-        client.post("/login", data={"email": ADDRESS})
+        client.post("/login", data={"email": ADDRESS}, headers=self.CALLER)
+        client.post("/login", data={"email": ADDRESS}, headers=self.CALLER)
         assert len(sent) == 1
 
     def test_and_that_page_is_the_same_page_too(self, cloud, sent, pg_user):
         cloud.config["LOGIN_LIMITER"] = Limiter(most=1, per=3600)
         client = client_for(cloud)
-        first = client.post("/login", data={"email": ADDRESS})
-        second = client.post("/login", data={"email": ADDRESS})
+        first = client.post("/login", data={"email": ADDRESS}, headers=self.CALLER)
+        second = client.post("/login", data={"email": ADDRESS}, headers=self.CALLER)
         assert first.get_data() == second.get_data()
+
+    def test_one_caller_does_not_limit_another(self, cloud, sent, pg_user):
+        """The whole point of the header ordering, end to end."""
+        cloud.config["LOGIN_LIMITER"] = Limiter(most=1, per=3600)
+        client = client_for(cloud)
+        client.post("/login", data={"email": ADDRESS}, headers=self.CALLER)
+        client.post("/login", data={"email": ADDRESS}, headers=self.SOMEBODY_ELSE)
+        assert len(sent) == 2
 
 
 # -- the gate ---------------------------------------------------------------

--- a/tests/test_cloud_mode.py
+++ b/tests/test_cloud_mode.py
@@ -108,10 +108,13 @@ class TestABoardOutOfPostgres:
 
         monkeypatch.setenv("DINKYDASH_MODE", "cloud")
         monkeypatch.setenv("DINKYDASH_SECRET_KEY", "a-real-one")
-        client = client_for(create_app(store))
+        # The pool, not the store. Cloud mode builds a `PostgresStore` per
+        # request from the family on the session, so handing one in would
+        # test a path production does not have.
+        client = client_for(create_app(pool=pg_pool))
         # These tests are about the rows, not the login. Signing in by hand is
         # what keeps them that way; `tests/test_auth.py` is where the gate
-        # itself is tested.
+        # itself is tested, and `tests/test_tenancy.py` the scoping.
         with client.session_transaction() as stored:
             stored["user_id"] = 1
             stored["family_id"] = str(pg_family)
@@ -142,7 +145,8 @@ class TestABoardOutOfPostgres:
                         (pg_family,))
             assert cur.fetchone()[0] == "The Bakers"
 
-    def test_the_board_is_identical_to_the_one_a_file_would_render(self, client, tmp_path):
+    def test_the_board_is_identical_to_the_one_a_file_would_render(
+            self, client, tmp_path, monkeypatch):
         """The template, the CSS and build_view are shared verbatim.
 
         If cloud mode ever rendered a different board, the mode check would have
@@ -152,6 +156,10 @@ class TestABoardOutOfPostgres:
         import yaml
 
         from dinkydash.store import FileStore
+        # A genuinely self-hosted app for the other side of the comparison. The
+        # fixture above set cloud mode for the whole test, and a cloud app with
+        # no session redirects to `/login` rather than rendering anything.
+        monkeypatch.delenv("DINKYDASH_MODE", raising=False)
         (tmp_path / "config.yaml").write_text(yaml.safe_dump(CONFIG, allow_unicode=True))
         file_store = FileStore(tmp_path / "config.yaml")
         today = payload_for_today()

--- a/tests/test_tenancy.py
+++ b/tests/test_tenancy.py
@@ -1,0 +1,410 @@
+"""Two families, one process, and no way from one to the other.
+
+PLAN.md's "done when" for phase 1:
+
+> two different families can be configured independently through the UI, and a
+> request carrying the wrong family's id in a URL gets a 404, never a row.
+
+The claim being tested is stronger than "ids are checked". **Cloud mode reads
+the family from the session and from nowhere else** — no path segment, no query
+parameter, no form field and no header names one — so there is no id for a
+caller to get wrong. What ids there *are* in URLs are item ids inside one
+family's config document, and another family's is simply not in the list.
+
+Skips without `DINKYDASH_TEST_DATABASE_URL`, like the rest of the Postgres
+half. Single mode is asserted unchanged here too: a self-hoster has one family,
+one file and no session, and none of this may reach them.
+"""
+
+import json
+import pathlib
+import subprocess
+
+import pytest
+import yaml
+
+from dinkydash.store import FileStore
+from tests.conftest import client_for
+from web import create_app
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+
+# Two families with nothing in common, so anything leaking is obvious.
+WILSONS = {
+    "family_name": "The Wilsons",
+    "timezone": "Europe/Berlin",
+    "theme": "light",
+    "people": [{"id": "mia11111", "name": "Mia", "date_of_birth": "2017-03-15"}],
+    "pets": [{"id": "dog11111", "name": "Rolo", "type": "dog"}],
+    "recurring": [{"id": "job11111", "title": "Set the table", "choices": ["Mia"]}],
+    "special_dates": [{"id": "day11111", "title": "Camping", "date": "07/14"}],
+    "calendars": [{"id": "cal11111", "label": "Wilson school",
+                   "url": "https://example.com/private-wwww/basic.ics", "enabled": True}],
+}
+
+BAKERS = {
+    "family_name": "The Bakers",
+    "timezone": "Europe/London",
+    "theme": "dark",
+    "people": [{"id": "otto2222", "name": "Otto", "date_of_birth": "2015-08-02"}],
+    "pets": [{"id": "cat22222", "name": "Smudge", "type": "cat"}],
+    "recurring": [{"id": "job22222", "title": "Feed the cat", "choices": ["Otto"]}],
+    "special_dates": [{"id": "day22222", "title": "Sailing", "date": "05/02"}],
+    "calendars": [{"id": "cal22222", "label": "Baker swimming",
+                   "url": "https://example.com/private-bbbb/basic.ics", "enabled": True}],
+}
+
+# Every section, and the item in each that belongs to the *other* family.
+SECTIONS = ["people", "pets", "recurring", "special_dates", "calendars"]
+BAKER_ITEMS = {
+    "people": "otto2222",
+    "pets": "cat22222",
+    "recurring": "job22222",
+    "special_dates": "day22222",
+    "calendars": "cal22222",
+}
+
+
+# A board each, so the `generations` and `agendas` rows are scoped too and not
+# only `families.config`.
+BOARDS = {
+    "wilsons": {"headline": "Swimming, then football", "note": "An octopus fact."},
+    "bakers": {"headline": "Sailing at low tide", "note": "A puffin fact."},
+}
+
+
+@pytest.fixture
+def families(pg_pool):
+    """Two families, each with a parent and a written board, cleaned up afterwards.
+
+    Returns `{"wilsons": (family_id, user_id), "bakers": (...)}`.
+    """
+    from dinkydash import config as config_module
+    from dinkydash.pgstore import PostgresStore
+
+    made = {}
+    with pg_pool.connection() as conn, conn.transaction():
+        with conn.cursor() as cur:
+            for name, config in (("wilsons", WILSONS), ("bakers", BAKERS)):
+                cur.execute(
+                    """INSERT INTO families (screen_token, config)
+                       VALUES (%s, %s::jsonb) RETURNING id""",
+                    (f"tok-{name}", json.dumps(config)),
+                )
+                family_id = cur.fetchone()[0]
+                cur.execute(
+                    "INSERT INTO users (family_id, email) VALUES (%s, %s) RETURNING id",
+                    (family_id, f"{name}@example.com"),
+                )
+                made[name] = (family_id, cur.fetchone()[0])
+
+    for name, config in (("wilsons", WILSONS), ("bakers", BAKERS)):
+        # Dated from the real clock: a payload from a fixed date would be stale
+        # by the time anybody ran this, and a stale board replaces the model's
+        # headline with a computed one.
+        today = config_module.today_for(config_module.with_defaults(dict(config)))
+        store = PostgresStore(pg_pool, made[name][0])
+        store.save_brief(config, {
+            "generated_for_date": today.isoformat(),
+            "generated_at": f"{today.isoformat()}T04:00:00+00:00",
+            **BOARDS[name],
+        })
+    yield made
+    with pg_pool.connection() as conn, conn.transaction():
+        with conn.cursor() as cur:
+            for family_id, _ in made.values():
+                cur.execute("DELETE FROM families WHERE id = %s", (family_id,))
+
+
+@pytest.fixture
+def app(pg_pool, monkeypatch):
+    """One cloud app, the way production builds it: a pool and no store."""
+    monkeypatch.setenv("DINKYDASH_MODE", "cloud")
+    monkeypatch.setenv("DINKYDASH_SECRET_KEY", "a-real-one")
+    return create_app(pool=pg_pool)
+
+
+def signed_in_as(app, family):
+    """A client carrying a session for that family. The login itself is test_auth's."""
+    family_id, user_id = family
+    client = client_for(app)
+    with client.session_transaction() as stored:
+        stored["user_id"] = user_id
+        stored["family_id"] = str(family_id)
+    return client
+
+
+@pytest.fixture
+def wilson(app, families):
+    return signed_in_as(app, families["wilsons"])
+
+
+@pytest.fixture
+def baker(app, families):
+    return signed_in_as(app, families["bakers"])
+
+
+def config_of(pg_pool, family_id):
+    with pg_pool.connection() as conn, conn.cursor() as cur:
+        cur.execute("SELECT config FROM families WHERE id = %s", (family_id,))
+        return cur.fetchone()[0]
+
+
+# -- each family sees their own -------------------------------------------
+
+class TestTwoFamiliesSideBySide:
+    """One app, one process, two sessions. The oldest multi-tenancy bug is a
+    module-level cache of "the" config, so both clients are used in one test."""
+
+    def test_the_settings_home_shows_each_their_own_name(self, wilson, baker):
+        assert "The Wilsons" in wilson.get("/settings/").get_data(as_text=True)
+        assert "The Bakers" in baker.get("/settings/").get_data(as_text=True)
+
+    def test_and_never_the_other_one(self, wilson, baker):
+        assert "The Bakers" not in wilson.get("/settings/").get_data(as_text=True)
+        assert "The Wilsons" not in baker.get("/settings/").get_data(as_text=True)
+
+    @pytest.mark.parametrize("section,mine,theirs", [
+        ("people", "Mia", "Otto"),
+        ("pets", "Rolo", "Smudge"),
+        ("recurring", "Set the table", "Feed the cat"),
+        ("special_dates", "Camping", "Sailing"),
+        ("calendars", "Wilson school", "Baker swimming"),
+    ])
+    def test_every_list_holds_only_one_familys_items(self, wilson, section, mine, theirs):
+        page = wilson.get(f"/settings/{section}").get_data(as_text=True)
+        assert mine in page
+        assert theirs not in page
+
+    def test_the_board_is_each_familys_own(self, wilson, baker):
+        """The headline comes out of `generations`, and the chore is recomputed
+        from `families.config` — so this covers both tables at once."""
+        ours = wilson.get("/").get_data(as_text=True)
+        theirs = baker.get("/").get_data(as_text=True)
+        assert "Swimming, then football" in ours and "Set the table" in ours
+        assert "Sailing at low tide" in theirs and "Feed the cat" in theirs
+
+    def test_and_neither_board_carries_the_others_words(self, wilson, baker):
+        assert "Sailing at low tide" not in wilson.get("/").get_data(as_text=True)
+        assert "Swimming, then football" not in baker.get("/").get_data(as_text=True)
+
+    def test_even_the_theme_follows_the_session(self, wilson, baker):
+        # The Bakers are on dark and the Wilsons on light. A shared store would
+        # give both the same one.
+        assert 'data-theme="light"' in wilson.get("/").get_data(as_text=True)
+        assert 'data-theme="dark"' in baker.get("/").get_data(as_text=True)
+
+    def test_a_calendar_url_never_crosses(self, wilson):
+        """The one value in a config that is a password."""
+        for path in ("/settings/", "/settings/calendars", "/"):
+            assert "private-bbbb" not in wilson.get(path).get_data(as_text=True)
+
+
+# -- another family's id in a URL -----------------------------------------
+
+class TestTheOtherFamilysIds:
+    """404, never a row — and never a 403 either, which would confirm it exists."""
+
+    @pytest.mark.parametrize("section", SECTIONS)
+    def test_opening_their_item_is_a_404(self, wilson, section):
+        response = wilson.get(f"/settings/{section}/{BAKER_ITEMS[section]}")
+        assert response.status_code == 404
+
+    @pytest.mark.parametrize("section", SECTIONS)
+    def test_saving_over_their_item_is_a_404(self, wilson, section):
+        response = wilson.post(f"/settings/{section}/{BAKER_ITEMS[section]}",
+                               data={"name": "Taken", "title": "Taken", "label": "Taken"})
+        assert response.status_code == 404
+
+    @pytest.mark.parametrize("section", SECTIONS)
+    def test_deleting_their_item_is_a_404(self, wilson, section):
+        response = wilson.post(f"/settings/{section}/{BAKER_ITEMS[section]}/delete")
+        assert response.status_code == 404
+
+    @pytest.mark.parametrize("section", SECTIONS)
+    def test_reordering_their_item_is_a_404(self, wilson, section):
+        response = wilson.post(f"/settings/{section}/{BAKER_ITEMS[section]}/move",
+                               data={"direction": "up"})
+        assert response.status_code == 404
+
+    def test_none_of_it_changed_a_thing(self, wilson, families, pg_pool):
+        """The 404s above must be refusals, not writes that happened to 404."""
+        before = config_of(pg_pool, families["bakers"][0])
+        for section in SECTIONS:
+            item = BAKER_ITEMS[section]
+            wilson.get(f"/settings/{section}/{item}")
+            wilson.post(f"/settings/{section}/{item}", data={"name": "Taken"})
+            wilson.post(f"/settings/{section}/{item}/delete")
+            wilson.post(f"/settings/{section}/{item}/move", data={"direction": "up"})
+        assert config_of(pg_pool, families["bakers"][0]) == before
+
+    def test_it_is_a_404_and_not_a_403(self, wilson):
+        """"Forbidden" would tell one family that another family's row exists."""
+        assert wilson.get("/settings/people/otto2222").status_code == 404
+
+
+# -- writes land on one family only ---------------------------------------
+
+class TestWritesStayHome:
+    def test_renaming_one_family_leaves_the_other(self, wilson, families, pg_pool):
+        before = config_of(pg_pool, families["bakers"][0])
+        wilson.post("/settings/system",
+                    data={"family_name": "The Wilsons of Ealing", "timezone": "Europe/Berlin"})
+        assert config_of(pg_pool, families["wilsons"][0])["family_name"] \
+            == "The Wilsons of Ealing"
+        assert config_of(pg_pool, families["bakers"][0]) == before
+
+    def test_adding_a_person_adds_them_to_one_family(self, wilson, families, pg_pool):
+        wilson.post("/settings/people/new",
+                    data={"name": "Bo", "date_of_birth": "2020-04-01"})
+        assert len(config_of(pg_pool, families["wilsons"][0])["people"]) == 2
+        assert len(config_of(pg_pool, families["bakers"][0])["people"]) == 1
+
+    def test_deleting_your_own_still_works(self, wilson, families, pg_pool):
+        assert wilson.post("/settings/people/mia11111/delete").status_code == 302
+        assert config_of(pg_pool, families["wilsons"][0])["people"] == []
+        assert len(config_of(pg_pool, families["bakers"][0])["people"]) == 1
+
+
+# -- what the session may say ---------------------------------------------
+
+class TestWhatTheSessionMaySay:
+    def test_no_session_means_no_board(self, app):
+        response = client_for(app).get("/")
+        assert response.status_code == 302
+        assert response.headers["Location"].endswith("/login")
+
+    def test_no_session_means_no_settings(self, app):
+        assert client_for(app).get("/settings/").status_code == 302
+
+    def test_a_cookie_we_did_not_sign_is_not_a_session(self, app, families):
+        """Flask signs the cookie; an invented one is discarded, not trusted."""
+        client = client_for(app)
+        client.set_cookie("session", "eyJmYW1pbHlfaWQiOiAiYW55dGhpbmcifQ.forged")
+        assert client.get("/settings/").status_code == 302
+
+    def test_a_family_id_that_is_not_a_uuid_never_reaches_a_query(self, app):
+        client = client_for(app)
+        with client.session_transaction() as stored:
+            stored["user_id"] = 1
+            stored["family_id"] = "'; DROP TABLE families; --"
+        assert client.get("/settings/").status_code == 404
+
+    def test_a_family_that_has_been_deleted_signs_you_out(self, app, pg_pool, families):
+        """A session lasts thirty days and an account can be deleted inside one."""
+        client = signed_in_as(app, families["wilsons"])
+        with pg_pool.connection() as conn, conn.transaction():
+            with conn.cursor() as cur:
+                cur.execute("DELETE FROM families WHERE id = %s", (families["wilsons"][0],))
+        response = client.get("/settings/")
+        assert response.status_code == 302
+        assert response.headers["Location"].endswith("/login")
+        with client.session_transaction() as stored:
+            assert "user_id" not in stored
+
+
+# -- the shape of the thing ------------------------------------------------
+
+class TestOneStorePerRequestAndOnePoolPerProcess:
+    def test_cloud_mode_holds_no_store_of_its_own(self, app):
+        """A store built at start-up could only be built from an environment
+        variable, which is what this replaced."""
+        assert app.config["STORE"] is None
+
+    def test_it_holds_exactly_one_pool(self, app, pg_pool):
+        assert app.config["POOL"] is pg_pool
+
+    def test_two_requests_get_two_stores_over_that_one_pool(self, app, families):
+        from web.family import current_store
+
+        seen = []
+        for family in (families["wilsons"], families["bakers"]):
+            with app.test_request_context("/"):
+                from flask import session as flask_session
+                flask_session["family_id"] = str(family[0])
+                store = current_store()
+                seen.append((store.family_id, store.pool))
+        assert seen[0][0] != seen[1][0]
+        assert seen[0][1] is seen[1][1]
+
+    def test_one_request_gets_one_store(self, app, families):
+        from web.family import current_store
+
+        with app.test_request_context("/"):
+            from flask import session as flask_session
+            flask_session["family_id"] = str(families["wilsons"][0])
+            assert current_store() is current_store()
+
+
+class TestSingleModeIsUntouched:
+    """A self-hoster has one family, one file and no session."""
+
+    @pytest.fixture
+    def client(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("DINKYDASH_MODE", raising=False)
+        (tmp_path / "config.yaml").write_text(yaml.safe_dump(WILSONS, allow_unicode=True))
+        return client_for(create_app(FileStore(tmp_path / "config.yaml")))
+
+    def test_the_board_needs_no_session(self, client):
+        assert client.get("/").status_code == 200
+
+    def test_the_settings_need_no_session(self, client):
+        assert "The Wilsons" in client.get("/settings/").get_data(as_text=True)
+
+    def test_it_still_uses_the_one_store_it_was_given(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("DINKYDASH_MODE", raising=False)
+        (tmp_path / "config.yaml").write_text("family_name: The Wilsons\n")
+        store = FileStore(tmp_path / "config.yaml")
+        app = create_app(store)
+        assert app.config["STORE"] is store
+        assert app.config["POOL"] is None
+
+    def test_and_writes_still_land(self, client, tmp_path):
+        client.post("/settings/system",
+                    data={"family_name": "The Wilsons of Ealing", "timezone": "UTC"})
+        assert "The Wilsons of Ealing" in (tmp_path / "config.yaml").read_text()
+
+
+class TestTheHardcodedFamilyIsGone:
+    """`grep -rn DINKYDASH_FAMILY_ID` returning nothing is the acceptance test.
+
+    A single surviving reference is a route that serves whoever the environment
+    says, to whoever asked.
+    """
+
+    def test_nothing_mentions_it_anywhere(self):
+        """Prose included, deliberately.
+
+        The dated notes in PLAN.md and doc/operations.md were rewritten rather
+        than left, because "cloud mode serves one family from an environment
+        variable" stopped being true — a log that records a fact is worth
+        keeping, and one that records a stale fact is worth correcting. This
+        file is excluded because a test asserting a name is gone has to say it.
+        """
+        found = subprocess.run(
+            ["git", "grep", "-l", "DINKYDASH_FAMILY_ID",
+             "--", ".", ":!tests/test_tenancy.py"],
+            cwd=REPO, capture_output=True, text=True,
+        )
+        # `git grep` exits 1 with no matches, which is the passing case.
+        assert found.stdout.strip() == "", found.stdout
+
+    def test_the_app_spec_does_not_set_it(self):
+        spec = yaml.safe_load((REPO / ".do" / "app.yaml").read_text())
+        assert "DINKYDASH_FAMILY_ID" not in {e["key"] for e in spec["envs"]}
+
+
+class TestHealthzStaysOpen:
+    """**Not a detail.** The health check arrives with no cookie, on a hostname
+    nobody signed in on. A 302 there fails it three times and App Platform
+    rolls the release back."""
+
+    def test_it_answers_with_no_session_in_cloud_mode(self, app):
+        response = client_for(app).get("/healthz")
+        assert response.status_code == 200
+        assert response.get_json()["status"] == "ok"
+
+    def test_it_still_touches_nothing(self, app, pg_pool):
+        # No store, no family, no query — so it cannot be made to fail by
+        # anything that is slow or broken behind it.
+        assert client_for(app).get("/healthz").status_code == 200

--- a/web/CLAUDE.md
+++ b/web/CLAUDE.md
@@ -16,6 +16,25 @@ branch in `parse_field` and a branch in `web/templates/settings/edit.html`; noth
 `web/templates/settings/home.html`. The list, edit, delete and reorder routes are generic and need
 no changes.
 
+**A route gets its store from `web.family.current_store()`, never from `app.config`.** In single
+mode that is the one `FileStore` the process was built with. In cloud mode it is a `PostgresStore`
+built for this request from the family on the session, cached on `g`, over the process-wide pool.
+A route that reads `app.config["STORE"]` directly works in single mode and serves `None` in cloud
+mode, which is the failure that looks like a bug in something else.
+
+**Poking at cloud mode locally: the session cookie is `Secure`, and http clients disagree about
+what that means.** Cloud mode is https-only, so the cookie is marked `Secure` and a laptop serving
+plain http is the odd case. Browsers treat `http://localhost` as a secure context and send it, so
+the preview works. `curl` sometimes does. **`requests` never does**, which makes every request
+arrive with no session — GETs redirect to `/login` and POSTs come back 400 from the CSRF check,
+which looks exactly like a broken feature. Drive `app.test_client()` in process instead: it has no
+cookie policy and exercises the same code. An hour went into that once.
+
+**A route that touches a store needs `session.guard`**, and the board blueprint's `before_request`
+is where that is decided. `board.healthz` is the one exemption and it is load-bearing: App
+Platform's health check arrives with no cookie, and a 302 there fails it three times and rolls the
+release back. It is also the only route that reads nothing, so it needs no family.
+
 **Every form that writes needs one hidden field.** `<input type="hidden" name="csrf_token"
 value="{{ csrf_token() }}">`, right inside the `<form>`. `csrf_token()` is a Jinja global set up by
 `web/session.py`, so no route has to remember to pass anything — but a form without the field is a

--- a/web/CLAUDE.md
+++ b/web/CLAUDE.md
@@ -22,13 +22,22 @@ built for this request from the family on the session, cached on `g`, over the p
 A route that reads `app.config["STORE"]` directly works in single mode and serves `None` in cloud
 mode, which is the failure that looks like a bug in something else.
 
-**Poking at cloud mode locally: the session cookie is `Secure`, and http clients disagree about
-what that means.** Cloud mode is https-only, so the cookie is marked `Secure` and a laptop serving
-plain http is the odd case. Browsers treat `http://localhost` as a secure context and send it, so
-the preview works. `curl` sometimes does. **`requests` never does**, which makes every request
-arrive with no session — GETs redirect to `/login` and POSTs come back 400 from the CSRF check,
-which looks exactly like a broken feature. Drive `app.test_client()` in process instead: it has no
-cookie policy and exercises the same code. An hour went into that once.
+**Poking at cloud mode locally: the session cookie is `Secure`, and every client disagrees about
+what that means over `http://localhost`.** Cloud mode is https-only, so the cookie is marked
+`Secure` and a laptop serving plain http is the odd case. Four different answers:
+
+| Client | Sends a `Secure` cookie to `http://localhost`? |
+|---|---|
+| Chrome (89+), Firefox (75+) | Yes — loopback is treated as a secure context |
+| **Safari** | **No.** There is no loopback exception, so the preview cannot sign in at all |
+| `curl` | Sometimes, depending on version |
+| `requests` | Never |
+
+The failure looks identical in all the failing cases and looks nothing like a cookie problem: GETs
+redirect to `/login` and POSTs come back 400 from the CSRF check, because there is no session to
+hold a token. **Use Chrome or Firefox for the Conductor preview**, and drive `app.test_client()` in
+process for anything scripted — it has no cookie policy and exercises the same code. An hour went
+into the `requests` half of that.
 
 **A route that touches a store needs `session.guard`**, and the board blueprint's `before_request`
 is where that is decided. `board.healthz` is the one exemption and it is load-bearing: App

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -12,19 +12,24 @@ Self-hosted mode has no accounts and no login — it serves one family on a home
 network. Anyone who can reach the port can edit the config, which is the same
 trust model as the config file it writes. Cloud mode cannot inherit that: there
 the session *is* the authentication, so `web/routes/auth.py` is registered and
-`/settings` is behind it.
+both `/` and `/settings` are behind it.
 
 `Secure` on the cookie is the fourth gate and the only one that is not a
 feature: a Pi serves plain HTTP on a LAN, and a `Secure` cookie is never sent
 over it. CSRF, by contrast, is on in **both** modes — see `web/session.py`.
 
-Everything else below `create_app` is mode-blind. The routes take a store out
-of `app.config` and never learn which one they were given.
+**Where the config is stored is also *whose* config**, which is why cloud mode
+holds no store here at all: `web/family.py` builds one per request from the
+family on the session. What this module owns is the pool behind them, built
+once and shared.
+
+Everything else below `create_app` is mode-blind. The routes ask
+`family.current_store()` and never learn what they were given.
 """
 
 import os
 
-from flask import Flask
+from flask import Flask, redirect, url_for
 
 SINGLE, CLOUD = "single", "cloud"
 
@@ -38,20 +43,29 @@ def mode():
     return os.environ.get("DINKYDASH_MODE", SINGLE).strip().lower() or SINGLE
 
 
-def create_app(store=None):
+def create_app(store=None, pool=None):
+    """The app. `store` and `pool` are seams for tests and for `app.py`.
+
+    In **single mode** one `FileStore` is built here and every request shares
+    it: one family, one file, no session to ask.
+
+    In **cloud mode** `STORE` stays `None` and `web/family.py` builds one per
+    request from the family on the session. An injected `store` is still used
+    for its pool, but **it is not used to serve a request** — cloud mode reads
+    the family from the session and from nowhere else, so there is no argument
+    to `create_app` that can quietly turn multi-tenancy off.
+    """
     app = Flask(__name__, static_folder="static", template_folder="templates")
     app.config["MODE"] = mode()
     app.secret_key = _secret_key(app.config["MODE"])
-    # Every route reads and writes through this one object, and none of them is
-    # told what is behind it. Cloud mode hands in a different store and nothing
-    # below this line changes (PLAN.md decision 10).
-    app.config["STORE"] = store or _default_store(app.config["MODE"])
-    # The connection pool, for the two things that are not one family's rows:
-    # signing somebody in, and the login-token sweep. Taken off the store
-    # rather than built again, so a test that hands in a `PostgresStore` gets a
-    # working login with no second piece of wiring. `FileStore` has no pool,
-    # and single mode never asks for one.
-    app.config["POOL"] = getattr(app.config["STORE"], "pool", None)
+    # Every route reads and writes through `family.current_store()`, and none
+    # of them is told what is behind it (PLAN.md decision 10).
+    app.config["STORE"] = store if store is not None else _fixed_store(app.config["MODE"])
+    # One pool for the life of the process, shared by every request's store and
+    # by the two things that are not one family's rows: signing somebody in,
+    # and the login-token sweep. **Never one pool per request** — the cluster
+    # has 22 connections and a PgBouncer in front of them.
+    app.config["POOL"] = _pool_for(app.config["MODE"], store, pool)
 
     # The hostname this board answers on, for the one URL that has to be built
     # outside a browser: the sign-in link in an email. **Not `request.host`**,
@@ -81,6 +95,21 @@ def create_app(store=None):
         # nobody to sign in.
         from .routes.auth import bp as auth_bp
         app.register_blueprint(auth_bp)
+
+        from dinkydash.pgstore import NoSuchFamily
+
+        @app.errorhandler(NoSuchFamily)
+        def family_is_gone(exc):
+            """A signed-in session naming a family that no longer exists.
+
+            A session lasts thirty days and an account can be deleted inside
+            one, so this is reachable without anything being wrong. Signing the
+            holder out and sending them to `/login` is the honest answer; a 500
+            would be a bug report about a working feature.
+            """
+            from .session import sign_out
+            sign_out()
+            return redirect(url_for("auth.login"))
 
     @app.after_request
     def no_referrer(response):
@@ -115,21 +144,39 @@ def _secret_key(current_mode):
     return SELF_HOSTED_KEY
 
 
-def _default_store(current_mode):
-    """The store this process should use when the caller did not supply one.
+def _fixed_store(current_mode):
+    """The one store a whole process shares, or `None` when each request needs its own.
 
-    The cloud imports are inside the branch on purpose: `dinkydash.pgstore` and
-    `dinkydash.db` pull in psycopg, which lives in `requirements-cloud.txt` and
-    is not installed on a Pi.
+    Cloud mode gets `None` on purpose. There is no "the" family there, so a
+    store built at start-up could only be built from an environment variable —
+    which is what this replaced, and what served whoever the environment said
+    to whoever asked.
     """
-    if current_mode != CLOUD:
-        from dinkydash.store import FileStore
-        return FileStore()
+    if current_mode == CLOUD:
+        return None
+    from dinkydash.store import FileStore
+    return FileStore()
+
+
+def _pool_for(current_mode, store, pool):
+    """The connection pool for this process, or `None` if it needs none.
+
+    The import is inside the branch on purpose: `dinkydash.db` pulls in
+    psycopg, which lives in `requirements-cloud.txt` and is not installed on a
+    Pi.
+
+    A supplied `pool` wins, then one hanging off a supplied `store` — both are
+    how the tests hand in a scratch database. Only a cloud app that was given
+    neither opens a connection, which is what lets a test build a cloud app
+    around a `FileStore` without one.
+    """
+    if pool is not None:
+        return pool
+    on_the_store = getattr(store, "pool", None)
+    if on_the_store is not None:
+        return on_the_store
+    if current_mode != CLOUD or store is not None:
+        return None
 
     from dinkydash import db
-    from dinkydash.pgstore import PostgresStore
-
-    # One family for now. Phase 1 replaces this with the family on the session,
-    # checked against the id in the URL before it reaches a query — the whole
-    # point of DIN-31 being the schema and not yet the multi-tenancy.
-    return PostgresStore(db.pool(), db.require("DINKYDASH_FAMILY_ID"))
+    return db.pool()

--- a/web/family.py
+++ b/web/family.py
@@ -1,0 +1,100 @@
+"""Which family a request is for, and the store that reaches only their rows.
+
+    current_store()   the store this request reads and writes through
+
+One line decides the whole of multi-tenancy:
+
+    cloud    one store per request, built from the family on the session
+    single   one store per process, because there is one family and no session
+
+**In cloud mode the family comes from the session and from nowhere else.**
+Not from a path segment, not from a query parameter, not from a form field and
+not from a header. That is a stronger promise than checking an id against the
+session, because there is no id to check: nothing a caller can send reaches a
+query as a family selector. When a route does one day need to name a family in
+its URL — the admin view is the likely first — the check belongs here, before
+the store is built, and **a mismatch is a 404 and never a 403**: "forbidden"
+confirms the row exists, which tells one family that another one does.
+
+The ids that *do* appear in URLs today are item ids inside one family's config
+document — `/settings/people/<item_id>`. They are already scoped by which
+family's config was loaded, so another family's id is simply not in the list
+and `find_item` 404s. `tests/test_tenancy.py` asserts that rather than assuming
+it.
+
+**One store per request must not mean one pool per request.** The pool is
+built once in `create_app` and lives for the life of the process; a
+`PostgresStore` is two attributes wrapped round it and costs nothing to build.
+Building a `ConnectionPool` per request would exhaust the cluster's 22
+connections and DigitalOcean's PgBouncer in front of them.
+
+The worker does not come through here and must not. `worker.family_ids` is the
+one deliberately unscoped read in the product, because there is no request and
+no user: walking every family is its job.
+"""
+
+import uuid
+
+from flask import abort, current_app, g, session
+
+from .session import FAMILY_ID
+
+
+def current_store():
+    """The store this request reads and writes through."""
+    from . import CLOUD
+
+    if current_app.config["MODE"] != CLOUD:
+        # One family, one file, no session. A Pi builds this once at start-up.
+        return current_app.config["STORE"]
+    return _for_the_session()
+
+
+def current_family_id():
+    """The family this request is for, as a string. Cloud mode only."""
+    return _family_on_the_session()
+
+
+def _for_the_session():
+    """One `PostgresStore`, cached for the length of this request.
+
+    Cached on `g` rather than rebuilt, so two calls in one view are one object
+    — and so that "one store per request" is literally true rather than
+    approximately true.
+    """
+    store = g.get("_store")
+    if store is not None:
+        return store
+
+    family_id = _family_on_the_session()
+    pool = current_app.config.get("POOL")
+    if pool is None:
+        raise RuntimeError(
+            "Cloud mode has no connection pool, so no request can be served."
+        )
+
+    from dinkydash.pgstore import PostgresStore
+
+    store = g._store = PostgresStore(pool, family_id)
+    return store
+
+
+def _family_on_the_session():
+    """The family id on the session, checked before it can reach a query.
+
+    Flask signs the cookie, so this value is one we put there — but it is
+    parsed as a UUID anyway before it goes anywhere near SQL. Belt and braces
+    costs one function call, and "the session is signed" is the kind of
+    assumption that survives right up until somebody adds a second way to write
+    a session.
+
+    **404, not a redirect.** Every route that reaches a store in cloud mode is
+    behind `session.guard`, which sends a signed-out visitor to `/login`. So
+    getting here without a family means something is wrong rather than somebody
+    being signed out, and 404 is the answer that says nothing at all.
+    """
+    claimed = session.get(FAMILY_ID)
+    try:
+        return str(uuid.UUID(str(claimed)))
+    except (AttributeError, TypeError, ValueError):
+        abort(404)

--- a/web/ratelimit.py
+++ b/web/ratelimit.py
@@ -73,37 +73,67 @@ class Limiter:
             self._seen.popitem(last=False)
 
 
+# Which header carries the caller's address, in the order they are trusted.
+#
+# **`X-Forwarded-For` is not first, and on App Platform it is not the caller at
+# all.** DigitalOcean's own documentation is explicit: "App Platform adds a
+# do-connecting-ip HTTP header that contains the client's IP address... While
+# the x-forwarded-for header is often used for this purpose, App Platform uses
+# this header for the IP address of the DigitalOcean ingress server that
+# forwarded the request to your app."
+#
+# That is worth stating because the obvious code is wrong here in a quiet way:
+# keying a per-caller limit on `X-Forwarded-For` keys it on DigitalOcean, so
+# every family in the world shares one bucket and the limit either never fires
+# or fires for everybody. It reads correctly and it is wrong.
+#
+# `CF-Connecting-IP` is the same idea from Cloudflare, and it is second because
+# App Platform *is* served through Cloudflare — `app.dinkydash.co` resolves to
+# Cloudflare addresses and answers with a `cf-ray`, even though our own zone is
+# DNS-only. Ours is not the edge in front of this app; DigitalOcean's is.
+CALLER_HEADERS = ("DO-Connecting-IP", "CF-Connecting-IP")
+
+
 def client_ip(request):
     """The address the request came from, as far as it can be known.
 
-    **Read `X-Forwarded-For` from the right, not the left.** A proxy appends
-    the address it saw, so entries near the end were written by our own
-    infrastructure and entries near the front are whatever the caller sent.
-    Trusting the leftmost — which is the obvious reading, and the wrong one —
-    would let one script claim a thousand addresses and walk straight past the
-    limit above.
+    Tries the platform's own header first, then a conventional proxy chain,
+    then the socket. **Returns `""` rather than guessing**, and an empty key is
+    one the limiter always allows — deliberately. If the caller cannot be
+    identified, the failure worth having is "the per-caller limit does not
+    fire" rather than "every caller shares one bucket", which is an outage
+    wearing a rate limit's clothes. The per-address limit in
+    `accounts.issue_link` is in Postgres and still bounds what any one account
+    can spend.
 
-    **Skipping private addresses on the way is what makes it safe either way.**
-    If App Platform ever puts a second hop in front of the container, the last
-    entry becomes an internal `10.x` and every family in the world would share
-    one bucket — twenty sign-ins an hour, globally, and it would look like a
-    mail problem rather than a rate limit. An internal hop is always a private
-    address and a real client on the internet never is, so the first public
-    address from the right is the client under either arrangement.
-
-    Falls back to the socket address, which is what a Pi and a test see.
+    A header can be forged by anyone who can reach the container without going
+    through the edge that sets it. There is no such path here — every hostname
+    this app answers on resolves to Cloudflare addresses in front of
+    DigitalOcean's ingress — and if there were, the cost is a bypassed spend
+    control with a database-backed one behind it.
     """
-    forwarded = request.headers.get("X-Forwarded-For", "")
-    hops = [hop.strip() for hop in forwarded.split(",") if hop.strip()]
+    for header in CALLER_HEADERS:
+        value = request.headers.get(header, "").strip()
+        if value:
+            return value
+
+    # A conventional proxy chain, for anywhere that is not App Platform. Read
+    # from the right, because a proxy *appends* what it saw: the last entry is
+    # the one our own infrastructure wrote and the earlier ones are whatever
+    # the caller sent. Private addresses are stepped over, because an internal
+    # hop is always private and a real client on the internet never is.
+    hops = [hop.strip()
+            for hop in request.headers.get("X-Forwarded-For", "").split(",")
+            if hop.strip()]
     for hop in reversed(hops):
         if _is_public(hop):
             return hop
-    # Everything was private or unparseable: local development, or a proxy
-    # arrangement nobody here anticipated. The rightmost is still the closest
-    # thing to the truth, and being over-strict is the safe direction.
-    if hops:
-        return hops[-1]
-    return request.remote_addr or ""
+
+    # The socket. On App Platform this is an internal address that differs
+    # between requests, which is why it is last and why `""` is an acceptable
+    # answer above it.
+    remote = request.remote_addr or ""
+    return remote if _is_public(remote) else ""
 
 
 def _is_public(address):

--- a/web/ratelimit.py
+++ b/web/ratelimit.py
@@ -75,17 +75,20 @@ class Limiter:
 
 # Which header carries the caller's address, in the order they are trusted.
 #
-# **`X-Forwarded-For` is not first, and on App Platform it is not the caller at
-# all.** DigitalOcean's own documentation is explicit: "App Platform adds a
-# do-connecting-ip HTTP header that contains the client's IP address... While
-# the x-forwarded-for header is often used for this purpose, App Platform uses
+# **`X-Forwarded-For` is not in this list, and that is the whole point.**
+# DigitalOcean's documentation is explicit: "App Platform adds a
+# `do-connecting-ip` HTTP header that contains the client's IP address... While
+# the `x-forwarded-for` header is often used for this purpose, App Platform uses
 # this header for the IP address of the DigitalOcean ingress server that
 # forwarded the request to your app."
 #
-# That is worth stating because the obvious code is wrong here in a quiet way:
-# keying a per-caller limit on `X-Forwarded-For` keys it on DigitalOcean, so
-# every family in the world shares one bucket and the limit either never fires
-# or fires for everybody. It reads correctly and it is wrong.
+# So `X-Forwarded-For` here is a *public* address shared by every request that
+# reaches us. Reading it — even as a last resort, even from the right — hands
+# every caller in the world the same key, which is the shared bucket this
+# ordering exists to prevent: twenty sign-in requests an hour between all of
+# them, and it would look like a mail problem. It was written that way once,
+# with a fallback that only ever ran on App Platform and therefore only ever
+# recreated the bug.
 #
 # `CF-Connecting-IP` is the same idea from Cloudflare, and it is second because
 # App Platform *is* served through Cloudflare — `app.dinkydash.co` resolves to
@@ -95,16 +98,20 @@ CALLER_HEADERS = ("DO-Connecting-IP", "CF-Connecting-IP")
 
 
 def client_ip(request):
-    """The address the request came from, as far as it can be known.
+    """The address the request came from, or `""` if it cannot be known.
 
-    Tries the platform's own header first, then a conventional proxy chain,
-    then the socket. **Returns `""` rather than guessing**, and an empty key is
-    one the limiter always allows — deliberately. If the caller cannot be
-    identified, the failure worth having is "the per-caller limit does not
-    fire" rather than "every caller shares one bucket", which is an outage
-    wearing a rate limit's clothes. The per-address limit in
-    `accounts.issue_link` is in Postgres and still bounds what any one account
-    can spend.
+    **`""` is a real answer, not a failure to produce one**, and the limiter
+    always allows an empty key. If callers cannot be told apart, the failure
+    worth having is "the per-caller limit does not fire" rather than "everybody
+    shares one bucket", which is an outage wearing a rate limit's clothes. The
+    per-address limit in `accounts.issue_link` is in Postgres and still bounds
+    what any one account can spend. `web.routes.auth` logs the empty case once
+    per process, so a control that has stopped working says so.
+
+    The socket address is the last resort and is only used when it is public —
+    a plain deployment with no proxy in front. On App Platform it is an
+    internal `10.244.x` that differs between requests, which is no more use as
+    a key than nothing at all.
 
     A header can be forged by anyone who can reach the container without going
     through the edge that sets it. There is no such path here — every hostname
@@ -117,22 +124,7 @@ def client_ip(request):
         if value:
             return value
 
-    # A conventional proxy chain, for anywhere that is not App Platform. Read
-    # from the right, because a proxy *appends* what it saw: the last entry is
-    # the one our own infrastructure wrote and the earlier ones are whatever
-    # the caller sent. Private addresses are stepped over, because an internal
-    # hop is always private and a real client on the internet never is.
-    hops = [hop.strip()
-            for hop in request.headers.get("X-Forwarded-For", "").split(",")
-            if hop.strip()]
-    for hop in reversed(hops):
-        if _is_public(hop):
-            return hop
-
-    # The socket. On App Platform this is an internal address that differs
-    # between requests, which is why it is last and why `""` is an acceptable
-    # answer above it.
-    remote = request.remote_addr or ""
+    remote = (request.remote_addr or "").strip()
     return remote if _is_public(remote) else ""
 
 

--- a/web/routes/auth.py
+++ b/web/routes/auth.py
@@ -76,6 +76,11 @@ PER_SECONDS = 3600
 
 SUBJECT = "Your DinkyDash sign-in link"
 
+# Set once, by `_warn_once_if_anonymous`. Module level rather than app config
+# because it is a fact about the platform this process is running on, not about
+# any one app built inside it.
+_warned_about_anonymous = False
+
 
 # The two loggers that write a request line: Flask's development server, and
 # gunicorn's access log. Both get the filter below.
@@ -162,12 +167,24 @@ def login():
 
 
 def _send_a_link(address):
-    """Do whatever there is to do, and tell the caller nothing about it.
+    """Do whatever there is to do, and tell the *caller* nothing about it.
 
     Every branch below returns the same None, and the page above is the same
     page, because each of them is something an attacker would otherwise learn:
     whether the address exists, whether it has asked recently, and whether our
     mail provider is up.
+
+    **The log is the exception, and that is the point of having one.** The
+    limits are ours rather than an edge rule precisely so that a refusal is a
+    line somebody can read. What goes in that line is chosen, not accidental:
+
+    * **the caller's address, in full.** Without it a rate-limit warning says
+      only "something happened", which is not worth writing. One script and a
+      hundred parents look identical.
+    * **the domain of the address asked about, never the address.** A flood of
+      `@mailinator.com` is the thing you want to see at a glance, and the list
+      of who has an account is the thing this endpoint exists not to publish —
+      in a page or in a third-party log we do not control.
 
     **Known and not closed: this takes longer when the address exists**, by
     roughly the time SendGrid takes to answer. Somebody timing the two could
@@ -175,11 +192,18 @@ def _send_a_link(address):
     a background worker's job rather than a login route's, and the enumeration
     it would buy is a list of addresses somebody already had.
     """
+    caller = ratelimit.client_ip(request)
+    _warn_once_if_anonymous(caller)
+
     limiter = current_app.config["LOGIN_LIMITER"]
-    if not limiter.allow(ratelimit.client_ip(request)):
-        # The caller's address, never the one they typed. Which addresses were
-        # asked about is the thing this endpoint exists not to say.
-        log.warning("A sign-in request was rate-limited by caller address.")
+    if not limiter.allow(caller):
+        # The limiter's own numbers, not the constants above. A line that
+        # reports a limit it did not apply is the kind of thing that misleads
+        # somebody at two in the morning.
+        log.warning("Sign-in requests from %s are over the limit "
+                    "(%s per %s minutes, in this process).",
+                    caller or "an unknown caller",
+                    limiter.most, round(limiter.per / 60))
         return
 
     pool = _pool()
@@ -189,6 +213,11 @@ def _send_a_link(address):
 
     token = accounts.issue_link(pool, user[0])
     if token is None:
+        # The limit that actually caps the SendGrid bill, and it used to be
+        # silent — the one refusal nobody could see.
+        log.warning("No sign-in link minted for a %s address from %s: "
+                    "%s live links already.", _domain(address),
+                    caller or "an unknown caller", accounts.MOST_LIVE_LINKS)
         return
 
     link = _link_for(token)
@@ -200,6 +229,39 @@ def _send_a_link(address):
         # must not add the link back. A failed send is a failed login, and the
         # person will ask again.
         log.warning("A sign-in link did not go out: %s", exc)
+    else:
+        # So the ordinary shape of the traffic is visible too, not only the
+        # refusals. `mail` logs that *an* email went; this says what kind.
+        log.info("Sent a sign-in link to a %s address.", _domain(address))
+
+
+def _domain(address):
+    """The part of an address that is not a person. `@example.com`, or `@?`."""
+    _, _, domain = accounts.normalise(address).partition("@")
+    return f"@{domain}" if domain else "@?"
+
+
+def _warn_once_if_anonymous(caller):
+    """Say so, once per process, if callers cannot be told apart.
+
+    `client_ip` returns `""` when no header identifies the caller, and an empty
+    key is one the limiter always allows — the deliberate choice, because
+    "everybody shares one bucket" is an outage wearing a rate limit's clothes.
+    But it means the per-caller limit has quietly stopped working, and a
+    control that fails silently is worse than one that is not there.
+
+    Once per process rather than per request: this is a platform-shaped fault,
+    so the second line would say nothing the first did not.
+    """
+    global _warned_about_anonymous
+    if caller or _warned_about_anonymous:
+        return
+    _warned_about_anonymous = True
+    log.warning(
+        "No caller address on this request: none of %s was set and the socket "
+        "address is not public. The per-caller sign-in limit is not firing; "
+        "the per-address one in Postgres still is.",
+        ", ".join(ratelimit.CALLER_HEADERS))
 
 
 def _link_for(token):

--- a/web/routes/board.py
+++ b/web/routes/board.py
@@ -2,11 +2,13 @@
 
 import os
 
-from flask import Blueprint, current_app, render_template, url_for
+from flask import Blueprint, render_template, request, url_for
 
 from dinkydash import board as board_view
 from dinkydash import config as config_module
 from web import manifest as manifest_module
+from web.family import current_store
+from web.session import guard
 
 bp = Blueprint("board", __name__)
 
@@ -16,9 +18,24 @@ PREVIEW_SIZES = [
     ("Old iPad", 1024, 768),
 ]
 
+# **`/healthz` must answer with no session, or every deploy rolls itself back.**
+# App Platform's health check arrives with no cookie and on a hostname nobody
+# signed in on; a 302 to `/login` there fails the check three times and the
+# platform reverts the release. It is also the one route that reads nothing, so
+# there is no family for it to need.
+OPEN_IN_CLOUD_MODE = {"board.healthz"}
 
-def current_store():
-    return current_app.config["STORE"]
+
+@bp.before_request
+def _needs_a_family():
+    """Cloud mode: the board is a family's board, so it needs a session.
+
+    Single mode has one family and no session, and `guard()` returns None there
+    — this is the same code in both modes, deciding differently.
+    """
+    if request.endpoint in OPEN_IN_CLOUD_MODE:
+        return None
+    return guard()
 
 
 def current_config():

--- a/web/routes/settings.py
+++ b/web/routes/settings.py
@@ -22,6 +22,7 @@ from dinkydash.context import compute_birthday_info, upcoming_for
 from dinkydash.runner import forget_calendar, refresh_calendars
 from dinkydash.runner import run as run_generation
 from web import manifest as manifest_module
+from web.family import current_store
 from web.session import guard
 
 log = logging.getLogger(__name__)
@@ -135,10 +136,6 @@ MONTHS = ["January", "February", "March", "April", "May", "June", "July",
 # cached, so anything under a quarter of an hour would be a promise we cannot
 # keep. The engine takes any integer — these are what the page offers.
 REFRESH_CHOICES = (15, 30, 60, 360, 1440)
-
-
-def current_store():
-    return current_app.config["STORE"]
 
 
 def current_config():

--- a/web/session.py
+++ b/web/session.py
@@ -86,12 +86,11 @@ def signed_in():
 
 
 def guard():
-    """Cloud mode: no session, no settings. Returns a redirect, or None.
+    """Cloud mode: no session, no family. Returns a redirect, or None.
 
-    This is authentication and not yet authorisation. Cloud mode still serves
-    the one family in `DINKYDASH_FAMILY_ID`; scoping every read and write to
-    the family on the session is its own issue, and is the actual "done when"
-    of PLAN.md phase 1.
+    Authentication and authorisation are the same act here, because the session
+    is not merely permission to see a board — it *is* which board. The family
+    on it is the only thing `web/family.py` will build a store from (DIN-39).
 
     No `next` parameter. A redirect target taken from a URL is an open redirect
     waiting to be written wrongly, and everything behind this gate is one page


### PR DESCRIPTION
`web/family.py` builds one `PostgresStore` per request from the family on the session; `create_app` holds no store at all in cloud mode and owns only the pool, built once and shared, because one store per request must not mean one pool per request.

**The property is stronger than "ids are checked":** nothing a caller can send names a family — no path segment, query parameter, form field or header — so there is no id to get wrong. The ids that do appear in URLs are item ids inside one family's config document, and another family's is not in the list; `tests/test_tenancy.py` walks all five sections and all four routes that take one, asserts a 404 (never a 403, which would confirm the row exists), and then asserts the other family's rows are unchanged — a 404 that wrote something first would otherwise pass.

The board is behind the session too, with `/healthz` the one exemption, because App Platform's check arrives with no cookie and a 302 there rolls the release back; `PostgresStore.load_config` now raises a named `NoSuchFamily` so a thirty-day session outliving its account signs the holder out instead of 500ing; and `login_link.py` prints a working sign-in link without waiting on email — same token, same limits, no bypass — because the Conductor preview now opens on `/login`.

The environment variable that named "the" family is gone from the code, the app spec, the Conductor script and the prose, and a `git grep` for it returning nothing is itself a test; verified live with two families in one process each seeing only their own name, theme, chore and headline, with 660 tests passing on a database and single mode asserted unchanged throughout.

**A second commit fixes a real bug found while checking this.** `client_ip` read `X-Forwarded-For`, which on App Platform is [documented](https://docs.digitalocean.com/support/where-can-i-find-the-client-ip-address-of-a-request-connecting-to-my-app/) as the *ingress server's* address, not the caller's — so the per-caller rate limit was keyed on DigitalOcean and every family would have shared one bucket. It now reads `DO-Connecting-IP` first, and an unidentifiable caller gets no key rather than a shared one. Relatedly: a `cf-ray` from `app.dinkydash.co` is not our Cloudflare — our zone is DNS-only on every record, and App Platform is itself served through Cloudflare's network. That is now written down beside the record it concerns.

The only thing outstanding after merge is applying the app spec again to drop the dead variable, which `deploy_on_push` will not do; leaving it late is harmless, since nothing reads it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)