### PR TITLE
Sign up: create a family from the product, not from a SQL insert (DIN-41)

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -149,6 +149,18 @@ services:
       --access-logformat '%(h)s %(l)s %(u)s %(t)s "%(m)s %(U)s %(H)s" %(s)s %(b)s "%(f)s" "%(a)s"'
       "wsgi:application"
 
+    # Component-scoped, because `_self` means nothing in the app-level block
+    # above. `${_self.COMMIT_HASH}` is a *bindable* variable: App Platform
+    # sets nothing in the environment on its own, so `/healthz` reported
+    # `"commit": "unknown"` on every deploy until this was bound. It is how
+    # you tell which code is actually running when a fix appears not to have
+    # shipped — `deploy_on_push` and `doctl apps update` are separate events,
+    # and this repo has already been caught out by that twice.
+    envs:
+      - key: GIT_SHA
+        scope: RUN_TIME
+        value: ${_self.COMMIT_HASH}
+
     instance_size_slug: apps-s-1vcpu-0.5gb
     instance_count: 1
     http_port: 8080

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,7 +155,11 @@ mode is a different product on the same code.
   `tests/test_auth.py`; none of them is a preference.
 - **A login request answers identically whether or not the address has an account**, including when
   it is rate-limited and when the send fails. Anything else enumerates accounts, and the accounts
-  are families.
+  are families. **`/login` is the sign-up form too** (DIN-41), which is why there is no "create an
+  account" route: a second page, or a second button, would say which addresses already have one.
+- **Nothing a stranger can POST creates a row that costs money.** A sign-up creates the family when
+  the emailed link is *clicked*, so an unverified one costs a token row and an email rather than a
+  trial and a daily Anthropic call. That is the rate limit; the cap is the spend breaker below.
 - **Every form that writes carries a CSRF token**, in *both* modes — `web/session.py`, with no
   switch to turn it off. A test walks the templates and fails on a form without one.
 - **Screen tokens are bearer credentials.** Rate-limited, `noindex`, no referrer leakage, rotatable,
@@ -262,7 +266,7 @@ dinkydash/
 ├── pgstore.py         PostgresStore, the cloud one. Imports psycopg; single mode never does
 ├── db.py              the connection pool and the migration runner (cloud only)
 ├── mail.py            one transactional email, over SendGrid (cloud only)
-├── accounts.py        users, and the magic links that sign them in (cloud only)
+├── accounts.py        users, the links that sign them in, and sign-up (cloud only)
 └── runner.py          the two halves of the day, reading and writing through a store
 
 web/

--- a/PLAN.md
+++ b/PLAN.md
@@ -8,6 +8,13 @@
 
 *September 8, later: **one service, not two.** The board joins the marketing site in the existing `dinkydash-site` app rather than getting its own, because that is how `qrpage.co` and `abc-league` already run in this account — one container, one gunicorn, everything in it. Staging is dropped until there is a paying family to protect. The `worker` is the one genuine addition, because the tick has no lock and two web instances would tick twice. See [Hosting and deployment](#hosting-and-deployment).*
 
+*September 8, later: **sign-up exists** (DIN-41). An address posted to `/login` gets a link, and
+clicking it creates the family, the parent and a starting config in one transaction. The design
+question that had to be settled first was *when* the family is created, and the answer is **on the
+click, not on the submit** — see [Sign-up](#sign-up) below. `login_tokens.user_id` is nullable and
+the row carries an `email` instead (`migrations/002_signup_tokens.sql`). Nothing is created by
+asking, so an unverified sign-up costs one token row and one email.*
+
 *September 8: the transactional email provider is settled — decision 13, **SendGrid**, on the account KeepTheScore already sends from. The open question is closed. `dinkydash.co` is an authenticated sending domain on that account (DKIM and a monitor-only DMARC record are live in Cloudflare), and this repo has its own send-only API key. What is not built is the sending itself — that arrives with magic links in Phase 1.*
 
 *September 7, later still: the Postgres layer is built (DIN-31) — `migrations/001_initial_schema.sql`, `migrate.py`, `dinkydash/db.py`, `dinkydash/pgstore.py`, and a contract suite that runs the same assertions over both stores in CI. Connection pooling is settled above. What is deliberately still missing is the multi-tenancy: cloud mode serves one family, named by an environment variable, because auth and scoping are Phase 1.*
@@ -131,6 +138,49 @@ them.
 `store.py` and `config.py` are now the only files under `dinkydash/` that open
 a file. That is the invariant to keep: a read anywhere else is a caller cloud
 mode would have to fork.
+
+### Sign-up
+
+*Built in DIN-41.* One form does both jobs. A new address and a returning one post the same field to
+`/login`, get the same page back, and are told apart behind that answer — two routes or two buttons
+would publish which addresses already have an account, which is the one thing that page exists to
+hide. What differs is only what lands in the mailbox, and whoever opens that mailbox already knows.
+
+**The family is created when the link is clicked.** This was the open question and it is worth
+writing down, because the simpler design is the other one. A `families` row starts the 14-day trial,
+and the worker calls Anthropic daily for every family that is not lapsed — so a POST that created
+one would let a script turn free sign-ups into a real and rising bill with no card behind it and
+nothing to charge back. Creating on the click instead means an unverified sign-up costs **one
+`login_tokens` row and one email**: no trial, no API call, and no second cleanup job, because the
+sweep that already deletes expired tokens is the cleanup. It also makes "signing in through the link
+*is* email verification" true of sign-up as well — otherwise a family exists for an address nobody
+has proved they can read.
+
+That is a rate limit's worth of protection and not a cap. The cap is the **global spend breaker**,
+which is Phase 2 and still to come. A CAPTCHA is deliberately last: it puts a third-party script on
+the page where a parent types their email, and friction on the one conversion step that matters, so
+it waits until abuse actually appears.
+
+**The cost was a schema change, and it bought one table rather than two.** `login_tokens.user_id` is
+now nullable, with an `email` column beside it and a CHECK that exactly one of the two is set. A
+separate `signup_tokens` table would have needed its own single-use `UPDATE`, its own expiry, its own
+sweep and its own rate limit — and single use is the property everything else rests on, so a second
+copy of that statement is a second thing to keep right. Both kinds of token prove the same thing;
+only what happens next differs, and that branch lives in one place in `accounts.consume_link`.
+
+**A new family is seeded rather than empty.** `config.starter_config()` is the same invented
+household `config.example.yaml` documents — two children, a dog, two chores, two countdowns, every
+one of them there to be replaced. An empty board looks broken rather than empty. **No calendar URL,
+not even an example**: an iCal address is a password in a URL, and one that worked would put somebody
+else's appointments on a stranger's wall. The settings home says so while the board is still
+untouched, which is `settings.looks_untouched` — no calendar and the default family name, a signal
+that is equally true of a freshly cloned Pi, so it needs no mode check.
+
+**Still open, and not this issue's:** the gap between the click and the first board. The worker's
+next tick refreshes the calendars within five minutes, but the brief waits for `brief_time` on the
+family's clock, so a 03:00 sign-up looks at a waiting screen until 06:00. PLAN.md's "**Generate now**
+on signup" line under [Scheduling](#scheduling-cloud-mode) is what closes it, and it is a Phase 2
+worker item — a web request must not call Anthropic.
 
 ### Three clocks, one setting
 
@@ -668,7 +718,7 @@ Critical path is 0 → 1 → 2 → 3. Phases 4–6 can run alongside 3. Nothing 
 - [x] Name the storage seam: `FileStore` gathering the six operations that exist today, and the settings routes, runner and board taking a store *(DIN-19)*
 - [x] Postgres + plain-SQL migrations; CI running the suite against a Postgres service container *(DIN-31)*
 - [x] Move DNS to Cloudflare and add the app records *(DIN-29)*. The apex now points at App Platform, not GitHub Pages — DIN-27 moved the marketing pages onto the app. The SendGrid records are in the same zone and validated: `em4199`, `s1._domainkey`, `s2._domainkey` and a `_dmarc` TXT at `p=none`. All four are **DNS-only** — a proxied CNAME answers as Cloudflare and domain authentication never passes.
-- [ ] Add the board to the existing `dinkydash-site` app and stand up Managed Postgres in Frankfurt; `app.dinkydash.co` live over TLS *(DIN-26)*. One service serving both hostnames, plus a `worker` and a `PRE_DEPLOY` migration job. No staging app — see the database section.
+- [x] Add the board to the existing `dinkydash-site` app and stand up Managed Postgres in Frankfurt; `app.dinkydash.co` live over TLS *(DIN-26)*. One service serving both hostnames, plus a `worker` and a `PRE_DEPLOY` migration job. No staging app — see the database section. Done on 8 September 2026: the board answers on `app.dinkydash.co`, the cluster is online in `fra1`, and the worker has been ticking every five minutes since 10:58 UTC. **Phase 0 is closed.**
 
 **Done when:** the engine runs from a dict with an injected date, tests pass in CI on Postgres, a same-day calendar change reaches a Pi within its chosen interval, and `app.dinkydash.co` serves a hardcoded family over TLS.
 
@@ -683,12 +733,13 @@ missing is the multi-tenant half — a schema, auth, and scoping every read and 
 - [x] Magic-link auth: token hashed at rest, single use, 15-minute expiry, request endpoint rate-limited per address and per caller. Signing in through the link *is* email verification — there is no second step. *(DIN-38)*
 - [x] Session hygiene: `Secure` (cloud only — a Pi serves plain HTTP), `HttpOnly`, `SameSite=Lax`; a CSRF token on every form, in **both** modes and with no switch to turn it off; cloud mode refuses to start without `DINKYDASH_SECRET_KEY` *(DIN-38)*
 - [x] `fetch_feed` hardening before any stranger's URL is fetched: `https` only, redirects that cannot land on a private range, a response size cap beside the timeout *(DIN-33)*. The settings page's "Check this link" goes through the same function, so it is covered too. DNS rebinding is documented as still open.
-- [ ] Family setup wizard: people + DOBs, emoji/color avatars, pets, chores, special dates
+- [x] **Sign-up: an address creates a family, a parent and a starting config — on the click, not on the submit** *(DIN-41)*. The same form as sign-in, and the same answer. `screen_token` and `trial_ends_at` are set at creation; see [Sign-up](#sign-up) for why the schema changed.
+- [ ] Family setup wizard: people + DOBs, emoji/color avatars, pets, chores, special dates. **Half of this exists**: the five lists are editable at `/settings/…` and a new family arrives seeded, with a first-run card on the settings home saying the household is invented and pointing at the calendar and the timezone (DIN-41). What is missing is a guided multi-step path rather than a settings page.
 - [ ] Multi-calendar management: add/label/enable/remove iCal feeds, with live validation on paste
 - [ ] Per-provider help content — Google, iCloud, Outlook each expose iCal URLs differently
 - [ ] Settings: timezone, family name, refresh cadence, screen URL display + rotation, account deletion. `claude_model` hidden in cloud mode.
 - [x] Every read and write scoped to the family on the session; the hardcoded family id deleted *(DIN-39)*
-- [ ] The URL map above: `/` redirects, `/login`, `/s/<token>`
+- [ ] The URL map above: `/` redirects, `/login`, `/s/<token>`. **`/login` is done** (DIN-38, DIN-41). The other two are one change and not two: in cloud mode `/` is the board today, so it cannot start redirecting to `/settings/` until `/s/<token>` is where the board lives — and that route is Phase 3's first box. Doing half of it would leave the board unreachable.
 
 **Done when:** two different families can be configured independently through the UI, and a request carrying the wrong family's id in a URL gets a 404, never a row. **Met by DIN-39**, and asserted in `tests/test_tenancy.py`.
 

--- a/dinkydash/CLAUDE.md
+++ b/dinkydash/CLAUDE.md
@@ -66,7 +66,7 @@ resolves an email address to a user before there is a family to scope to. A magi
 exactly one person without being told which family they belong to, which is why `users.email` is
 globally unique.
 
-## Signing somebody in
+## Signing somebody in, and signing somebody up
 
 `accounts.py` is the token lifecycle and nothing else: mint, hash, spend, sweep. Four things in it
 are load-bearing, and each is asserted in `tests/test_auth.py`:
@@ -87,6 +87,28 @@ The per-address rate limit lives in the same `INSERT` — at most `MOST_LIVE_LIN
 per user — so two requests arriving together cannot both read "two live links" and both make a
 third. The per-IP half is in `web/ratelimit.py` and is in-process, because a database write on
 every unauthenticated request is itself something to flood.
+
+**Sign-up is the same token and the same `consume_link`** (DIN-41). An address with no account gets
+a row carrying the address instead of a `user_id`; spending it creates the family, the parent and a
+starter config in the transaction that spent it. Five things about that are deliberate:
+
+- **The family is created on the click, never on the submit.** A `families` row starts a 14-day
+  trial and the worker calls Anthropic daily for it, so a POST that created one would be a way to
+  spend our money without a card. Verifying first makes an unverified sign-up cost one row and one
+  email. The reasoning in full is in [PLAN.md](../PLAN.md#sign-up).
+- **One table, not two.** `login_tokens.user_id` is nullable with an `email` beside it and a CHECK
+  that exactly one is set. A `signup_tokens` table would have meant a second single-use `UPDATE`,
+  and that statement is the thing the whole design rests on — written twice, one copy drifts.
+- **A sign-up token is outside every cascade.** It has no `user_id`, so deleting a family does not
+  reach it; the sweep does, fifteen minutes later. That is fine in production and it bit the test
+  suite, where the scratch database is reused between runs — `tests/conftest.forget_ownerless_tokens`
+  is what stops three abandoned sign-ups silently exhausting `MOST_LIVE_LINKS` on the next run.
+- **Two links for one new address must not make two families.** `_start_a_family` looks the address
+  up first and the INSERT that follows carries `ON CONFLICT DO NOTHING`; losing that race means
+  deleting the family just made, which nothing else can have seen.
+- **The screen token is generated and checked in the same statement**, so the UNIQUE index is the
+  backstop rather than the error path. A collision at 59 bits is not something anyone will see, but
+  an unhandled one would spend somebody's sign-up link and hand them a 500.
 
 ## Cloud mode: schema, migrations, connections
 

--- a/dinkydash/accounts.py
+++ b/dinkydash/accounts.py
@@ -1,14 +1,30 @@
-"""Users, and the links that sign them in. Cloud mode only.
+"""Users, the links that sign them in, and the families those links create.
+Cloud mode only.
 
-    normalise(email)             -> the address as it is compared
-    user_for(pool, email)        -> (user_id, family_id), or None
-    issue_link(pool, user_id)    -> the plaintext token, or None if rate-limited
-    consume_link(pool, token)    -> (user_id, family_id), or None
-    sweep(pool)                  -> how many dead tokens were deleted
+    normalise(email)                 -> the address as it is compared
+    user_for(pool, email)            -> (user_id, family_id), or None
+    issue_link(pool, user_id)        -> the plaintext token, or None if limited
+    issue_signup_link(pool, email)   -> the same, for an address with no account
+    consume_link(pool, token)        -> (user_id, family_id), or None
+    sweep(pool)                      -> how many dead tokens were deleted
 
 One email in, one link out, one session (PLAN.md phase 1). Signing in through
 the link *is* email verification: there is no second step, no password, and
 nothing to reset.
+
+**Sign-up is the same act, and the same token** (DIN-41). An address with no
+account gets a token carrying the address instead of a user id; spending it
+creates the family and the user and signs them in. There is one `consume_link`
+because single use is the property everything else rests on, and a second copy
+of that statement is a second thing to keep right.
+
+**The family is created when the link is clicked, never when the address is
+submitted.** A `families` row starts a 14-day trial and the worker calls
+Anthropic daily for it, so creating one on an unverified POST would let a
+script run up a real bill with no card behind it. This way an unverified
+sign-up costs one token row and one email, and the existing sweep is already
+the cleanup. It is a rate limit's worth of protection rather than a cap: the
+cap is the global spend breaker, which is PLAN.md phase 2 and still to come.
 
 **Only the hash is stored.** The plaintext exists for the length of one email
 and is never written anywhere else — not to a row, not to a log line, not into
@@ -39,9 +55,12 @@ under the `generate()` boundary knows that users exist.
 """
 
 import hashlib
+import json
 import logging
 import secrets
 from datetime import timedelta
+
+from . import config as config_module
 
 log = logging.getLogger(__name__)
 
@@ -69,6 +88,22 @@ MOST_LIVE_LINKS = 3
 # Anything longer than a real token is not one, and there is no reason to hash
 # it to find that out. A URL can carry a great deal.
 LONGEST_TOKEN = 200
+
+# What `users.email` and `login_tokens.email` both allow, and the longest an
+# address can be under RFC 5321. Checked here rather than left to the column,
+# because a CHECK violation is a 500 on a route anybody can post to.
+LONGEST_EMAIL = 320
+
+# The trial, in the app rather than in Stripe (PLAN.md decisions 6 and phase 4):
+# a family that never converts never becomes a Stripe customer.
+TRIAL = timedelta(days=14)
+
+# How many times to try for an unused screen token before giving up. 12
+# characters of `config.ID_ALPHABET` is about 59 bits, so a collision is not
+# something anyone will see — but the column is UNIQUE, and an unhandled
+# violation here would spend somebody's sign-up link and hand them a 500. Three
+# tries costs nothing and turns an astronomically rare 500 into a retry.
+SCREEN_TOKEN_TRIES = 3
 
 
 def normalise(email):
@@ -138,12 +173,54 @@ def issue_link(pool, user_id, ttl=TOKEN_TTL, most=MOST_LIVE_LINKS):
     return token
 
 
+def issue_signup_link(pool, email, ttl=TOKEN_TTL, most=MOST_LIVE_LINKS):
+    """Mint one token for an address with no account. Plaintext, or None.
+
+    The same shape as `issue_link` and deliberately so: the same TTL, the same
+    single use, and the same "at most three live at once" counted inside the
+    INSERT rather than in a SELECT before it. The only difference is what the
+    row points at — an address, because the user it will become does not exist
+    yet.
+
+    **It does not check whether the address already has an account**, and does
+    not need to: `_start_a_family` signs an existing user in rather than making
+    them a second family, so a token minted by mistake is harmless. The check
+    belongs at the call site, which needs the answer anyway to choose which
+    email to send.
+    """
+    address = normalise(email)
+    if not address or "@" not in address or len(address) > LONGEST_EMAIL:
+        return None
+    token = new_token()
+    with pool.connection() as conn, conn.transaction():
+        with conn.cursor() as cur:
+            cur.execute(
+                """INSERT INTO login_tokens (email, token_hash, expires_at)
+                   SELECT %s, %s, now() + %s
+                   WHERE (SELECT count(*) FROM login_tokens
+                          WHERE email = %s AND expires_at > now()) < %s
+                   RETURNING id""",
+                (address, hash_token(token), ttl, address, most),
+            )
+            if cur.fetchone() is None:
+                # Same as the sign-in half: asking twice is what somebody does
+                # when the first email is slow, so this is not an error.
+                return None
+    return token
+
+
 def consume_link(pool, token):
     """Spend a token. Returns (user_id, family_id), or None for anything wrong.
 
     Expired, already used, and never issued are one answer on purpose. The
     caller shows one page for all three, so there is nothing here for a caller
     to leak by accident.
+
+    **Two kinds of token, one statement.** The UPDATE below marks either kind
+    used; what comes back decides what happens next. A `user_id` means somebody
+    signing in. An `email` means somebody signing up, and the family is created
+    here — inside the same transaction that spent the token, so a family can
+    never exist for a link that did not work.
     """
     if not token or len(token) > LONGEST_TOKEN:
         return None
@@ -155,18 +232,100 @@ def consume_link(pool, token):
                    WHERE token_hash = %s
                      AND used_at IS NULL
                      AND expires_at > now()
-                   RETURNING user_id""",
+                   RETURNING user_id, email""",
                 (hash_token(token),),
             )
             row = cur.fetchone()
             if row is None:
                 return None
+            user_id, email = row
+            if user_id is None:
+                return _start_a_family(cur, email)
             cur.execute(
                 "UPDATE users SET last_login_at = now() WHERE id = %s "
                 "RETURNING id, family_id",
-                (row[0],),
+                (user_id,),
             )
             return cur.fetchone()
+
+
+def _start_a_family(cur, email):
+    """Create the family and the parent, and return (user_id, family_id).
+
+    **One transaction, and the caller's.** A `families` row with no user is
+    unreachable and a `users` row with no family violates the foreign key, so
+    there is no half-way state worth keeping — and because this runs inside the
+    same transaction that spent the token, a failure anywhere leaves the token
+    unspent and the person able to click again.
+
+    **A second link for the same new address must not make a second family.**
+    Two POSTs before either click mints two tokens, and both work. So the
+    address is looked up first, and the INSERT that follows carries
+    `ON CONFLICT DO NOTHING` for the case where the two clicks land close
+    enough together that the lookup missed. Losing that race means undoing the
+    family just created — hence the DELETE, which removes a row nothing else
+    can have seen yet.
+    """
+    address = normalise(email)
+    cur.execute("SELECT id FROM users WHERE lower(email) = %s", (address,))
+    existing = cur.fetchone()
+    if existing is None:
+        family_id = _new_family(cur)
+        cur.execute(
+            """INSERT INTO users (family_id, email, last_login_at)
+               VALUES (%s, %s, now())
+               ON CONFLICT (email) DO NOTHING
+               RETURNING id, family_id""",
+            (family_id, address),
+        )
+        made = cur.fetchone()
+        if made is not None:
+            log.info("Created a family for a %s address.", _domain(address))
+            return made
+        cur.execute("DELETE FROM families WHERE id = %s", (family_id,))
+
+    cur.execute(
+        "UPDATE users SET last_login_at = now() WHERE lower(email) = %s "
+        "RETURNING id, family_id",
+        (address,),
+    )
+    return cur.fetchone()
+
+
+def _new_family(cur):
+    """One `families` row, on the trial, with a screen token and a board to show.
+
+    The token is generated here and checked in the same statement rather than
+    trusted, so the UNIQUE index is the backstop and not the error path.
+    """
+    starter = json.dumps(config_module.starter_config())
+    for _ in range(SCREEN_TOKEN_TRIES):
+        token = config_module.new_screen_token()
+        cur.execute(
+            """INSERT INTO families (screen_token, config, trial_ends_at)
+               SELECT %s, %s::jsonb, now() + %s
+               WHERE NOT EXISTS (
+                   SELECT 1 FROM families WHERE screen_token = %s)
+               RETURNING id""",
+            (token, starter, TRIAL, token),
+        )
+        row = cur.fetchone()
+        if row is not None:
+            return row[0]
+    raise RuntimeError(
+        f"No unused screen token in {SCREEN_TOKEN_TRIES} tries, which should "
+        "not be possible at 59 bits — check new_screen_token.")
+
+
+def _domain(address):
+    """The part of an address that is not a person, for a log line.
+
+    The same rule the login route follows: a flood from one domain is worth
+    seeing, and the list of who has an account is the thing none of this
+    publishes.
+    """
+    _, _, domain = normalise(address).partition("@")
+    return f"@{domain}" if domain else "@?"
 
 
 def sweep(pool):

--- a/dinkydash/config.py
+++ b/dinkydash/config.py
@@ -56,6 +56,11 @@ LIST_KEYS = ("people", "pets", "recurring", "special_dates", "calendars")
 ID_ALPHABET = "23456789abcdefghjkmnpqrstuvwxyz"
 ID_LENGTH = 8
 
+# A screen URL is read off a television and typed on a remote, so it uses the
+# same unambiguous alphabet — 12 characters of it is about 59 bits, which is
+# what PLAN.md's "Screen URLs" section settled on. The column allows 10 to 32.
+SCREEN_TOKEN_LENGTH = 12
+
 
 def quoted(value):
     """A string that stays quoted when the file is written back.
@@ -146,6 +151,77 @@ def new_id(taken=()):
         value = "".join(secrets.choice(ID_ALPHABET) for _ in range(ID_LENGTH))
         if value not in taken:
             return value
+
+
+def new_screen_token():
+    """The unguessable part of a family's board URL.
+
+    A bearer credential: whoever holds it sees the board, which is the whole
+    point — a wall panel cannot sign in. Rotatable from the settings page, so
+    this is called again rather than once per family for ever.
+    """
+    return "".join(secrets.choice(ID_ALPHABET)
+                   for _ in range(SCREEN_TOKEN_LENGTH))
+
+
+def starter_config():
+    """What a brand-new family gets before they have typed anything.
+
+    A board with nothing on it looks broken rather than empty, and the first
+    thing a parent sees should be the shape of the thing they signed up for —
+    so this seeds the same invented family `config.example.yaml` documents:
+    two children, a dog, two chores that rotate between them, and two
+    countdowns. Every one of them is there to be replaced.
+
+    **No calendar.** Not even an example URL. An iCal address is a password in
+    a URL, and one that worked would put somebody else's appointments on a
+    stranger's wall; one that did not would be a broken feed on a board nobody
+    has finished setting up yet. Adding the first calendar is the parent's
+    first real act in the settings UI, and the per-provider help is written for
+    exactly that moment.
+
+    **The timezone is the default, which is UTC**, because guessing it from an
+    IP address is wrong often enough to be worse than asking. It is the one
+    setting that changes what the board *says* — when today rolls over, and
+    what time the brief is written — so the welcome on the settings home points
+    at it first.
+
+    Pure, and no clock: dates of birth are fixed like the example file's, and
+    the ages computed from them move on their own. `ensure_ids` runs here so
+    the settings UI can address a person the moment the family exists, rather
+    than rewriting the document on first open.
+    """
+    config = with_defaults({
+        "family_name": "Our family",
+        "people": [
+            {"name": "Mia", "date_of_birth": "2017-03-15",
+             "avatar_emoji": "\U0001f996", "avatar_color": "purple",
+             "interests": "dinosaurs, drawing, swimming"},
+            {"name": "Theo", "date_of_birth": "2019-06-20",
+             "avatar_emoji": "\u26bd", "avatar_color": "blue",
+             "interests": "football, lego"},
+        ],
+        "pets": [
+            {"name": "Biscuit", "type": "dog", "avatar_emoji": "\U0001f415"},
+        ],
+        "recurring": [
+            {"title": "Set the table", "emoji": "\U0001f37d",
+             "choices": ["Mia", "Theo"]},
+            {"title": "Feed Biscuit", "emoji": "\U0001f9b4",
+             "choices": ["Theo", "Mia"]},
+        ],
+        "special_dates": [
+            {"title": "Christmas", "emoji": "\U0001f384", "date": "12/25"},
+            {"title": "Summer holidays", "emoji": "\u2600\ufe0f", "date": "07/01"},
+        ],
+    })
+    ensure_ids(config)
+    # Storage-layer keys: they say where a self-hoster's generated files go and
+    # mean nothing as a jsonb column. `with_defaults` puts them in; a hosted
+    # family should not carry two filenames nothing will ever open.
+    for key in ("data_file", "content_history_file"):
+        config.pop(key, None)
+    return config
 
 
 def ensure_ids(config):

--- a/doc/operations.md
+++ b/doc/operations.md
@@ -117,13 +117,17 @@ like a quiet day: `doctl apps logs <id> worker --type run --follow` is the only 
 
 ## Magic links, 8 September 2026 (DIN-38)
 
-`/login`, `/login/link` and `/logout` exist in cloud mode. **Nothing creates a user yet** — sign-up
-is a later issue — so the one family seeded from `config.example.yaml` needs a row inserted by hand
-before anybody can sign in:
+`/login`, `/login/link` and `/logout` exist in cloud mode. **Nothing created a user when this was
+written**, so the one family seeded from `config.example.yaml` needed a row inserted by hand:
 
 ```sql
 INSERT INTO users (family_id, email) VALUES ('<the family uuid>', 'you@example.com');
 ```
+
+**That statement is obsolete as of DIN-41, below.** It is left here because it is what was actually
+run on 8 September 2026, and because it is still the way in if the app is down and somebody needs an
+account made. It is no longer the only way in, and it should not be the first thing anybody reaches
+for.
 
 One outstanding action, and it is a security one. **`.do/app.yaml` now sets a gunicorn
 `--access-logformat`** built from `%(U)s`, so the sign-in link's `?t=` is not written to the
@@ -159,7 +163,8 @@ it applied-late is harmless here: the variable is simply ignored by code that no
 **Signing in for development or support:** `venv/bin/python login_link.py you@example.com` prints a
 working link without waiting on email. Same token, same fifteen minutes, same single use, same
 per-address limit — the only thing it skips is SendGrid. **What it prints is a credential**, so it
-does not go in an issue or a screenshot. It does not create accounts; the `INSERT` above still does.
+does not go in an issue or a screenshot. It does not create accounts; sign-up does, and that now
+exists — see below.
 
 **What the sign-in limits write to the log**, which is the reason for keeping them in the app
 rather than moving them to a Cloudflare rule. Grep `web.routes.auth`:
@@ -200,6 +205,40 @@ through Cloudflare**: the CNAME target `clownfish-app-7xt89.ondigitalocean.app` 
 hostname carries a `cf-ray` too. So a Cloudflare header on a response says nothing about our proxy
 setting, and `CF-Connecting-IP` may well be present without us having put it there.
 
+
+## Sign-up, 8 September 2026 (DIN-41)
+
+**A family can be created by the product.** Posting an address to `/login` sends a link; clicking it
+creates the `families` row, the `users` row and a starting config in one transaction. The hand-written
+`INSERT` above is no longer the way in.
+
+**Nothing is created by the POST**, and that is the abuse control rather than a detail. A `families`
+row starts the 14-day trial and the worker calls Anthropic daily for it, so an unverified sign-up
+costs one `login_tokens` row and one email instead. `login_tokens.user_id` is nullable as of
+`migrations/002_signup_tokens.sql`, with an `email` column beside it.
+
+**What to watch, now that a stranger can make rows.** There is still no global spend breaker (PLAN.md
+phase 2), so the ceiling on a scripted sign-up run is the two rate limits and nothing else: twenty
+requests per caller address per hour **per web process** (`--workers 2`, so forty, and a redeploy
+resets it), and three live links per address in Postgres. Neither bounds a distributed run. Until the
+breaker lands, the check is the family count against the Anthropic bill:
+
+```sql
+SELECT status, count(*), min(created_at), max(created_at) FROM families GROUP BY status;
+```
+
+`doctl apps logs <id> site --type run | grep "sign-up link"` shows the shape of the traffic — the
+domain asked about and the caller, never the address.
+
+**Applying the migration.** `deploy_on_push` runs the `PRE_DEPLOY` job, so the schema change goes out
+with the code and needs no separate step. A failed migration fails the deploy rather than half-updating
+a live app, which is the point of it being a pre-deploy job.
+
+**Two outstanding spec applies, and they want one run.** Neither is urgent and both need the
+merge-values-from-`.env` dance in the header of `.do/app.yaml`: the dead environment variable DIN-39
+removed, and `GIT_SHA` bound to `${_self.COMMIT_HASH}` so `/healthz` stops answering
+`"commit": "unknown"`. That variable is *bindable*, not automatic — App Platform sets nothing on its
+own, which is why the two guessed fallbacks that used to be in `healthz` never fired.
 
 ## GitHub's own secret scanning
 

--- a/login_link.py
+++ b/login_link.py
@@ -19,9 +19,11 @@ that person until it is spent. It grants nothing you did not already have —
 running it needs the database password — but pasting it into an issue, a chat
 or a screenshot hands it to somebody who has neither.
 
-It does not create accounts. Sign-up is the product's job (DIN-41); until that
-exists, a new family needs a row inserted by hand, and doc/operations.md has
-the statement.
+**It does not create accounts, and no longer needs to.** Sign-up is the
+product's job and the product now does it (DIN-41): posting an address to
+`/login` sends a link, and clicking that link creates the family. This is for
+getting into an account that already exists without waiting on email — which
+is the developer's case and the support case, not a new family's.
 
 Reads `DATABASE_URL`, like the app.
 """
@@ -69,8 +71,9 @@ def main(argv=None):
             # Said plainly here, unlike the web route: this is a local tool run
             # by somebody holding the database password, so there is nobody to
             # enumerate accounts for.
-            print(f"No account for {args.email}. Nothing creates one yet — see "
-                  f"doc/operations.md.", file=sys.stderr)
+            print(f"No account for {args.email}. To make one, post the address "
+                  f"to /login and click the link it sends — that is what "
+                  f"creates a family.", file=sys.stderr)
             return 1
 
         token = accounts.issue_link(pool, user[0])

--- a/migrations/002_signup_tokens.sql
+++ b/migrations/002_signup_tokens.sql
@@ -1,0 +1,45 @@
+-- Sign-up: let a token exist before the family it will create (DIN-41).
+--
+-- Until now a `login_tokens` row needed a `user_id`, so nothing could be sent
+-- to somebody who did not already have an account. That is why the only family
+-- in production was inserted by hand with SQL.
+--
+-- **Why the family is created when the link is clicked, not when the address is
+-- submitted.** A `families` row starts a 14-day trial, and the worker calls
+-- Anthropic daily for every family that is not lapsed. If a POST to /login
+-- created one, ten thousand scripted sign-ups would be a real and rising daily
+-- bill with no card behind it and nothing to charge back. Verifying first makes
+-- an unverified sign-up cost one row here and one email — no trial, no API call,
+-- and nothing to sweep up afterwards that the existing sweep does not already
+-- take. It also makes "signing in through the link *is* email verification"
+-- (PLAN.md phase 1) true of sign-up as well: without it a family exists for an
+-- address nobody has proved they can read.
+--
+-- **Why this is one table and not two.** A `signup_tokens` table beside this one
+-- would need its own single-use UPDATE, its own expiry, its own sweep and its own
+-- rate limit — and single use is the one property the whole design rests on
+-- (`UPDATE ... WHERE used_at IS NULL RETURNING`, decided and marked in one
+-- statement). Written twice, one copy drifts. What both kinds of token prove is
+-- identical: whoever clicked it reads that mailbox. Only what happens next
+-- differs, and that branch belongs in one place in `accounts.consume_link`.
+--
+-- The cost is the column below plus a CHECK, which is cheaper than a second
+-- table's worth of the same care.
+
+-- A sign-up token has no user yet. Every existing row has one and keeps it.
+ALTER TABLE login_tokens ALTER COLUMN user_id DROP NOT NULL;
+
+-- Who the token is for when there is no user: the address it was mailed to.
+-- Same 320-character bound as `users.email`, because it becomes one.
+ALTER TABLE login_tokens ADD COLUMN email TEXT CHECK (length(email) <= 320);
+
+-- Exactly one of the two, never both and never neither. A row with both would
+-- be a token that could sign one person in and create an account for another;
+-- a row with neither is a credential belonging to nobody.
+ALTER TABLE login_tokens ADD CONSTRAINT login_tokens_one_subject
+    CHECK ((user_id IS NULL) <> (email IS NULL));
+
+-- The per-address rate limit on sign-up counts live tokens for one address, the
+-- way `login_tokens_user_idx` serves the same limit for one user. Partial,
+-- because every sign-in token has a NULL here and none of them is ever counted.
+CREATE INDEX login_tokens_email_idx ON login_tokens (email) WHERE email IS NOT NULL;

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,8 +45,28 @@ def pg_pool():
 
     pool = db.pool(url, min_size=1, max_size=2)
     pool.wait(timeout=10)
+    forget_ownerless_tokens(pool)
     yield pool
     pool.close()
+
+
+def forget_ownerless_tokens(pool):
+    """Delete every sign-up token, which nothing else will.
+
+    A sign-up token has no `user_id` — that is the whole point of it (DIN-41),
+    and it is why `login_tokens.user_id` became nullable. The consequence is
+    that `ON DELETE CASCADE` from `families` does not reach one, so a test that
+    posts an address and never clicks the link leaves a row behind that outlives
+    its own database.
+
+    In production the sweep takes it fifteen minutes later. Here the scratch
+    database is reused between runs, so three abandoned sign-ups for one address
+    silently exhaust `MOST_LIVE_LINKS` and the next run fails somewhere else
+    entirely. Once when the pool is built, and again after every family.
+    """
+    with pool.connection() as conn, conn.transaction():
+        with conn.cursor() as cur:
+            cur.execute("DELETE FROM login_tokens WHERE user_id IS NULL")
 
 
 @pytest.fixture
@@ -69,6 +89,8 @@ def pg_family(pg_pool):
     with pg_pool.connection() as conn, conn.transaction():
         with conn.cursor() as cur:
             cur.execute("DELETE FROM families WHERE id = %s", (family_id,))
+    # Not part of that cascade, and not reachable from it — see above.
+    forget_ownerless_tokens(pg_pool)
 
 
 # -- a test client that behaves like a browser ------------------------------

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -351,9 +351,18 @@ class TestAskingForALink:
         assert len(sent) == 1
         assert sent[0]["to"] == ADDRESS
 
-    def test_an_unknown_address_gets_none(self, client, sent, pg_user):
+    def test_an_unknown_address_gets_one_too_now_that_it_can_sign_up(
+            self, client, sent, pg_user):
+        """This asserted `sent == []` until DIN-41, and the change is the point.
+
+        The same form is now the sign-up form, so an address with no account
+        gets a link that starts a board rather than silence. What must not
+        change is the page: `test_but_the_two_pages_are_identical` below is the
+        assertion that actually guards against enumeration, and it still holds.
+        """
         client.post("/login", data={"email": "stranger@example.com"})
-        assert sent == []
+        assert len(sent) == 1
+        assert "Start your DinkyDash board" in sent[0]["subject"]
 
     def test_but_the_two_pages_are_identical(self, client, sent, pg_user):
         known = client.post("/login", data={"email": ADDRESS})
@@ -667,12 +676,17 @@ class TestWhatTheLogSays:
         assert "Sent a sign-in link to a @example.com address." in caplog.text
         assert ADDRESS not in caplog.text
 
-    def test_nothing_is_logged_about_an_address_with_no_account(
+    def test_an_address_with_no_account_is_logged_by_domain_and_never_in_full(
             self, cloud, sent, pg_user, caplog):
+        """Before DIN-41 nothing happened for an unknown address, so nothing was
+        logged. Now a sign-up link goes out, and the same rule applies to it as
+        to every other line here: the domain, because a flood from one is the
+        thing worth seeing at a glance, and never the address itself."""
         with caplog.at_level("INFO"):
             client_for(cloud).post("/login", data={"email": "stranger@nowhere.test"},
                                    headers=self.CALLER)
-        assert "nowhere.test" not in caplog.text
+        assert "Sent a sign-up link to a @nowhere.test address." in caplog.text
+        assert "stranger@nowhere.test" not in caplog.text
 
     def test_a_caller_we_cannot_identify_says_so_once(self, cloud, sent, pg_user, caplog):
         """A control that has stopped working silently is worse than none."""

--- a/tests/test_secrets_and_headers.py
+++ b/tests/test_secrets_and_headers.py
@@ -127,8 +127,7 @@ class TestHealthz:
         assert client.get("/healthz").get_json()["commit"] == "abc1234"
 
     def test_an_unknown_commit_is_not_an_error(self, client, monkeypatch):
-        for name in ("GIT_SHA", "APP_PLATFORM_COMPONENT_COMMIT", "SOURCE_COMMIT"):
-            monkeypatch.delenv(name, raising=False)
+        monkeypatch.delenv("GIT_SHA", raising=False)
         assert client.get("/healthz").get_json()["commit"] == "unknown"
 
     def test_it_touches_no_storage(self, client, monkeypatch):

--- a/tests/test_signup.py
+++ b/tests/test_signup.py
@@ -1,0 +1,447 @@
+"""Sign-up: a family created by the product rather than by a SQL insert (DIN-41).
+
+Four claims, and the first is the one the whole design turns on:
+
+* **nothing is created until the link is clicked.** A `families` row starts a
+  14-day trial and the worker calls Anthropic daily for it, so a POST that made
+  one would let a script run up a bill with no card behind it. An unverified
+  sign-up must cost exactly one `login_tokens` row and one email;
+* **the family and the parent arrive together**, in one transaction, with a
+  screen token and a config that renders a board rather than an empty page;
+* **the sign-up page and the sign-in page are the same page**, byte for byte,
+  because a separate "create an account" route publishes which addresses have
+  one;
+* **clicking twice, or signing up twice, does not make two families.**
+
+Skips without `DINKYDASH_TEST_DATABASE_URL`, like the rest of the Postgres
+half — every assertion here needs rows.
+"""
+
+import re
+
+import pytest
+import yaml
+
+from dinkydash import accounts, config as config_module, mail
+from tests.conftest import client_for
+from web import create_app
+
+NEWCOMER = "newcomer@example.com"
+
+CONFIG = '''\
+family_name: "The Wilsons"
+timezone: "Europe/Berlin"
+'''
+
+
+@pytest.fixture
+def sent(monkeypatch):
+    """Every email the app tried to send, instead of sending it."""
+    outbox = []
+
+    def _send(to, subject, text, html=None, **kwargs):
+        outbox.append({"to": to, "subject": subject, "text": text, "html": html})
+
+    monkeypatch.setattr(mail, "send", _send)
+    return outbox
+
+
+@pytest.fixture
+def cloud(pg_pool, pg_family, monkeypatch):
+    """A cloud app with a pool.
+
+    `pg_family` is here for its teardown and because the app needs a pool
+    either way. The families this module makes are its own, created by the
+    product under test, and `clean_up` below removes them.
+    """
+    from dinkydash.pgstore import PostgresStore
+
+    PostgresStore(pg_pool, pg_family).save_config(yaml.safe_load(CONFIG))
+    monkeypatch.setenv("DINKYDASH_MODE", "cloud")
+    monkeypatch.setenv("DINKYDASH_SECRET_KEY", "a-real-one")
+    return create_app(pool=pg_pool)
+
+
+@pytest.fixture
+def client(cloud):
+    return client_for(cloud)
+
+
+@pytest.fixture(autouse=True)
+def clean_up(pg_pool):
+    """Delete whatever a test signed up, however it got created.
+
+    Autouse and keyed on the address rather than on a returned id, because the
+    point of most of these tests is that the row appears without anybody being
+    handed its id.
+    """
+    yield
+    with pg_pool.connection() as conn, conn.transaction():
+        with conn.cursor() as cur:
+            cur.execute(
+                """DELETE FROM families WHERE id IN (
+                       SELECT family_id FROM users WHERE email LIKE %s)""",
+                ("%@example.com",),
+            )
+            cur.execute("DELETE FROM login_tokens WHERE email LIKE %s",
+                        ("%@example.com",))
+
+
+def link_in(message):
+    found = re.search(r"https?://\S+/login/link\?t=[\w\-]+", message["text"])
+    assert found, message["text"]
+    return found.group(0)
+
+
+def rows(pg_pool, sql, args=()):
+    with pg_pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(sql, args)
+        return cur.fetchall()
+
+
+def family_of(pg_pool, address):
+    """The family row behind an address, or None. As a dict, for readability."""
+    found = rows(pg_pool, """SELECT f.id, f.screen_token, f.status, f.plan,
+                                    f.trial_ends_at, f.config
+                             FROM families f JOIN users u ON u.family_id = f.id
+                             WHERE lower(u.email) = %s""", (address,))
+    if not found:
+        return None
+    keys = ("id", "screen_token", "status", "plan", "trial_ends_at", "config")
+    return dict(zip(keys, found[0]))
+
+
+# -- nothing is created by asking -------------------------------------------
+
+class TestSubmittingAnAddressCreatesNothing:
+    """The abuse control, and the reason the schema changed.
+
+    At roughly $0.13 per family per month, ten thousand scripted sign-ups that
+    each started a trial would be a real and rising daily Anthropic bill with
+    nothing to charge back. So the POST must be cheap.
+    """
+
+    def test_no_family_and_no_user_exist_after_a_post(self, client, sent, pg_pool):
+        client.post("/login", data={"email": NEWCOMER})
+        assert rows(pg_pool, "SELECT id FROM users WHERE email = %s",
+                    (NEWCOMER,)) == []
+        assert family_of(pg_pool, NEWCOMER) is None
+
+    def test_what_it_does_cost_is_one_token_and_one_email(
+            self, client, sent, pg_pool):
+        client.post("/login", data={"email": NEWCOMER})
+        assert len(rows(pg_pool,
+                        "SELECT id FROM login_tokens WHERE email = %s",
+                        (NEWCOMER,))) == 1
+        assert len(sent) == 1
+
+    def test_the_token_carries_the_address_and_no_user(self, client, sent, pg_pool):
+        client.post("/login", data={"email": NEWCOMER})
+        held = rows(pg_pool,
+                    "SELECT user_id, email FROM login_tokens WHERE email = %s",
+                    (NEWCOMER,))
+        assert held == [(None, NEWCOMER)]
+
+    def test_an_unclicked_signup_is_swept_like_any_other_dead_token(
+            self, client, sent, pg_pool):
+        """There is no second cleanup job to write, which is most of the point."""
+        client.post("/login", data={"email": NEWCOMER})
+        with pg_pool.connection() as conn, conn.transaction():
+            with conn.cursor() as cur:
+                cur.execute("UPDATE login_tokens SET expires_at = now() - "
+                            "interval '1 minute' WHERE email = %s", (NEWCOMER,))
+        assert accounts.sweep(pg_pool) >= 1
+        assert rows(pg_pool, "SELECT id FROM login_tokens WHERE email = %s",
+                    (NEWCOMER,)) == []
+
+
+# -- clicking is what creates it --------------------------------------------
+
+class TestClickingTheLinkStartsTheFamily:
+    def test_a_family_and_a_parent_appear(self, client, sent, pg_pool):
+        client.post("/login", data={"email": NEWCOMER})
+        client.get(link_in(sent[0]))
+        family = family_of(pg_pool, NEWCOMER)
+        assert family is not None
+        assert family["plan"] == "standard"
+
+    def test_and_the_session_is_theirs(self, client, sent, pg_pool):
+        client.post("/login", data={"email": NEWCOMER})
+        landed = client.get(link_in(sent[0]))
+        assert landed.status_code == 302
+        assert landed.headers["Location"].endswith("/settings/")
+        with client.session_transaction() as stored:
+            assert stored["family_id"] == str(family_of(pg_pool, NEWCOMER)["id"])
+
+    def test_the_screen_token_is_there_from_the_first_moment(
+            self, client, sent, pg_pool):
+        """Never null: the board's URL is not something to add later."""
+        client.post("/login", data={"email": NEWCOMER})
+        client.get(link_in(sent[0]))
+        token = family_of(pg_pool, NEWCOMER)["screen_token"]
+        assert 10 <= len(token) <= 32
+        assert set(token) <= set(config_module.ID_ALPHABET)
+
+    def test_the_trial_is_fourteen_days_and_the_family_is_trialing(
+            self, client, sent, pg_pool):
+        client.post("/login", data={"email": NEWCOMER})
+        client.get(link_in(sent[0]))
+        family = family_of(pg_pool, NEWCOMER)
+        assert family["status"] == "trialing"
+        [(days,)] = rows(pg_pool,
+                         "SELECT round(extract(epoch from (trial_ends_at - now()))"
+                         " / 86400) FROM families WHERE id = %s", (family["id"],))
+        assert days == 14
+
+    def test_no_stripe_customer_is_created(self, client, sent, pg_pool):
+        """The trial lives in the app; Stripe enters at conversion (phase 4)."""
+        client.post("/login", data={"email": NEWCOMER})
+        client.get(link_in(sent[0]))
+        [(customer,)] = rows(pg_pool,
+                             "SELECT stripe_customer_id FROM families WHERE id = %s",
+                             (family_of(pg_pool, NEWCOMER)["id"],))
+        assert customer is None
+
+    def test_a_dead_link_creates_nothing(self, client, sent, pg_pool):
+        client.post("/login", data={"email": NEWCOMER})
+        link = link_in(sent[0])
+        with pg_pool.connection() as conn, conn.transaction():
+            with conn.cursor() as cur:
+                cur.execute("UPDATE login_tokens SET expires_at = now() - "
+                            "interval '1 minute' WHERE email = %s", (NEWCOMER,))
+        client.get(link)
+        assert family_of(pg_pool, NEWCOMER) is None
+
+
+# -- what the new family sees -----------------------------------------------
+
+class TestTheStartingConfig:
+    def test_the_board_has_people_on_it_rather_than_nothing(
+            self, client, sent, pg_pool):
+        """An empty board looks broken; the invented family is there to replace."""
+        client.post("/login", data={"email": NEWCOMER})
+        client.get(link_in(sent[0]))
+        config = family_of(pg_pool, NEWCOMER)["config"]
+        assert [person["name"] for person in config["people"]] == ["Mia", "Theo"]
+        assert config["recurring"] and config["special_dates"] and config["pets"]
+
+    def test_and_never_a_calendar_url(self, client, sent, pg_pool):
+        """An iCal address is a password in a URL. A working example would put
+        somebody else's appointments on a stranger's wall."""
+        client.post("/login", data={"email": NEWCOMER})
+        client.get(link_in(sent[0]))
+        assert family_of(pg_pool, NEWCOMER)["config"]["calendars"] == []
+
+    def test_every_item_can_be_addressed_before_anybody_opens_the_settings(self):
+        """Ids are backfilled on first open in single mode. A hosted family
+        should not need that round trip, so the starter carries them."""
+        config = config_module.starter_config()
+        for key in config_module.LIST_KEYS:
+            for item in config[key]:
+                assert item.get("id")
+
+    def test_it_carries_no_file_paths(self):
+        """`data_file` and `content_history_file` are FileStore's business, and
+        a jsonb column is not a directory."""
+        config = config_module.starter_config()
+        assert "data_file" not in config
+        assert "content_history_file" not in config
+
+    def test_the_board_renders_for_a_family_that_has_typed_nothing(
+            self, client, sent):
+        """It shows the waiting screen, not the seeded people, and that is
+        right: there is no payload until the worker's next tick writes one.
+
+        **The seeded config is what the tick then has to work with**, which is
+        the reason for seeding it — a family with no people would get a board
+        with nothing on it but a date. PLAN.md's "Generate now on signup" is
+        what closes the gap between the click and the first board, and it is a
+        phase 2 worker item: a web request must not call Anthropic.
+        """
+        client.post("/login", data={"email": NEWCOMER})
+        client.get(link_in(sent[0]))
+        page = client.get("/")
+        assert page.status_code == 200
+        assert "Our family" in page.get_data(as_text=True)
+
+    def test_but_the_settings_show_the_people_straight_away(self, client, sent):
+        """Which is where a new parent is sent, and where they replace them."""
+        client.post("/login", data={"email": NEWCOMER})
+        client.get(link_in(sent[0]))
+        assert client.get("/settings/").status_code == 200
+        listed = client.get("/settings/people").get_data(as_text=True)
+        assert "Mia" in listed and "Theo" in listed
+
+
+class TestTheSettingsSayTheHouseholdIsInvented:
+    """Seeding without saying so is somebody else's children on your page."""
+
+    def test_a_brand_new_family_is_told(self, client, sent):
+        client.post("/login", data={"email": NEWCOMER})
+        client.get(link_in(sent[0]))
+        page = client.get("/settings/").get_data(as_text=True)
+        assert "Make it yours" in page
+        assert "invented" in page
+
+    def test_and_pointed_at_the_two_things_that_matter_first(self, client, sent):
+        client.post("/login", data={"email": NEWCOMER})
+        client.get(link_in(sent[0]))
+        page = client.get("/settings/").get_data(as_text=True)
+        assert "Add a calendar" in page and "Set the timezone" in page
+
+    def test_it_goes_once_there_is_a_calendar(self, client, sent, pg_pool):
+        from dinkydash.pgstore import PostgresStore
+
+        client.post("/login", data={"email": NEWCOMER})
+        client.get(link_in(sent[0]))
+        store = PostgresStore(pg_pool, family_of(pg_pool, NEWCOMER)["id"])
+        config = store.load_config()
+        config["calendars"] = [{"id": "cal11111", "label": "Ours",
+                                "url": "https://example.com/private-xxxx/basic.ics",
+                                "enabled": True}]
+        store.save_config(config)
+        assert "Make it yours" not in client.get("/settings/").get_data(as_text=True)
+
+    def test_it_goes_once_the_family_has_a_name(self, client, sent, pg_pool):
+        from dinkydash.pgstore import PostgresStore
+
+        client.post("/login", data={"email": NEWCOMER})
+        client.get(link_in(sent[0]))
+        store = PostgresStore(pg_pool, family_of(pg_pool, NEWCOMER)["id"])
+        config = store.load_config()
+        config["family_name"] = "The Bakers"
+        store.save_config(config)
+        assert "Make it yours" not in client.get("/settings/").get_data(as_text=True)
+
+    def test_the_signal_needs_no_mode_check(self):
+        """It is the config that says untouched, so a freshly cloned Pi is told
+        the same two things — which is why there is no `cloud` branch in it."""
+        from web.routes.settings import looks_untouched
+
+        assert looks_untouched(config_module.starter_config())
+        assert not looks_untouched({"family_name": "The Bakers", "calendars": []})
+        assert not looks_untouched(
+            {"family_name": "Our family", "calendars": [{"id": "c", "url": "x"}]})
+
+
+# -- one family, however many links -----------------------------------------
+
+class TestOnlyEverOneFamilyPerAddress:
+    def test_clicking_the_same_link_twice_signs_in_once_and_creates_once(
+            self, client, sent, pg_pool):
+        client.post("/login", data={"email": NEWCOMER})
+        link = link_in(sent[0])
+        client.get(link)
+        client.get(link)  # single use: the second is a dead link
+        assert len(rows(pg_pool, "SELECT id FROM users WHERE email = %s",
+                        (NEWCOMER,))) == 1
+
+    def test_two_signups_then_both_links_still_make_one_family(
+            self, client, sent, pg_pool):
+        """Two POSTs before either click mint two live tokens, and both work."""
+        client.post("/login", data={"email": NEWCOMER})
+        client.post("/login", data={"email": NEWCOMER})
+        assert len(sent) == 2
+        first = family_after(client, sent[0], pg_pool)
+        second = family_after(client, sent[1], pg_pool)
+        assert first == second
+        assert len(rows(pg_pool, "SELECT id FROM families WHERE id = %s",
+                        (first,))) == 1
+
+    def test_and_the_second_click_leaves_no_orphan_family(
+            self, client, sent, pg_pool):
+        """Losing the race means undoing the family just made, not keeping it."""
+        client.post("/login", data={"email": NEWCOMER})
+        client.post("/login", data={"email": NEWCOMER})
+        before = rows(pg_pool, "SELECT count(*) FROM families")[0][0]
+        client.get(link_in(sent[0]))
+        client.get(link_in(sent[1]))
+        after = rows(pg_pool, "SELECT count(*) FROM families")[0][0]
+        assert after == before + 1
+
+    def test_signing_up_with_an_address_that_already_has_an_account(
+            self, client, sent, pg_pool):
+        """A token minted for an address that gained an account meanwhile signs
+        them in rather than giving them a second board."""
+        client.post("/login", data={"email": NEWCOMER})
+        client.get(link_in(sent[0]))
+        family = family_of(pg_pool, NEWCOMER)["id"]
+
+        # Signed in, and `/login` redirects somebody who already is — so this
+        # is what asking for a second link actually looks like.
+        client.post("/logout")
+        client.post("/login", data={"email": NEWCOMER})   # now a sign-in link
+        client.get(link_in(sent[1]))
+        assert family_of(pg_pool, NEWCOMER)["id"] == family
+
+    def test_an_absurdly_long_address_is_refused_before_it_reaches_a_row(
+            self, client, sent, pg_pool):
+        """`users.email` is 320 characters, and a CHECK violation would be a 500
+        on a route anybody can post to. Refused as bad input, and — the reason
+        it is checked in the route — never logged as a rate limit it did not
+        hit."""
+        page = client.post("/login", data={"email": "a" * 400 + "@example.com"})
+        assert b"does not look like an email address" in page.get_data()
+        assert sent == []
+        assert rows(pg_pool, "SELECT id FROM login_tokens WHERE email IS NOT NULL") == []
+
+    def test_the_per_address_limit_counts_signup_links_too(
+            self, client, sent, pg_pool):
+        """Three live links per address, whichever kind. It is the control that
+        caps the SendGrid bill, and sign-up must not be a way round it."""
+        for _ in range(5):
+            client.post("/login", data={"email": NEWCOMER})
+        assert len(sent) == accounts.MOST_LIVE_LINKS
+
+
+def family_after(client, message, pg_pool):
+    client.get(link_in(message))
+    return family_of(pg_pool, NEWCOMER)["id"]
+
+
+# -- and it still says nothing about who exists ------------------------------
+
+class TestTheAnswerIsStillTheSame:
+    def test_a_new_address_and_a_returning_one_get_identical_pages(
+            self, client, sent, pg_pool):
+        """The assertion that actually prevents enumeration. It mattered before
+        DIN-41 and it matters more now that one of the two creates something."""
+        client.post("/login", data={"email": NEWCOMER})
+        client.get(link_in(sent[0]))          # NEWCOMER now has an account
+
+        returning = client.post("/login", data={"email": NEWCOMER})
+        stranger = client.post("/login", data={"email": "nobody@example.com"})
+        assert returning.status_code == stranger.status_code
+        assert returning.get_data() == stranger.get_data()
+
+    def test_the_page_promises_a_link_without_a_condition_on_it(self, client):
+        """It used to say "if that address has an account". Now every address
+        that asks really does get one, so the hedge would be a lie."""
+        page = client.post("/login", data={"email": NEWCOMER})
+        body = page.get_data(as_text=True)
+        assert "A link is on its way" in body
+        assert "if that address has an account" not in body.lower()
+
+    def test_the_form_is_one_form_with_one_button(self, client):
+        """Two buttons is two ways to learn whether an address is registered."""
+        page = client.get("/login").get_data(as_text=True)
+        assert page.count("<form") == 1
+        assert page.count('type="submit"') == 1
+
+    def test_the_two_emails_differ_only_in_the_mailbox(self, client, sent):
+        """Safe, because whoever opens that mailbox already knows which they are.
+        Telling a new parent the link starts a board is what gets it finished."""
+        client.post("/login", data={"email": NEWCOMER})
+        client.get(link_in(sent[0]))
+        client.post("/logout")
+        client.post("/login", data={"email": NEWCOMER})
+        assert "Start your DinkyDash board" in sent[0]["subject"]
+        assert "sign-in link" in sent[1]["subject"]
+
+    def test_neither_email_carries_anything_but_the_link(self, client, sent):
+        """No image, no pixel, no third-party CSS: a login email that loads
+        anything hands the fact of the login to whoever serves it."""
+        client.post("/login", data={"email": NEWCOMER})
+        html = sent[0]["html"]
+        assert "<img" not in html and "http://" not in html
+        assert len(re.findall(r"https://", html)) == 1

--- a/web/CLAUDE.md
+++ b/web/CLAUDE.md
@@ -51,6 +51,13 @@ value="{{ csrf_token() }}">`, right inside the `<form>`. `csrf_token()` is a Jin
 deliberately no switch to turn the check off; the test client in `tests/conftest.py` fills the field
 in the way a browser does.
 
+**The settings home has a first-run card**, shown by `settings.looks_untouched`: no calendar and the
+default family name. A hosted family is created with an invented household in it so the board has
+something to show (DIN-41), and this is what stops that reading as a bug. **The signal is the config,
+not the mode** — a freshly cloned Pi is in the same state and wants the same two prompts — so there
+is no `cloud` branch in it, and it leaves on its own the moment either half is answered. Nothing to
+dismiss and nothing remembered.
+
 **Two chromes, one base.** `settings/base.html` is the phone-shaped shell for everything a person
 signs into — the settings pages and, in cloud mode, `auth/login.html` and `auth/sent.html`. The
 manifest link in its `<head>` is a `{% block manifest %}` so the login page can drop it: the

--- a/web/routes/auth.py
+++ b/web/routes/auth.py
@@ -5,6 +5,13 @@
     GET  /login/link     spend the token, start the session, go to the settings
     POST /logout         throw the session away
 
+**This is the sign-up form too** (DIN-41). A new address and a returning one
+submit the same field to the same route and get the same page back; which one
+happened is decided behind that answer, in `_send_a_link`, and the family is
+not created until the link is clicked. Two routes or two buttons would publish
+whether an address is already registered, which is the one thing this page
+exists to hide.
+
 Registered only when `DINKYDASH_MODE=cloud`. Self-hosted has no accounts by
 design — one family on their own network, and the same trust model as the
 config file the settings UI writes — so in single mode these routes do not
@@ -59,9 +66,14 @@ bp = Blueprint("auth", __name__)
 A_TOKEN = re.compile(r"([?&]t=)[^&\s\"']+")
 REDACTED = r"\1[redacted]"
 
-# The one answer a login request ever gets.
-SAME_ANSWER = ("If that address has an account, a link is on its way. "
-               "It works once, and for fifteen minutes.")
+# The one answer a login request ever gets. It used to begin "If that address
+# has an account", because an unknown one got nothing at all. Now that the same
+# form starts a board, a link really does go to every address that asks — so
+# the hedge is gone and the sentence is simply true. The cases that still send
+# nothing are the two rate limits and a failed send, none of which is about
+# whether an account exists.
+SAME_ANSWER = ("A link is on its way. It works once, and for fifteen minutes. "
+               "If you have not got a board yet, the link starts one.")
 
 # What a token that is expired, spent or invented all get.
 DEAD_LINK = ("That link no longer works — it has either been used already or "
@@ -75,6 +87,7 @@ MOST_PER_IP = 20
 PER_SECONDS = 3600
 
 SUBJECT = "Your DinkyDash sign-in link"
+WELCOME_SUBJECT = "Start your DinkyDash board"
 
 # Set once, by `_warn_once_if_anonymous`. Module level rather than app config
 # because it is a fact about the platform this process is running on, not about
@@ -156,9 +169,16 @@ def login():
         return render_template("auth/login.html")
 
     address = request.form.get("email", "")
-    if "@" not in address:
+    if "@" not in address or len(address.strip()) > accounts.LONGEST_EMAIL:
         # The one thing worth saying back, and it says nothing about accounts:
         # this is about what was typed, not about who exists.
+        #
+        # The length is checked here rather than left to the column, and it has
+        # to be checked *here* rather than only inside `issue_signup_link`: that
+        # function answers None for a refusal too, and the caller below would
+        # then log "3 live links already" about an address that has none. A line
+        # reporting a limit it did not apply is the kind of thing that misleads
+        # somebody at two in the morning.
         return render_template("auth/login.html", email=address,
                                problem="That does not look like an email address.")
 
@@ -209,30 +229,43 @@ def _send_a_link(address):
     pool = _pool()
     user = accounts.user_for(pool, address)
     if user is None:
-        return
+        # No account, so this is a sign-up. **Nothing is created here.** The
+        # token carries the address, and the family is made when the link is
+        # clicked (DIN-41) — an unverified sign-up costs one row and one email
+        # rather than a trial and a daily Anthropic call.
+        kind, token = "sign-up", accounts.issue_signup_link(pool, address)
+    else:
+        kind, token = "sign-in", accounts.issue_link(pool, user[0])
 
-    token = accounts.issue_link(pool, user[0])
     if token is None:
         # The limit that actually caps the SendGrid bill, and it used to be
         # silent — the one refusal nobody could see.
-        log.warning("No sign-in link minted for a %s address from %s: "
-                    "%s live links already.", _domain(address),
+        log.warning("No %s link minted for a %s address from %s: "
+                    "%s live links already.", kind, _domain(address),
                     caller or "an unknown caller", accounts.MOST_LIVE_LINKS)
         return
 
     link = _link_for(token)
+    new_family = kind == "sign-up"
     try:
-        mail.send(accounts.normalise(address), SUBJECT,
-                  _text(link), html=_html(link))
+        mail.send(accounts.normalise(address),
+                  WELCOME_SUBJECT if new_family else SUBJECT,
+                  _text(link, new_family), html=_html(link, new_family))
     except mail.MailError as exc:
         # `mail` messages carry no address, no key and no body, and this one
         # must not add the link back. A failed send is a failed login, and the
         # person will ask again.
-        log.warning("A sign-in link did not go out: %s", exc)
+        log.warning("A %s link did not go out: %s", kind, exc)
     else:
         # So the ordinary shape of the traffic is visible too, not only the
         # refusals. `mail` logs that *an* email went; this says what kind.
-        log.info("Sent a sign-in link to a %s address.", _domain(address))
+        #
+        # **The kind is safe to write and the address is not.** Which of the
+        # two an address got is exactly what the page above refuses to say, so
+        # it goes in our own log — where the point of having one is that a
+        # refusal is a line somebody can read — with the domain and never the
+        # address, the same rule as everything else here.
+        log.info("Sent a %s link to a %s address.", kind, _domain(address))
 
 
 def _domain(address):
@@ -308,7 +341,31 @@ def logout():
     return redirect(url_for("auth.login"))
 
 
-def _text(link):
+def _text(link, new_family=False):
+    """The email. Two openings, because one of them is somebody's first.
+
+    **The difference is safe.** What the page says back is identical either
+    way; this only differs in a mailbox, and whoever opens that mailbox knows
+    whether they already had a board. Telling a new parent that the link starts
+    one is the difference between finishing the sign-up and abandoning it.
+    """
+    if new_family:
+        return f"""\
+Welcome to DinkyDash.
+
+Open this link and your board is ready — people, chores and countdowns are
+already filled in with an invented family for you to replace:
+
+{link}
+
+It works once, and for fifteen minutes.
+
+If you did not ask for this, you can ignore it. Nothing has been created, and
+the link stops working on its own.
+
+- DinkyDash
+https://dinkydash.co
+"""
     return f"""\
 Here is your link to sign in to DinkyDash:
 
@@ -324,12 +381,23 @@ https://dinkydash.co
 """
 
 
-def _html(link):
+def _html(link, new_family=False):
     """Deliberately plain. No images, no tracking pixel, no third-party CSS.
 
     A login email that loads anything from anywhere else hands the fact of the
     login, and often the URL, to whoever serves it.
     """
+    if new_family:
+        return f"""\
+<p>Welcome to DinkyDash.</p>
+<p>Open this link and your board is ready — people, chores and countdowns are
+already filled in with an invented family for you to replace:</p>
+<p><a href="{link}">Start my board</a></p>
+<p>It works once, and for fifteen minutes.</p>
+<p>If you did not ask for this, you can ignore it. Nothing has been created,
+and the link stops working on its own.</p>
+<p>— DinkyDash</p>
+"""
     return f"""\
 <p>Here is your link to sign in to DinkyDash:</p>
 <p><a href="{link}">Sign in to DinkyDash</a></p>

--- a/web/routes/board.py
+++ b/web/routes/board.py
@@ -91,12 +91,17 @@ def healthz():
     question it should be able to answer wrongly.
 
     The SHA comes from the environment because a deployed checkout has no
-    `.git` to ask. App Platform sets it; anything else falls back to "unknown".
+    `.git` to ask. **App Platform does not set one on its own** — this read
+    "unknown" in production from the first deploy until 8 September 2026,
+    because the two fallbacks that used to be here (`APP_PLATFORM_COMPONENT_
+    COMMIT`, `SOURCE_COMMIT`) were guesses at variable names that do not
+    exist. What does exist is `${_self.COMMIT_HASH}`, a *bindable* variable:
+    it has to be assigned to a key in the component's own `envs` before
+    anything can read it, and it is component-scoped, so it cannot live in the
+    app-level block with the rest. `.do/app.yaml` binds it to `GIT_SHA`, which
+    is the one name `website/site.py` already agreed on.
     """
     return {
         "status": "ok",
-        "commit": os.environ.get("GIT_SHA")
-        or os.environ.get("APP_PLATFORM_COMPONENT_COMMIT")
-        or os.environ.get("SOURCE_COMMIT")
-        or "unknown",
+        "commit": os.environ.get("GIT_SHA") or "unknown",
     }, 200, {"Cache-Control": "no-store", "X-Robots-Tag": "noindex"}

--- a/web/routes/settings.py
+++ b/web/routes/settings.py
@@ -237,7 +237,26 @@ def home():
     return render_template(
         "settings/home.html", config=config, status=status, counts=counts,
         broken=broken, sections=SECTIONS, cadence=cadence_summary(config),
+        first_run=looks_untouched(config),
     )
+
+
+def looks_untouched(config):
+    """Is this still the board it was handed, rather than one somebody made?
+
+    A family created by sign-up starts with an invented household in it, so
+    that the board has something to show rather than looking broken (DIN-41).
+    That is only kind if the settings page says so — otherwise a new parent
+    opens it and finds two children who are not theirs, with no explanation.
+
+    **The signal is the config, not the mode.** No calendar and the default
+    family name means nothing has been set up, and that is as true of a Pi
+    somebody has just cloned as of a hosted family five seconds old. Both
+    should be told the same two things, so there is no mode check here. The
+    banner leaves on its own the moment either is answered.
+    """
+    return (not (config.get("calendars") or [])
+            and config.get("family_name") == config_module.DEFAULTS["family_name"])
 
 
 def _clock(stamp, tzinfo):

--- a/web/templates/auth/login.html
+++ b/web/templates/auth/login.html
@@ -1,7 +1,10 @@
-{# The only page cloud mode serves to somebody with no session. One field, one
-   button, and the same answer whatever is typed into it. #}
+{# The only page cloud mode serves to somebody with no session, and it is the
+   sign-up form as well as the sign-in one. One field, one button, and the same
+   answer whatever is typed into it — a separate "create an account" page would
+   publish which addresses already have one. So the wording has to invite both
+   without saying which the reader is. #}
 {% extends "settings/base.html" %}
-{% block title %}Sign in{% endblock %}
+{% block title %}Sign in or start a board{% endblock %}
 {% block manifest %}{% endblock %}
 
 {% block appbar %}
@@ -15,10 +18,11 @@
 
 <div class="card pad" style="display:flex;flex-direction:column;gap:0.875rem;">
     <div>
-        <div style="font-size:1.125rem;font-weight:800;">Sign in</div>
+        <div style="font-size:1.125rem;font-weight:800;">Sign in or start a board</div>
         <div class="hint" style="margin-top:0.1875rem;">
-            Type the address your board is under. We send a link that signs you in — there
-            is no password to remember and none to lose.
+            Type your email address and we send you a link. It signs you in, or starts a
+            new board if you have not got one — there is no password to remember and none
+            to lose.
         </div>
     </div>
     <form method="post" action="{{ url_for('auth.login') }}"
@@ -34,6 +38,9 @@
                    spellcheck="false" inputmode="email" required>
         </div>
         <button class="btn" type="submit">Email me a link</button>
+        <div class="hint">
+            New here? The first fourteen days are free and we do not ask for a card.
+        </div>
     </form>
 </div>
 {% endblock %}

--- a/web/templates/settings/home.html
+++ b/web/templates/settings/home.html
@@ -8,6 +8,34 @@
 {% endblock %}
 
 {% block content %}
+{% if first_run %}
+{# Shown while the board is still the one it was handed: no calendar, and the
+   default family name. A new family is seeded with an invented household so
+   that the board has something on it, and this is what stops that reading as
+   a bug — somebody else's children on your settings page, unexplained. It
+   goes as soon as either half is answered, so there is nothing to dismiss. #}
+<div class="card pad" style="display:flex;flex-direction:column;gap:0.75rem;">
+    <div>
+        <div style="font-size:1.125rem;font-weight:800;">Make it yours</div>
+        <div class="hint" style="margin-top:0.1875rem;">
+            The people, pets and chores below are invented, so the board has something
+            to show while you set it up. Replace them with your own.
+        </div>
+    </div>
+    <div class="note-box">
+        Two things are worth doing first: add a calendar, which is what puts today's
+        plans on the board, and set your timezone — it decides when the day rolls over
+        and when the morning's line is written.
+    </div>
+    <div style="display:flex;gap:0.625rem;">
+        <a class="btn" style="flex:1;"
+           href="{{ url_for('settings.section_list', section_name='calendars') }}">Add a calendar</a>
+        <a class="btn outline" style="flex:1;"
+           href="{{ url_for('settings.system') }}">Set the timezone</a>
+    </div>
+</div>
+{% endif %}
+
 <div class="card pad" style="display:flex;flex-direction:column;gap:0.875rem;">
     <div>
         <div style="font-size:1.125rem;font-weight:800;">{{ config.family_name or "Your board" }}</div>


### PR DESCRIPTION
Closes DIN-41. Also closes Phase 0's last box, and fixes `/healthz` reporting `"commit": "unknown"`.

## The question that had to be settled first

**The family is created when the link is clicked, not when the address is submitted.**

The issue's scope said submitted. That is the simpler design and it is where the money leaks: a `families` row starts the 14-day trial, and the worker calls Anthropic **daily** for every family that is not lapsed. A POST that created one would let a script turn free sign-ups into a real and rising bill with no card behind it and nothing to charge back.

Creating on the click makes an unverified sign-up cost **one `login_tokens` row and one email** — no trial, no API call, and no cleanup job to write, because the sweep that already deletes expired tokens is the cleanup. It also makes "signing in through the link *is* email verification" true of sign-up: otherwise a family exists for an address nobody has proved they can read.

That is a rate limit's worth of protection, not a cap. The cap is the **global spend breaker** (phase 2). A CAPTCHA stays last, as the issue's abuse-control comment argues.

## The schema change, and why it is one table

`login_tokens.user_id` is nullable, with an `email` column beside it and a CHECK that exactly one is set (`migrations/002_signup_tokens.sql`).

A separate `signup_tokens` table would have needed its own single-use `UPDATE`, its own expiry, its own sweep and its own rate limit. **Single use is the property everything else rests on** — `UPDATE ... WHERE used_at IS NULL RETURNING`, decided and marked in one statement — so a second copy of it is a second thing to keep right. Both kinds of token prove the same thing; only what happens next differs, and that branch lives in one place in `accounts.consume_link`.

## Sign-up is a branch behind `/login`, not a second route

A new address and a returning one submit the same field and get the same page back, byte for byte. Two routes or two buttons would publish which addresses already have an account. What differs is only what lands in the mailbox — safe, because whoever opens that mailbox already knows which they are, and telling a new parent the link starts a board is what gets the sign-up finished.

One nice consequence: the answer used to hedge ("*if* that address has an account"). Every address that asks now gets a link, so the hedge is gone and the sentence is simply true.

## Three races that took care

- **A sign-up token is outside every cascade**, having no user to hang off. The sweep gets it in production. In the suite the scratch database is reused between runs, so three abandoned sign-ups silently exhausted `MOST_LIVE_LINKS` and failed a later run somewhere else entirely — `conftest.forget_ownerless_tokens` clears them.
- **Two links for one new address must not make two families.** The address is looked up first and the INSERT carries `ON CONFLICT DO NOTHING`; losing that race deletes the family just made, which nothing else can have seen.
- **The screen token is generated and checked in one statement**, so the UNIQUE index is the backstop rather than the error path.

## A new family is seeded, and told so

`config.starter_config()` is the invented household `config.example.yaml` documents — an empty board looks broken rather than empty. **No calendar URL, not even an example**: an iCal address is a password in a URL, and one that worked would put somebody else's appointments on a stranger's wall.

Seeding without saying so is somebody else's children on your settings page, so the settings home carries a first-run card while the board is untouched. The signal is the config, not the mode — no calendar and the default family name is equally true of a freshly cloned Pi — so there is no mode check in it.

## Not in this change, said out loud

- **The setup wizard.** The five lists are already editable and a new family arrives seeded and pointed at the two settings that matter. A guided multi-step path is separate UI work.
- **The `/` redirects.** In cloud mode `/` is the board, so it cannot start redirecting to `/settings/` until `/s/<token>` is where the board lives — and that route is phase 3's first box. Doing half of it leaves the board unreachable.
- **"Generate now" on sign-up.** The worker refreshes calendars within five minutes, but the brief waits for `brief_time`, so a 03:00 sign-up sees a waiting screen until 06:00. That is a phase 2 worker item: a web request must not call Anthropic.

## The two small things

- **Phase 0's last checkbox** ticked — `app.dinkydash.co` has served over TLS since 8 September and the box had not caught up.
- **`/healthz` reported `"commit": "unknown"` on every deploy.** The two fallbacks beside `GIT_SHA` were guesses at App Platform variables that do not exist. `${_self.COMMIT_HASH}` does exist, and is *bindable* rather than automatic — it has to be assigned in the component's own `envs`, and is component-scoped. **Needs a `doctl apps update`**, which the DIN-39 env var removal is also waiting for; one apply covers both.

## Testing

- 699 pass with `DINKYDASH_TEST_DATABASE_URL`, 529 with 170 skipped without. `tests/test_signup.py` is 32 of them.
- Migration applied from scratch and re-checked idempotent.
- **Walked end to end in process** with `app.test_client()`: zero families before the click, one after — screen token, 14-day trial, `trialing`, no Stripe customer, Mia and Theo on `/settings/people`, and the second click a dead link with no second family.
- Both new pages shot in headless Chrome.

## One thing to know if the suite fails locally

`pytest-flask` is not a declared dependency, but it was installed in the working venv. Its autouse fixture pushes a request context, so `g` is shared across requests and `web/family.py`'s per-request store cache leaks — which fails five `test_tenancy.py` assertions in a way that looks exactly like a multi-tenancy bug. `pip uninstall pytest-flask`, or `-p no:flask`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VqGomc6Y1LYeEA6LaokUdZ