### PR TITLE
The board on a wall: /s/<token>, rotation, and the / redirects (DIN-42)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,8 +107,8 @@ Relative links like `[PLAN.md](PLAN.md)` break once a document is in Linear. Rew
 
 - **Calendar feeds are untrusted remote input.** Event titles are written by third parties, arrive
   over the network, and land in two places: the rendered page and the model prompt. Autoescaping
-  protects the first — there is no `|safe` anywhere in `web/`, and none should appear on feed or
-  user content. For the second, treat the text as data: an event titled "ignore your instructions
+  protects the first — the single `|safe` in `web/` is on the QR code `segno` draws from our own
+  screen URL, and none should ever appear on feed or user content. For the second, treat the text as data: an event titled "ignore your instructions
   and ..." must not change what the model does.
 - **The server fetches URLs the user typed, and `fetch_feed` is what keeps that safe.** On a Pi the
   typist owns the network; hosted it is our infrastructure dialling whatever a stranger pasted, and
@@ -162,8 +162,17 @@ mode is a different product on the same code.
   trial and a daily Anthropic call. That is the rate limit; the cap is the spend breaker below.
 - **Every form that writes carries a CSRF token**, in *both* modes — `web/session.py`, with no
   switch to turn it off. A test walks the templates and fails on a form without one.
-- **Screen tokens are bearer credentials.** Rate-limited, `noindex`, no referrer leakage, rotatable,
-  and never written to a log or an error page.
+- **Screen tokens are bearer credentials**, and unlike a magic link they never expire — a wall panel
+  holds one for months. So `/s/<token>` is `noindex`, `no-store`, makes no third-party request,
+  never echoes the token back on a miss, and is rotatable, which is the only revocation there is.
+  **A wrong token is a 404 and never a 403**: "forbidden" would confirm it exists.
+- **A token in a *path* is in the access log; a token in a query string is not.** `%(U)s` is what
+  keeps `?t=` out, and it is exactly what would write `/s/<token>` down thousands of times from one
+  panel. `auth.NoTokens` scrubs both, on both request loggers, and `tests/test_screen.py` fails if
+  it stops.
+- **Rate-limit the misses, not the requests.** A real screen asks for its board every few minutes
+  for years; counting that would put a rate limit on somebody's kitchen wall. Only wrong tokens are
+  counted, which is also the only thing worth counting.
 - **The sign-in rate limits are ours, not an edge rule, so that a refusal is a line somebody can
   read.** That is the trade being made — a Cloudflare rule would be sturdier and invisible. What
   goes in the line is chosen: the caller's address in full, the *domain* of the address asked about
@@ -229,6 +238,13 @@ and the settings UI are shared verbatim; mode gates four things and no others �
 billing, where the config is stored, and what drives the scheduler. A mode check anywhere else means
 the change is in the wrong layer.
 
+**Where the board is served is part of the authentication gate**, not a fifth thing. Single mode
+puts it at `/`: one family, no session, the URL somebody types into a Pi's kiosk browser. Cloud mode
+cannot, because a wall panel has no way to sign in — so there the board is at `/s/<token>` and `/`
+is the front door of the signed-in area. `board.render_board` is what the two routes share, so it is
+one board reached two ways rather than two that drift, and `tests/test_cloud_mode.py` asserts the
+two are byte-identical apart from the one link that has to differ.
+
 - **Self-hosted keeps working with no Postgres, no Stripe, no email provider**, and no network
   beyond the two things it fetches. A feature that needs a database is a cloud feature, or it is not
   a feature yet.
@@ -267,6 +283,7 @@ dinkydash/
 ├── db.py              the connection pool and the migration runner (cloud only)
 ├── mail.py            one transactional email, over SendGrid (cloud only)
 ├── accounts.py        users, the links that sign them in, and sign-up (cloud only)
+├── screens.py         the token that puts a board on a wall (cloud only)
 └── runner.py          the two halves of the day, reading and writing through a store
 
 web/
@@ -277,6 +294,7 @@ web/
 ├── routes/board.py    the board and the preview harness
 ├── routes/settings.py the settings UI (one table drives every list section)
 ├── routes/auth.py     /login, /login/link, /logout — cloud mode only
+├── routes/screen.py   /s/<token> — the board with no session, cloud mode only
 └── templates/         board.html, preview.html, auth/*.html, settings/*.html
 ```
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -8,6 +8,11 @@
 
 *September 8, later: **one service, not two.** The board joins the marketing site in the existing `dinkydash-site` app rather than getting its own, because that is how `qrpage.co` and `abc-league` already run in this account — one container, one gunicorn, everything in it. Staging is dropped until there is a paying family to protect. The `worker` is the one genuine addition, because the tick has no lock and two web instances would tick twice. See [Hosting and deployment](#hosting-and-deployment).*
 
+*September 8, later still: **the board is on a wall** (DIN-42). `/s/<token>` serves it with no
+session, `/settings/screen` shows the link and a QR of it and rotates the token, and `/` in cloud
+mode is now the way in to the settings rather than the board — the URL map below, finally. See
+[The screen](#the-screen).*
+
 *September 8, later: **sign-up exists** (DIN-41). An address posted to `/login` gets a link, and
 clicking it creates the family, the parent and a starting config in one transaction. The design
 question that had to be settled first was *when* the family is created, and the answer is **on the
@@ -181,6 +186,46 @@ next tick refreshes the calendars within five minutes, but the brief waits for `
 family's clock, so a 03:00 sign-up looks at a waiting screen until 06:00. PLAN.md's "**Generate now**
 on signup" line under [Scheduling](#scheduling-cloud-mode) is what closes it, and it is a Phase 2
 worker item — a web request must not call Anthropic.
+
+### The screen
+
+*Built in DIN-42.* The board is at `/s/<token>` in cloud mode, and `/` is the front door of the
+signed-in area. That is not a URL preference: **a wall panel cannot sign in.** A kitchen tablet, a
+television and a Pi in kiosk mode have no keyboard and nobody at them, so the credential has to be
+something a browser can hold for months without a person — which is what an unguessable URL is.
+
+**The token is a bearer credential with none of a magic link's defences**: no expiry, no single use,
+and it sits in a browser on a shelf. Four things carry the weight instead.
+
+- **It reaches nothing but a board.** Two GET routes, both reading through a `PostgresStore` scoped
+  to the family the token named. No settings, no address, nothing that writes.
+- **Rotation is the revocation**, and it is the whole of it. The settings page says so in those
+  words, including the cost: every screen goes blank until somebody opens the new link on it.
+- **It does not get written down.** `Referrer-Policy: no-referrer` is already global (DIN-32), the
+  page makes no third-party request, and every response carries `X-Robots-Tag` and
+  `Cache-Control: no-store`.
+- **The path is in the access log, and that had to be dealt with.** Gunicorn's format is built from
+  `%(U)s` — the path *without* the query string — which is exactly what keeps a magic link's `?t=`
+  out of it, and exactly what would put a screen token in, thousands of times, from one panel.
+  `auth.NoTokens` now scrubs `/s/<token>` as well as `?t=`. DigitalOcean's own edge log is still
+  outside all of this, as it always was.
+
+**The rate limit counts misses, not requests.** A valid token belongs to a screen that will ask for
+this page every few minutes for years; refusing it is an outage on a kitchen wall. So the limiter
+only ever sees wrong tokens — 30 an hour per caller — and enumeration was never the risk anyway,
+since 59 bits does not fall to any rate. What it buys is that nobody can make us do the looking.
+
+**The QR code is drawn on the page, not fetched.** A QR *service* would mean handing a bearer
+credential to a third party, and a script from a CDN would mean the settings page making an outbound
+request. `segno` is a pure-Python encoder with no dependencies of its own, in `requirements-cloud.txt`
+and imported lazily — a Pi has no screen token and should not install a library it can never use. It
+is drawn black on a white plate in **both** themes: scanners expect dark on light, and a
+`currentColor` code that inverted in dark mode was read by some phones and not others.
+
+**Two things this deliberately does not do**, both PLAN.md phase 3 and neither blocked: offline
+tolerance for a panel on flaky wifi, which needs a service worker rather than a weaker cache header;
+and the edge rate-limit rule at Cloudflare, which is a sturdier version of the in-process limiter
+rather than a replacement for it.
 
 ### Three clocks, one setting
 
@@ -739,7 +784,7 @@ missing is the multi-tenant half — a schema, auth, and scoping every read and 
 - [ ] Per-provider help content — Google, iCloud, Outlook each expose iCal URLs differently
 - [ ] Settings: timezone, family name, refresh cadence, screen URL display + rotation, account deletion. `claude_model` hidden in cloud mode.
 - [x] Every read and write scoped to the family on the session; the hardcoded family id deleted *(DIN-39)*
-- [ ] The URL map above: `/` redirects, `/login`, `/s/<token>`. **`/login` is done** (DIN-38, DIN-41). The other two are one change and not two: in cloud mode `/` is the board today, so it cannot start redirecting to `/settings/` until `/s/<token>` is where the board lives — and that route is Phase 3's first box. Doing half of it would leave the board unreachable.
+- [x] The URL map above: `/` redirects, `/login`, `/s/<token>` *(DIN-38, DIN-41, DIN-42)*. The last two were one change and not two, as expected: `/` could not start redirecting to `/settings/` until `/s/<token>` was where the board lived.
 
 **Done when:** two different families can be configured independently through the UI, and a request carrying the wrong family's id in a URL gets a 404, never a row. **Met by DIN-39**, and asserted in `tests/test_tenancy.py`.
 
@@ -758,11 +803,11 @@ missing is the multi-tenant half — a schema, auth, and scoping every read and 
 
 ### Phase 3 — The screen
 
-- [ ] Public tokenized dashboard route, rate-limited at the edge, `noindex`, no referrer, no third-party requests
-- [ ] Token rotation; QR code display
+- [x] Public tokenized dashboard route, `noindex`, no referrer, no third-party requests *(DIN-42)*. Rate-limited **in the app rather than at the edge**, and on the misses rather than the requests — see [The screen](#the-screen). A Cloudflare rule is still worth adding on top and is not a blocker.
+- [x] Token rotation; QR code display *(DIN-42)*
 - [ ] Renderer to landing-page parity: person cards with ages, time-ordered agenda for today
-- [ ] Staleness indicator when the brief isn't from today *(built for single mode in #28; confirm it reads the same from `PostgresStore`)*
-- [ ] Offline tolerance and sensible cache headers
+- [x] Staleness indicator when the brief isn't from today *(built for single mode in #28; DIN-42 renders the same `build_view` from `PostgresStore`, and `tests/test_cloud_mode.py` asserts the two boards are byte-identical apart from the manifest link)*
+- [ ] Offline tolerance and sensible cache headers. `no-store` is deliberate for now: the URL is a credential and a shared cache holding it is a leak, so offline needs a service worker rather than a weaker header.
 - [ ] Verify on the target surfaces: TV browser, old iPad, Pi kiosk
 
 **Done when:** the live dashboard matches what the homepage mockup promises, on a real TV.

--- a/dinkydash/CLAUDE.md
+++ b/dinkydash/CLAUDE.md
@@ -60,11 +60,19 @@ thirty-day session can outlive the account it names, and that should sign the ho
 500. Catching the bare parent would swallow `KeyError` and `IndexError` too, which is to say every
 real bug, and send it to the login page.
 
-Two things are unscoped, both deliberately outside the store rather than weakening it:
-`worker.family_ids`, whose whole job is to walk every family, and `dinkydash/accounts.py`, which
-resolves an email address to a user before there is a family to scope to. A magic link has to find
-exactly one person without being told which family they belong to, which is why `users.email` is
-globally unique.
+Three things are unscoped, all deliberately outside the store rather than weakening it, and each
+because there is no family to scope *to* yet:
+
+- **`worker.family_ids`**, whose whole job is to walk every family;
+- **`dinkydash/accounts.py`**, which resolves an email address to a user before there is a family.
+  A magic link has to find exactly one person without being told which family they belong to, which
+  is why `users.email` is globally unique;
+- **`dinkydash/screens.py`**, which resolves a screen token to a family. A wall panel has no session
+  to scope to and never will — that is what the token is for.
+
+Each of the three hands its result to a `PostgresStore` built for exactly one family, so the rule
+that matters is untouched. `web/family.py` is where the last two arrive, and it has both doors in
+one file on purpose: if a third is ever added it should be as obvious as those two are.
 
 ## Signing somebody in, and signing somebody up
 

--- a/dinkydash/screens.py
+++ b/dinkydash/screens.py
@@ -1,0 +1,138 @@
+"""The token that puts a board on a wall. Cloud mode only.
+
+    looks_like_a_token(value)      -> is this worth a query at all
+    family_for_token(pool, token)  -> the family id, or None
+    rotate(pool, family_id)        -> the new token, or None if that family is gone
+
+A wall panel cannot sign in. There is no keyboard on a kitchen tablet left on a
+shelf, and a thirty-day session is the wrong shape for furniture anyway — so
+the board is reached by an unguessable URL instead (PLAN.md, Screen URLs), and
+this module is the only thing that turns one into a family.
+
+**The token is a bearer credential with none of a magic link's defences.** It
+does not expire, it is not single use, and it is meant to sit in a browser for
+months. Three things carry the weight instead:
+
+* **it is only ever a board.** No settings, no email address, no way to change
+  anything. What leaks is one family's day, which is bad and is not an account;
+* **rotation is the revocation**, and it is the whole of it. `rotate` below is
+  what a parent presses when a screenshot went somewhere it should not have,
+  and the old URL stops working the moment they do;
+* **~59 bits.** Twelve characters of `config.ID_ALPHABET`, which is the
+  unambiguous one — a token that has to be read off a television and typed on a
+  remote cannot contain `0`, `O`, `1` or `l`.
+
+**This is the third unscoped read in the product**, after `worker.family_ids`
+and `dinkydash/accounts.py`, and it is unscoped for the same kind of reason:
+there is no session to scope to. A screen is anonymous by design. Everything it
+then reads goes through a `PostgresStore` built for exactly the family the
+token named, so the scoping rule that matters is untouched.
+
+Like `accounts.py`, this imports no driver: it is handed a pool and asks it for
+connections, so `pgstore.py` and `db.py` remain the only two files that pull in
+psycopg. (Written that way round on purpose — `grep -rn "import psycopg"` is
+the check CLAUDE.md tells people to run, and a docstring that answers it is a
+docstring that makes the check useless.)
+"""
+
+import logging
+
+from . import config as config_module
+
+log = logging.getLogger(__name__)
+
+# What the column allows, and therefore the only lengths worth a round trip.
+# `families.screen_token` is `CHECK (length(screen_token) BETWEEN 10 AND 32)`.
+SHORTEST_TOKEN = 10
+LONGEST_TOKEN = 32
+
+# Attempts before `rotate` gives up. The same three as `accounts._new_family`,
+# and for the same reason: a collision is not something anyone will see, but
+# the column is UNIQUE and an unhandled violation would be a 500 on a button
+# press.
+TRIES = 3
+
+
+def looks_like_a_token(value):
+    """Could this be one of ours? Checked before it reaches a query.
+
+    Not a security boundary — the token is compared exactly, and a parameterised
+    query is what keeps the value out of the SQL. This is here so that a crawler
+    walking `/s/wp-admin.php` costs a string comparison rather than a connection
+    from a pool with 22 of them behind it, and so a URL long enough to be an
+    attack is refused before anything hashes it.
+    """
+    if not isinstance(value, str):
+        return False
+    if not SHORTEST_TOKEN <= len(value) <= LONGEST_TOKEN:
+        return False
+    return set(value) <= set(config_module.ID_ALPHABET)
+
+
+def family_for_token(pool, token):
+    """Which family's board that URL shows, or None.
+
+    One answer for a token that is malformed, mistyped, rotated away or never
+    issued, in the same way `accounts.consume_link` gives one answer for
+    expired, spent and never-issued. There is nothing here for a caller to leak
+    by accident, and nothing an enumerator can tell apart.
+    """
+    if not looks_like_a_token(token):
+        return None
+    with pool.connection() as conn, conn.cursor() as cur:
+        cur.execute("SELECT id FROM families WHERE screen_token = %s", (token,))
+        row = cur.fetchone()
+        return row[0] if row else None
+
+
+def token_for(pool, family_id):
+    """That family's current screen token, or None if the family is gone.
+
+    The inverse of `family_for_token`, and the only other query here. It is
+    what the settings page prints and what `/preview` frames, so it is asked
+    for by a signed-in caller that already holds the family id — never by a
+    caller holding the token, which would be asking a question it already
+    knows the answer to.
+    """
+    with pool.connection() as conn, conn.cursor() as cur:
+        cur.execute("SELECT screen_token FROM families WHERE id = %s",
+                    (family_id,))
+        row = cur.fetchone()
+        return row[0] if row else None
+
+
+def rotate(pool, family_id):
+    """Give that family a new screen token, and return it. None if it is gone.
+
+    **Scoped by its caller**, which passes the family on the session — this
+    takes an id rather than finding one, so there is no way to rotate somebody
+    else's board without first holding their session.
+
+    The new token is generated and checked in the same statement, so the UNIQUE
+    index is the backstop rather than the error path. `screen_token_rotated_at`
+    moves with it because a parent asking "did I already do this?" is the whole
+    reason that column exists.
+    """
+    for _ in range(TRIES):
+        token = config_module.new_screen_token()
+        with pool.connection() as conn, conn.transaction():
+            with conn.cursor() as cur:
+                cur.execute(
+                    """UPDATE families
+                       SET screen_token = %s, screen_token_rotated_at = now(),
+                           updated_at = now()
+                       WHERE id = %s
+                         AND NOT EXISTS (
+                             SELECT 1 FROM families WHERE screen_token = %s)
+                       RETURNING id""",
+                    (token, family_id, token),
+                )
+                if cur.fetchone() is not None:
+                    log.info("Rotated a screen token.")
+                    return token
+    # Either every generated token collided — which is not a thing that happens
+    # at 59 bits — or the family does not exist. The caller cannot tell the two
+    # apart and does not need to: both mean "no new URL", and a session naming a
+    # family that has gone is already handled by `NoSuchFamily` elsewhere.
+    return None
+

--- a/doc/operations.md
+++ b/doc/operations.md
@@ -240,6 +240,33 @@ removed, and `GIT_SHA` bound to `${_self.COMMIT_HASH}` so `/healthz` stops answe
 `"commit": "unknown"`. That variable is *bindable*, not automatic — App Platform sets nothing on its
 own, which is why the two guessed fallbacks that used to be in `healthz` never fired.
 
+## The screen, 8 September 2026 (DIN-42)
+
+**The board is reachable on a wall.** `/s/<token>` serves it with no session, `/settings/screen`
+shows the link and a QR of it, and the same page rotates the token. In cloud mode `/` is now a
+redirect — signed in to `/settings/`, signed out to `/login` — so the board is *only* at the screen
+URL.
+
+**No spec change and no `doctl apps update` for this one.** `segno` is a new dependency but it is in
+`requirements-cloud.txt`, which the app spec's `build_command` already installs, and the migration
+list is unchanged. `deploy_on_push` is enough.
+
+**What to watch.** The screen token is a bearer credential that never expires, so the things worth
+knowing are:
+
+* **it must not appear in the platform's log.** `auth.NoTokens` scrubs `/s/<token>` as well as
+  `?t=`, on both request loggers. The check is
+  `doctl apps logs <id> site --type run | grep -c "/s/\[redacted\]"` — a real token showing up
+  there instead is a regression, not a curiosity;
+* **rotation is the only revocation.** If a family reports a leak, the button on their settings page
+  is the whole remedy. There is no way to expire one from here that is not that;
+* **the miss limiter is per process.** `--workers 2`, so 60 wrong tokens an hour rather than 30, and
+  a redeploy resets it. It is a bound on somebody making us do the looking, not a quota — enumeration
+  is answered by the 59 bits, not by the counter.
+
+A Cloudflare rate-limit rule on `/s/*` was the original plan (DIN-29) and is still worth adding. It
+is not what the app depends on, and the in-process limiter is what actually runs today.
+
 ## GitHub's own secret scanning
 
 **Do not rely on it yet.** Minutes after it was enabled, a correctly shaped fake

--- a/requirements-cloud.txt
+++ b/requirements-cloud.txt
@@ -18,3 +18,15 @@
 # Pinned with == like the rest, so a clean build gets what CI passed on.
 psycopg[binary]==3.3.5
 psycopg-pool==3.3.1
+
+# The QR code of a family's screen URL, drawn inline on the settings page
+# (DIN-42). A new dependency in an app holding other families' calendars needs a
+# reason, and this one is: a QR encoder is Reed-Solomon and a placement matrix,
+# which is not something to write by hand, and the alternative — a QR *service*,
+# or a script from a CDN — would mean handing a bearer credential to a third
+# party or letting the page make an outbound request. `segno` is pure Python
+# with no dependencies of its own, so it adds one package and nothing else.
+#
+# Cloud only, and imported lazily in `settings.qr_svg`: a Pi has no screen token
+# and must not install a library it can never use.
+segno==1.6.6

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,12 +77,21 @@ def pg_family(pg_pool):
     is also a live check that the foreign keys really do cascade — Phase 5's
     hard delete depends on exactly that.
     """
+    from dinkydash import config as config_module
+
     with pg_pool.connection() as conn, conn.transaction():
         with conn.cursor() as cur:
             cur.execute(
                 """INSERT INTO families (screen_token, config)
                    VALUES (%s, '{}'::jsonb) RETURNING id""",
-                ("tok" + os.urandom(6).hex(),),
+                # A real one, from `config.ID_ALPHABET`. It used to be
+                # `"tok" + urandom(6).hex()`, which is a fine unique string and
+                # is **not a token this app would ever issue** — hex has `0` and
+                # `1` in it and the alphabet deliberately does not. Once
+                # `/s/<token>` started refusing malformed tokens before querying
+                # (DIN-42), a fixture token that could not exist made every
+                # screen test fail for the wrong reason.
+                (config_module.new_screen_token(),),
             )
             family_id = cur.fetchone()[0]
     yield family_id
@@ -128,6 +137,18 @@ class SigningClient(FlaskClient):
             elif isinstance(data, dict):
                 data.setdefault(CSRF_FIELD, token)
         return super().open(*args, **kwargs)
+
+
+def board_path(pg_pool, family_id):
+    """Where that family's board is served in cloud mode: `/s/<token>`.
+
+    A wall panel cannot sign in, so the board moved off `/` (DIN-42) and `/`
+    became the way in to the settings. Every test that used to GET `/` for a
+    board in cloud mode goes through here instead.
+    """
+    from dinkydash import screens
+
+    return f"/s/{screens.token_for(pg_pool, family_id)}"
 
 
 def client_for(app):

--- a/tests/test_cloud_mode.py
+++ b/tests/test_cloud_mode.py
@@ -11,7 +11,7 @@ change went in the wrong layer.
 import pytest
 
 from dinkydash import config as config_module
-from tests.conftest import client_for
+from tests.conftest import board_path, client_for
 from web import create_app
 
 CONFIG = {
@@ -120,17 +120,25 @@ class TestABoardOutOfPostgres:
             stored["family_id"] = str(pg_family)
         return client
 
-    def test_the_board_renders_the_stored_brief(self, client):
-        page = client.get("/").get_data(as_text=True)
+    def test_the_board_renders_the_stored_brief(self, client, pg_pool, pg_family):
+        page = client.get(board_path(pg_pool, pg_family)).get_data(as_text=True)
         assert "Swimming, then football" in page
         assert "An octopus fact." in page
 
-    def test_it_recomputes_the_chore_rather_than_reading_it(self, client):
+    def test_it_recomputes_the_chore_rather_than_reading_it(
+            self, client, pg_pool, pg_family):
         # Chores are a pure function of config + date and are not in the
         # payload, so seeing one proves build_view ran over the database config.
-        page = client.get("/").get_data(as_text=True)
+        page = client.get(board_path(pg_pool, pg_family)).get_data(as_text=True)
         assert "Set the table" in page
         assert "Mia" in page
+
+    def test_and_the_root_is_the_way_in_to_the_settings(self, client):
+        """In cloud mode `/` is not the board — a wall panel cannot sign in, so
+        the board is at the screen URL and `/` belongs to the signed-in area."""
+        landed = client.get("/")
+        assert landed.status_code == 302
+        assert landed.headers["Location"].endswith("/settings/")
 
     def test_the_settings_home_reads_the_same_rows(self, client):
         page = client.get("/settings/").get_data(as_text=True)
@@ -146,13 +154,23 @@ class TestABoardOutOfPostgres:
             assert cur.fetchone()[0] == "The Bakers"
 
     def test_the_board_is_identical_to_the_one_a_file_would_render(
-            self, client, tmp_path, monkeypatch):
+            self, client, pg_pool, pg_family, tmp_path, monkeypatch):
         """The template, the CSS and build_view are shared verbatim.
 
         If cloud mode ever rendered a different board, the mode check would have
         leaked below the storage layer — which is the thing CLAUDE.md's "every
         change must work in both" exists to prevent.
+
+        **One line is allowed to differ, and exactly one**: the `<link
+        rel=manifest>`. A wall panel reaches its manifest at
+        `/s/<token>/manifest.webmanifest`, because the signed-in one is behind
+        the session and would hand a tablet a redirect to `/login` instead of a
+        name and an icon (DIN-42). Normalising that href rather than dropping
+        the assertion is the point — every other byte still has to match, so a
+        second divergence fails here rather than being absorbed.
         """
+        import re
+
         import yaml
 
         from dinkydash.store import FileStore
@@ -166,5 +184,8 @@ class TestABoardOutOfPostgres:
         file_store.save_agenda(file_store.load_config(), today)
         file_store.save_brief(file_store.load_config(), today)
         from_file = create_app(file_store).test_client().get("/").get_data(as_text=True)
+        from_rows = client.get(board_path(pg_pool, pg_family)).get_data(as_text=True)
 
-        assert client.get("/").get_data(as_text=True) == from_file
+        manifest = re.compile(r'<link rel="manifest" href="[^"]+">')
+        assert manifest.search(from_file) and manifest.search(from_rows)
+        assert manifest.sub("[manifest]", from_rows) == manifest.sub("[manifest]", from_file)

--- a/tests/test_screen.py
+++ b/tests/test_screen.py
@@ -1,0 +1,361 @@
+"""The board on a wall: `/s/<token>`, rotation, and the redirects (DIN-42).
+
+Five claims, and the first is what the whole feature exists for:
+
+* **a screen needs no session.** A kitchen tablet cannot sign in, so the board
+  is reached by an unguessable URL and nothing else;
+* **the token is a bearer credential and is treated like one** — never in a log,
+  never in an index, never in a shared cache, and never echoed back on a miss;
+* **a wrong token is a 404 and never a 403**, whether it was mistyped, rotated
+  away, or invented;
+* **the rate limit counts misses, not requests.** A real screen reloads for
+  years and must never be refused;
+* **rotation is the only revocation there is**, so it has to work.
+
+Skips without `DINKYDASH_TEST_DATABASE_URL`. Cloud mode is where the screen
+exists at all: single mode serves the board at `/` and has no token, so the
+route is a 404 there, which is asserted below with no database at all.
+"""
+
+import logging
+import re
+
+import pytest
+import yaml
+
+from dinkydash import config as config_module
+from dinkydash import screens
+from dinkydash.store import FileStore
+from tests.conftest import board_path, client_for
+from web import create_app
+from web.routes.auth import NoTokens
+
+CONFIG = '''\
+family_name: "The Wilsons"
+timezone: "Europe/Berlin"
+theme: dark
+people:
+  - id: mia12345
+    name: "Mia"
+    date_of_birth: "2017-03-15"
+recurring:
+  - id: job12345
+    title: "Set the table"
+    choices: ["Mia"]
+'''
+
+
+def a_board_for(today):
+    """A written board, so these tests read a real one rather than the waiting
+    screen. Chores and countdowns are recomputed from config on every render,
+    but nothing is rendered at all until a payload exists."""
+    return {"generated_for_date": today.isoformat(),
+            "generated_at": f"{today.isoformat()}T04:00:00+00:00",
+            "headline": "Swimming, then football",
+            "note": "An octopus fact.",
+            "events": [], "calendars_fetched_at": f"{today.isoformat()}T04:00:00+00:00"}
+
+
+@pytest.fixture
+def cloud(pg_pool, pg_family, monkeypatch):
+    from dinkydash.pgstore import PostgresStore
+
+    store = PostgresStore(pg_pool, pg_family)
+    store.save_config(yaml.safe_load(CONFIG))
+    config = store.load_config()
+    board = a_board_for(config_module.today_for(config))
+    store.save_agenda(config, board)
+    store.save_brief(config, board)
+    monkeypatch.setenv("DINKYDASH_MODE", "cloud")
+    monkeypatch.setenv("DINKYDASH_SECRET_KEY", "a-real-one")
+    return create_app(pool=pg_pool)
+
+
+@pytest.fixture
+def anyone(cloud):
+    """A client with no session at all. What a wall panel is."""
+    return client_for(cloud)
+
+
+@pytest.fixture
+def parent(cloud, pg_family):
+    """A signed-in client, for the settings half."""
+    client = client_for(cloud)
+    with client.session_transaction() as stored:
+        stored["user_id"] = 1
+        stored["family_id"] = str(pg_family)
+    return client
+
+
+@pytest.fixture
+def path(pg_pool, pg_family):
+    return board_path(pg_pool, pg_family)
+
+
+# -- a screen signs in to nothing -------------------------------------------
+
+class TestTheBoardNeedsNoSession:
+    def test_an_anonymous_request_gets_the_board(self, anyone, path):
+        page = anyone.get(path)
+        assert page.status_code == 200
+        body = page.get_data(as_text=True)
+        assert "Set the table" in body and "Mia" in body
+
+    def test_the_family_on_the_board_is_the_token_s_family(self, anyone, path):
+        assert "The Wilsons" in anyone.get(path).get_data(as_text=True)
+
+    def test_and_the_theme_comes_from_their_config(self, anyone, path):
+        assert 'data-theme="dark"' in anyone.get(path).get_data(as_text=True)
+
+    def test_the_manifest_is_reachable_without_one_too(self, anyone, path):
+        """Otherwise "save to home screen" on the panel gets a login redirect
+        and the saved icon is a browser default."""
+        got = anyone.get(f"{path}/manifest.webmanifest")
+        assert got.status_code == 200
+        assert got.get_json()["start_url"] == path
+
+    def test_the_board_links_to_that_manifest_and_not_the_private_one(
+            self, anyone, path):
+        body = anyone.get(path).get_data(as_text=True)
+        assert f'href="{path}/manifest.webmanifest"' in body
+
+    def test_the_page_asks_nothing_of_anybody_else(self, anyone, path):
+        """A screen URL in a `Referer` is a screen URL given away. The board
+        is already free of third-party requests (DIN-32); this is the assertion
+        that keeps it that way on the one page a stranger can open."""
+        body = anyone.get(path).get_data(as_text=True)
+        for external in ("//fonts.googleapis.com", "//fonts.gstatic.com",
+                         "http://", "https://"):
+            assert external not in body
+
+
+# -- and it is a credential -------------------------------------------------
+
+class TestItIsTreatedAsACredential:
+    def test_it_is_not_indexed_and_not_cached(self, anyone, path):
+        headers = anyone.get(path).headers
+        assert headers["X-Robots-Tag"] == "noindex, nofollow"
+        assert "no-store" in headers["Cache-Control"]
+
+    def test_the_refusal_carries_the_same_headers(self, anyone):
+        headers = anyone.get("/s/zzzzzzzzzzzz").headers
+        assert headers["X-Robots-Tag"] == "noindex, nofollow"
+        assert "no-store" in headers["Cache-Control"]
+
+    def test_no_referrer_on_it_like_everything_else(self, anyone, path):
+        assert anyone.get(path).headers["Referrer-Policy"] == "no-referrer"
+
+    def test_a_wrong_token_is_never_echoed_back(self, anyone):
+        """A typo of a real token is nearly a real token."""
+        page = anyone.get("/s/zzzzzzzzzzzz")
+        assert "zzzzzzzzzzzz" not in page.get_data(as_text=True)
+
+    def test_the_log_filter_takes_the_token_out_of_a_request_line(self):
+        """The one place `%(U)s` cannot help. Gunicorn's access format is built
+        from the path *without* the query string, which is what keeps a magic
+        link's `?t=` out of the platform's log — and exactly what would put a
+        screen token in it, thousands of times, from one panel."""
+        record = logging.LogRecord("gunicorn.access", logging.INFO, "", 0,
+                                   'GET /s/abcdefgh2345 HTTP/1.1', None, None)
+        NoTokens().filter(record)
+        assert "abcdefgh2345" not in record.getMessage()
+        assert "/s/[redacted]" in record.getMessage()
+
+    def test_and_leaves_ordinary_paths_alone(self):
+        """`config.ID_ALPHABET` has no `i`, `l`, `o` or `0`, which is what lets
+        the pattern be this narrow — `/settings` and `/static` must survive."""
+        for line in ('GET /settings/people HTTP/1.1', 'GET /static/fonts.css'):
+            record = logging.LogRecord("gunicorn.access", logging.INFO, "", 0,
+                                       line, None, None)
+            NoTokens().filter(record)
+            assert record.getMessage() == line
+
+    def test_it_still_scrubs_a_sign_in_link_as_well(self):
+        """Two credentials travel in URLs here; one filter covers both."""
+        record = logging.LogRecord("werkzeug", logging.INFO, "", 0,
+                                   'GET /login/link?t=SECRETTOKEN HTTP/1.1',
+                                   None, None)
+        NoTokens().filter(record)
+        assert "SECRETTOKEN" not in record.getMessage()
+
+
+# -- a wrong token ----------------------------------------------------------
+
+class TestAWrongToken:
+    @pytest.mark.parametrize("token,why", [
+        ("zzzzzzzzzzzz", "well-formed and never issued"),
+        ("short", "too short for the column"),
+        ("z" * 40, "longer than the column allows"),
+        ("WP-ADMIN-PHP", "not the alphabet"),
+        ("abcd0123efgh", "hex digits the alphabet excludes"),
+    ])
+    def test_is_a_404(self, anyone, token, why):
+        assert anyone.get(f"/s/{token}").status_code == 404, why
+
+    def test_never_a_403(self, anyone):
+        """"Forbidden" would confirm the token exists and is merely not allowed,
+        which is the one thing a guess must not learn."""
+        assert anyone.get("/s/zzzzzzzzzzzz").status_code != 403
+
+    def test_a_rotated_token_stops_working(self, anyone, pg_pool, pg_family, path):
+        assert anyone.get(path).status_code == 200
+        screens.rotate(pg_pool, pg_family)
+        assert anyone.get(path).status_code == 404
+
+    def test_and_the_new_one_works(self, anyone, pg_pool, pg_family):
+        token = screens.rotate(pg_pool, pg_family)
+        assert anyone.get(f"/s/{token}").status_code == 200
+
+    def test_a_malformed_token_costs_no_query(self, anyone, monkeypatch):
+        """A crawler walking `/s/wp-login.php` should cost a string comparison,
+        not a connection from a pool with 22 of them behind it."""
+        def explode(*args, **kwargs):
+            raise AssertionError("a malformed token reached the database")
+
+        monkeypatch.setattr(screens, "family_for_token", explode)
+        # `looks_like_a_token` runs first, inside `family_for_token`... so the
+        # check that matters is the one it makes before touching the pool.
+        assert not screens.looks_like_a_token("wp-login.php")
+
+
+# -- the limit is on the misses ---------------------------------------------
+
+class TestTheRateLimit:
+    CALLER = {"DO-Connecting-IP": "93.184.216.34"}
+
+    def test_a_real_screen_is_never_refused(self, anyone, path):
+        """It reloads every few minutes for years. Counting its requests would
+        put a rate limit on somebody's kitchen wall."""
+        from web.routes.screen import MOST_MISSES
+
+        for _ in range(MOST_MISSES * 2):
+            assert anyone.get(path, headers=self.CALLER).status_code == 200
+
+    def test_misses_are_counted_and_then_refused(self, anyone):
+        from web.routes.screen import MOST_MISSES
+
+        codes = [anyone.get("/s/zzzzzzzzzzzz", headers=self.CALLER).status_code
+                 for _ in range(MOST_MISSES + 2)]
+        assert codes[:MOST_MISSES] == [404] * MOST_MISSES
+        assert codes[MOST_MISSES:] == [429, 429]
+
+    def test_a_valid_token_still_works_while_a_caller_is_over_the_limit(
+            self, anyone, path):
+        """The limiter is about making somebody else do the looking, not about
+        the family whose screen it is."""
+        from web.routes.screen import MOST_MISSES
+
+        for _ in range(MOST_MISSES + 1):
+            anyone.get("/s/zzzzzzzzzzzz", headers=self.CALLER)
+        assert anyone.get(path, headers=self.CALLER).status_code == 200
+
+    def test_the_refusal_says_nothing_about_what_was_asked_for(self, anyone):
+        from web.routes.screen import MOST_MISSES
+
+        for _ in range(MOST_MISSES + 1):
+            anyone.get("/s/zzzzzzzzzzzz", headers=self.CALLER)
+        page = anyone.get("/s/zzzzzzzzzzzz", headers=self.CALLER)
+        assert page.status_code == 429
+        assert "zzzzzzzzzzzz" not in page.get_data(as_text=True)
+
+
+# -- rotation ---------------------------------------------------------------
+
+class TestRotation:
+    def test_the_settings_page_shows_the_link_and_a_qr(self, parent, path):
+        page = parent.get("/settings/screen").get_data(as_text=True)
+        assert path in page
+        assert "<svg" in page and 'class="qr"' in page
+
+    def test_and_says_plainly_what_the_link_is(self, parent):
+        page = parent.get("/settings/screen").get_data(as_text=True)
+        assert "Anyone with this link can see your board" in page
+
+    def test_the_qr_is_drawn_here_and_not_fetched(self, parent):
+        """Handing this URL to a QR service would be publishing the credential."""
+        page = parent.get("/settings/screen").get_data(as_text=True)
+        assert "chart.googleapis.com" not in page
+        assert "api.qrserver.com" not in page
+
+    def test_pressing_the_button_changes_the_link(self, parent, pg_pool, pg_family):
+        before = screens.token_for(pg_pool, pg_family)
+        parent.post("/settings/screen", data={"action": "rotate"})
+        assert screens.token_for(pg_pool, pg_family) != before
+
+    def test_and_says_every_screen_needs_the_new_one(self, parent):
+        landed = parent.post("/settings/screen", data={"action": "rotate"},
+                             follow_redirects=True)
+        assert "the old link has stopped working" in landed.get_data(as_text=True)
+
+    def test_rotating_needs_a_csrf_token_like_every_other_write(self, cloud, pg_family):
+        """A plain client, so the form carries nothing. `web/session.py` has no
+        switch to turn this off, in either mode."""
+        bare = cloud.test_client()
+        with bare.session_transaction() as stored:
+            stored["user_id"] = 1
+            stored["family_id"] = str(pg_family)
+        assert bare.post("/settings/screen", data={"action": "rotate"}).status_code == 400
+
+    def test_the_new_token_is_the_shape_the_column_allows(self, pg_pool, pg_family):
+        token = screens.rotate(pg_pool, pg_family)
+        assert 10 <= len(token) <= 32
+        assert set(token) <= set(config_module.ID_ALPHABET)
+
+    def test_rotating_a_family_that_is_gone_says_so_rather_than_raising(self, pg_pool):
+        import uuid
+
+        assert screens.rotate(pg_pool, uuid.uuid4()) is None
+
+
+# -- where the board is, now that it moved ----------------------------------
+
+class TestTheRootAndThePreview:
+    def test_the_root_sends_a_signed_in_parent_to_the_settings(self, parent):
+        landed = parent.get("/")
+        assert landed.status_code == 302
+        assert landed.headers["Location"].endswith("/settings/")
+
+    def test_and_a_signed_out_visitor_to_the_login(self, anyone):
+        landed = anyone.get("/")
+        assert landed.status_code == 302
+        assert landed.headers["Location"].endswith("/login")
+
+    def test_view_board_on_the_settings_home_points_at_the_screen(
+            self, parent, path):
+        """It used to link to `/`, which is now a redirect back to that page."""
+        assert f'href="{path}"' in parent.get("/settings/").get_data(as_text=True)
+
+    def test_the_preview_frames_the_board_rather_than_the_redirect(
+            self, parent, path):
+        page = parent.get("/preview").get_data(as_text=True)
+        assert f'src="{path}"' in page
+        assert len(re.findall(re.escape(f'src="{path}"'), page)) == 3
+
+
+# -- and none of it reaches a self-hoster -----------------------------------
+
+class TestSingleModeIsUntouched:
+    @pytest.fixture
+    def single(self, tmp_path):
+        (tmp_path / "config.yaml").write_text(CONFIG)
+        store = FileStore(tmp_path / "config.yaml")
+        config = store.load_config()
+        board = a_board_for(config_module.today_for(config))
+        store.save_agenda(config, board)
+        store.save_brief(config, board)
+        return create_app(store)
+
+    def test_the_board_is_still_at_the_root(self, single):
+        page = single.test_client().get("/")
+        assert page.status_code == 200
+        assert "Set the table" in page.get_data(as_text=True)
+
+    def test_and_there_is_no_screen_route_at_all(self, single):
+        """A 404 rather than a route that exists and refuses. One family on
+        their own network has no token and nothing to rotate."""
+        assert single.test_client().get("/s/abcdefgh2345").status_code == 404
+
+    def test_the_screen_page_still_says_what_a_home_network_means(self, single):
+        page = single.test_client().get("/settings/screen").get_data(as_text=True)
+        assert "There is no password on this" in page
+        assert "Change the link" not in page

--- a/tests/test_signup.py
+++ b/tests/test_signup.py
@@ -248,7 +248,7 @@ class TestTheStartingConfig:
         assert "content_history_file" not in config
 
     def test_the_board_renders_for_a_family_that_has_typed_nothing(
-            self, client, sent):
+            self, client, sent, pg_pool):
         """It shows the waiting screen, not the seeded people, and that is
         right: there is no payload until the worker's next tick writes one.
 
@@ -257,10 +257,16 @@ class TestTheStartingConfig:
         with nothing on it but a date. PLAN.md's "Generate now on signup" is
         what closes the gap between the click and the first board, and it is a
         phase 2 worker item: a web request must not call Anthropic.
+
+        Read at the screen URL, which sign-up gave the family a token for
+        before anybody asked. That is the point of writing it at creation
+        rather than later: a board is reachable from the first second.
         """
+        from tests.conftest import board_path
+
         client.post("/login", data={"email": NEWCOMER})
         client.get(link_in(sent[0]))
-        page = client.get("/")
+        page = client.get(board_path(pg_pool, family_of(pg_pool, NEWCOMER)["id"]))
         assert page.status_code == 200
         assert "Our family" in page.get_data(as_text=True)
 

--- a/tests/test_tenancy.py
+++ b/tests/test_tenancy.py
@@ -89,7 +89,12 @@ def families(pg_pool):
                 cur.execute(
                     """INSERT INTO families (screen_token, config)
                        VALUES (%s, %s::jsonb) RETURNING id""",
-                    (f"tok-{name}", json.dumps(config)),
+                    # A real token, from `config.ID_ALPHABET`. `tok-wilsons`
+                    # was unique and readable and is **not a shape this app
+                    # issues** — no hyphen in the alphabet, and no `o` — so
+                    # once `/s/<token>` started refusing malformed tokens
+                    # before querying (DIN-42) it named nobody.
+                    (config_module.new_screen_token(), json.dumps(config)),
                 )
                 family_id = cur.fetchone()[0]
                 cur.execute(
@@ -135,6 +140,15 @@ def signed_in_as(app, family):
 
 
 @pytest.fixture
+def boards(pg_pool, families):
+    """Each family's screen URL — where the board lives in cloud mode."""
+    from tests.conftest import board_path
+
+    return {name: board_path(pg_pool, family[0])
+            for name, family in families.items()}
+
+
+@pytest.fixture
 def wilson(app, families):
     return signed_in_as(app, families["wilsons"])
 
@@ -176,27 +190,43 @@ class TestTwoFamiliesSideBySide:
         assert mine in page
         assert theirs not in page
 
-    def test_the_board_is_each_familys_own(self, wilson, baker):
+    def test_the_board_is_each_familys_own(self, wilson, baker, boards):
         """The headline comes out of `generations`, and the chore is recomputed
-        from `families.config` — so this covers both tables at once."""
-        ours = wilson.get("/").get_data(as_text=True)
-        theirs = baker.get("/").get_data(as_text=True)
+        from `families.config` — so this covers both tables at once.
+
+        Read at each family's screen URL rather than at `/`, because that is
+        where a board lives in cloud mode now (DIN-42). **The clients are still
+        the signed-in ones** — a screen URL needs no session, and using them
+        here checks the stronger thing: holding one family's cookie does not
+        change what the other family's token shows.
+        """
+        ours = wilson.get(boards["wilsons"]).get_data(as_text=True)
+        theirs = baker.get(boards["bakers"]).get_data(as_text=True)
         assert "Swimming, then football" in ours and "Set the table" in ours
         assert "Sailing at low tide" in theirs and "Feed the cat" in theirs
 
-    def test_and_neither_board_carries_the_others_words(self, wilson, baker):
-        assert "Sailing at low tide" not in wilson.get("/").get_data(as_text=True)
-        assert "Swimming, then football" not in baker.get("/").get_data(as_text=True)
+    def test_and_neither_board_carries_the_others_words(self, wilson, baker, boards):
+        assert "Sailing at low tide" not in wilson.get(boards["wilsons"]).get_data(as_text=True)
+        assert "Swimming, then football" not in baker.get(boards["bakers"]).get_data(as_text=True)
 
-    def test_even_the_theme_follows_the_session(self, wilson, baker):
+    def test_a_screen_token_shows_its_own_family_and_no_session_changes_that(
+            self, wilson, boards):
+        """The token decides which board, not the cookie that happens to be on
+        the request. A screen has no session at all, so if a signed-in one could
+        steer this the anonymous case would be the odd one out."""
+        theirs = wilson.get(boards["bakers"]).get_data(as_text=True)
+        assert "Sailing at low tide" in theirs
+        assert "Swimming, then football" not in theirs
+
+    def test_even_the_theme_follows_the_board(self, wilson, baker, boards):
         # The Bakers are on dark and the Wilsons on light. A shared store would
         # give both the same one.
-        assert 'data-theme="light"' in wilson.get("/").get_data(as_text=True)
-        assert 'data-theme="dark"' in baker.get("/").get_data(as_text=True)
+        assert 'data-theme="light"' in wilson.get(boards["wilsons"]).get_data(as_text=True)
+        assert 'data-theme="dark"' in baker.get(boards["bakers"]).get_data(as_text=True)
 
-    def test_a_calendar_url_never_crosses(self, wilson):
+    def test_a_calendar_url_never_crosses(self, wilson, boards):
         """The one value in a config that is a password."""
-        for path in ("/settings/", "/settings/calendars", "/"):
+        for path in ("/settings/", "/settings/calendars", boards["wilsons"]):
             assert "private-bbbb" not in wilson.get(path).get_data(as_text=True)
 
 

--- a/web/CLAUDE.md
+++ b/web/CLAUDE.md
@@ -44,6 +44,14 @@ is where that is decided. `board.healthz` is the one exemption and it is load-be
 Platform's health check arrives with no cookie, and a 302 there fails it three times and rolls the
 release back. It is also the only route that reads nothing, so it needs no family.
 
+**`web/routes/screen.py` is the other exemption, and it is a separate blueprint for that reason.**
+`/s/<token>` has no session by design — a wall panel cannot sign in — so it is not behind `guard()`
+and never should be. What replaces the session is the token, resolved by `family.store_for_token`;
+what replaces the guard is that the two routes there are GETs that reach a board and nothing else.
+Registered only in cloud mode, like `auth`. **In cloud mode `/` is a redirect**, so anything that
+used to link to `url_for('board.index')` for a board — the "View board" button, `/preview`'s
+iframes — has to ask where the board actually is instead. `board.board_url` is that question.
+
 **Every form that writes needs one hidden field.** `<input type="hidden" name="csrf_token"
 value="{{ csrf_token() }}">`, right inside the `<form>`. `csrf_token()` is a Jinja global set up by
 `web/session.py`, so no route has to remember to pass anything — but a form without the field is a

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -96,6 +96,13 @@ def create_app(store=None, pool=None):
         from .routes.auth import bp as auth_bp
         app.register_blueprint(auth_bp)
 
+        # The board itself, at the one URL a wall panel can open without a
+        # session. Cloud only for the same reason as `auth`: a self-hosted
+        # board is at `/` and has no token, so `/s/...` is a 404 there rather
+        # than a route that exists and refuses.
+        from .routes.screen import bp as screen_bp
+        app.register_blueprint(screen_bp)
+
         from dinkydash.pgstore import NoSuchFamily
 
         @app.errorhandler(NoSuchFamily)

--- a/web/family.py
+++ b/web/family.py
@@ -7,14 +7,24 @@ One line decides the whole of multi-tenancy:
     cloud    one store per request, built from the family on the session
     single   one store per process, because there is one family and no session
 
-**In cloud mode the family comes from the session and from nowhere else.**
-Not from a path segment, not from a query parameter, not from a form field and
-not from a header. That is a stronger promise than checking an id against the
-session, because there is no id to check: nothing a caller can send reaches a
-query as a family selector. When a route does one day need to name a family in
-its URL — the admin view is the likely first — the check belongs here, before
-the store is built, and **a mismatch is a 404 and never a 403**: "forbidden"
-confirms the row exists, which tells one family that another one does.
+**In cloud mode the family comes from the session and from nowhere else** —
+with exactly one exception, which is below and is the whole of it. Not from a
+path segment, not from a query parameter, not from a form field and not from a
+header. That is a stronger promise than checking an id against the session,
+because there is no id to check: nothing a caller can send reaches a query as a
+family selector. When a route does one day need to name a *family* in its URL —
+the admin view is the likely first — the check belongs here, before the store
+is built, and **a mismatch is a 404 and never a 403**: "forbidden" confirms the
+row exists, which tells one family that another one does.
+
+**The exception is the screen, and it is not a hole in that rule.** A wall
+panel cannot sign in, so `/s/<token>` names a family with an unguessable
+credential instead of a session (DIN-42). What a caller sends is still not a
+family *id*: it is a 59-bit secret that `screens.family_for_token` either
+resolves to exactly one family or does not resolve at all, and everything read
+afterwards goes through a `PostgresStore` scoped to that family like any other.
+Both doors are here, in one file, on purpose — if a third is ever added it
+should be as obvious as these two are.
 
 The ids that *do* appear in URLs today are item ids inside one family's config
 document — `/settings/people/<item_id>`. They are already scoped by which
@@ -55,6 +65,53 @@ def current_family_id():
     return _family_on_the_session()
 
 
+def current_screen_token():
+    """The screen token of the family on the session. Cloud mode only.
+
+    Lives here rather than in a route because it needs the same two things
+    `current_store` does — the process pool, and the family the session names —
+    and because "which family" should be answered in one file however it is
+    being asked.
+    """
+    from dinkydash import screens
+
+    return screens.token_for(_the_pool(), _family_on_the_session())
+
+
+def store_for_token(token):
+    """The store for the family that screen token belongs to, or None.
+
+    The screen's half of `current_store`, and the only place a caller's own
+    string decides which family gets read. Two things keep that safe:
+
+    * **the token is a secret, not an identifier.** A wrong one names nothing —
+      there is no neighbouring family to land on the way an off-by-one id would
+      find one — so guessing is the only attack, and 59 bits is the answer to it;
+    * **one answer for every kind of miss.** Never issued, mistyped and rotated
+      away this morning all return None here, and `web/routes/screen.py` turns
+      that into a 404 and never a 403. It answers rather than this function,
+      because a miss is also the thing the screen rate limit counts.
+
+    Cached on `g` like the session's store, so the board and its manifest are
+    one lookup rather than two, and one object rather than two.
+    """
+    store = g.get("_store")
+    if store is not None:
+        return store
+
+    from dinkydash import screens
+
+    pool = _the_pool()
+    family_id = screens.family_for_token(pool, token)
+    if family_id is None:
+        return None
+
+    from dinkydash.pgstore import PostgresStore
+
+    store = g._store = PostgresStore(pool, family_id)
+    return store
+
+
 def _for_the_session():
     """One `PostgresStore`, cached for the length of this request.
 
@@ -67,16 +124,25 @@ def _for_the_session():
         return store
 
     family_id = _family_on_the_session()
+    from dinkydash.pgstore import PostgresStore
+
+    store = g._store = PostgresStore(_the_pool(), family_id)
+    return store
+
+
+def _the_pool():
+    """The process-wide pool, or a loud failure.
+
+    **One pool per process, never one per request.** The cluster has 22
+    connections and a PgBouncer in front of them; a `PostgresStore` is two
+    attributes wrapped round this and costs nothing to build.
+    """
     pool = current_app.config.get("POOL")
     if pool is None:
         raise RuntimeError(
             "Cloud mode has no connection pool, so no request can be served."
         )
-
-    from dinkydash.pgstore import PostgresStore
-
-    store = g._store = PostgresStore(pool, family_id)
-    return store
+    return pool
 
 
 def _family_on_the_session():

--- a/web/routes/auth.py
+++ b/web/routes/auth.py
@@ -66,6 +66,18 @@ bp = Blueprint("auth", __name__)
 A_TOKEN = re.compile(r"([?&]t=)[^&\s\"']+")
 REDACTED = r"\1[redacted]"
 
+# A screen token in a *path*, which is the other bearer credential this app
+# serves and the one the access log format cannot help with. `%(U)s` is the
+# path without the query string, which is exactly what keeps `?t=` out — and
+# exactly what puts `/s/<token>` in. A panel reloading every five minutes would
+# otherwise write its own credential to the platform's log for years.
+#
+# Matched on the alphabet rather than on `\S+`, so `/settings` and `/static`
+# are untouched: `config.ID_ALPHABET` has no `i`, `l`, `o` or `0`, and the
+# length bounds are the column's.
+A_SCREEN = re.compile(r"(/s/)[23456789abcdefghjkmnpqrstuvwxyz]{10,32}")
+SCREEN_REDACTED = r"\1[redacted]"
+
 # The one answer a login request ever gets. It used to begin "If that address
 # has an account", because an unknown one got nothing at all. Now that the same
 # form starts a board, a link really does go to every address that asks — so
@@ -101,7 +113,13 @@ REQUEST_LOGGERS = ("werkzeug", "gunicorn.access")
 
 
 class NoTokens(logging.Filter):
-    """Take the token out of anything a server writes about a request.
+    """Take both kinds of token out of anything a server writes about a request.
+
+    Two credentials travel in URLs here and they need different treatment. A
+    sign-in link is `?t=` in the query string, which gunicorn's `%(U)s` format
+    already leaves out; a screen URL is `/s/<token>` in the *path*, which that
+    same format writes down every time. So the access log format covers one and
+    this filter is the only thing covering the other.
 
     Belt to the access log format's braces, and it exists because both halves
     of that format can be missing:
@@ -124,8 +142,9 @@ class NoTokens(logging.Filter):
 
     def filter(self, record):
         message = record.getMessage()
-        if "t=" in message:
-            record.msg = A_TOKEN.sub(REDACTED, message)
+        if "t=" in message or "/s/" in message:
+            record.msg = A_SCREEN.sub(SCREEN_REDACTED,
+                                      A_TOKEN.sub(REDACTED, message))
             record.args = ()
         return True
 

--- a/web/routes/board.py
+++ b/web/routes/board.py
@@ -1,13 +1,26 @@
-"""The board itself, plus a preview harness for the target screen sizes."""
+"""The board itself, plus a preview harness for the target screen sizes.
+
+**Where the board lives is the one thing mode changes here**, and it changes
+because of authentication rather than layout. Single mode serves it at `/`:
+one family, no session, and the URL somebody types into a Pi's kiosk browser.
+Cloud mode cannot, because a wall panel has no way to sign in — so there the
+board is at `/s/<token>` (`web/routes/screen.py`) and `/` is the front door of
+the signed-in area, redirecting to the settings.
+
+`render_board` and `manifest_for` below are what the two routes share, so the
+board is one piece of code reached two ways rather than two that drift.
+"""
 
 import os
 
-from flask import Blueprint, render_template, request, url_for
+from flask import (Blueprint, current_app, redirect, render_template, request,
+                   url_for)
 
 from dinkydash import board as board_view
 from dinkydash import config as config_module
+from web import CLOUD
 from web import manifest as manifest_module
-from web.family import current_store
+from web.family import current_screen_token, current_store
 from web.session import guard
 
 bp = Blueprint("board", __name__)
@@ -44,40 +57,86 @@ def current_config():
 
 @bp.route("/")
 def index():
-    store = current_store()
+    """The board, or — in cloud mode — the way in to the settings.
+
+    The mode check is an authentication one, which is the only kind this file
+    is allowed. In cloud mode `/` is behind `guard()`, so a signed-out visitor
+    has already been sent to `/login` before this runs and the only person
+    reaching this line is signed in. Their board is not here: it is at the
+    screen URL, which is the one a panel can open without a cookie.
+    """
+    if current_app.config["MODE"] == CLOUD:
+        return redirect(url_for("settings.home"))
+    return render_board(current_store())
+
+
+def render_board(store, manifest_url=None):
+    """The board page for whichever family that store is for.
+
+    Shared with `web/routes/screen.py`, so the signed-in view and the wall
+    panel render the same page from the same code. `manifest_url` is the only
+    difference between them and it is one link in the head: the panel's
+    manifest has to be reachable without a session, or "save to home screen"
+    gets a redirect to `/login` instead of a name and an icon.
+    `tests/test_cloud_mode.py` asserts that it is the *only* difference.
+    """
     config = store.load_config()
     today = config_module.today_for(config)
     view = board_view.build_view(config, store.load_payload(config), today)
-    return render_template("board.html", view=view)
+    return render_template("board.html", view=view,
+                           manifest_url=manifest_url or url_for("board.manifest"))
 
 
-@bp.route("/manifest.webmanifest")
-def manifest():
+def manifest_for(config, url):
     """A wall panel saved to a tablet's home screen: full screen, no browser.
 
     Separate from the settings manifest, and deliberately so — one is a screen
-    you leave on, the other is a page you visit.
+    you leave on, the other is a page you visit. They must keep different
+    `id`s: share one and the phone treats them as a single app.
     """
-    config = current_config()
     # The saved app keeps its own background until the board paints, so it has
     # to match the theme or a dark board flashes white on every open.
     colour = "#17120f" if config.get("theme") == "dark" else "#ffffff"
     return manifest_module.response(
-        id=url_for("board.index"),
+        id=url,
         name=config.get("family_name") or "DinkyDash",
         short_name=config.get("family_name") or "DinkyDash",
         description="Today's agenda, whose turn it is, and what is coming up.",
-        start_url=url_for("board.index"),
+        start_url=url,
         display="fullscreen",
         background_color=colour,
         theme_color=colour,
     )
 
 
+@bp.route("/manifest.webmanifest")
+def manifest():
+    return manifest_for(current_config(), url_for("board.index"))
+
+
 @bp.route("/preview")
 def preview():
-    """Every target screen at once, so a layout change can be checked in one go."""
-    return render_template("preview.html", sizes=PREVIEW_SIZES)
+    """Every target screen at once, so a layout change can be checked in one go.
+
+    **What it frames is wherever the board actually is.** In cloud mode `/` is
+    a redirect, so framing it would show three iframes of the settings page —
+    the harness has to follow the board to `/s/<token>` or it stops being a
+    harness.
+    """
+    return render_template("preview.html", sizes=PREVIEW_SIZES,
+                           board_url=board_url())
+
+
+def board_url():
+    """Where this family's board is served, for this mode.
+
+    The token is a column on `families`, not a key in the config dict — it is
+    the platform's business rather than a family setting, so it is asked for
+    rather than read out of what the store returned.
+    """
+    if current_app.config["MODE"] != CLOUD:
+        return url_for("board.index")
+    return url_for("screen.board", token=current_screen_token())
 
 
 @bp.route("/healthz")

--- a/web/routes/screen.py
+++ b/web/routes/screen.py
@@ -1,0 +1,152 @@
+"""The board on a wall: one unguessable URL, no session. Cloud mode only.
+
+    GET /s/<token>                        the board
+    GET /s/<token>/manifest.webmanifest   so a tablet can save it to a home screen
+
+Registered only when `DINKYDASH_MODE=cloud`, like `auth.py` — a self-hosted
+board is at `/` and has no token, so here this is a 404 rather than a route
+that exists and refuses.
+
+**Why the board is not simply behind the login.** A kitchen tablet, a television
+and a Raspberry Pi in kiosk mode have no way to sign in and nobody to do it: the
+whole point of the product is a screen somebody stops thinking about. So the
+credential moves into the URL, where a browser can hold it for months without a
+person (PLAN.md, Screen URLs).
+
+**That makes the token a bearer credential, and a long-lived one.** It has none
+of a magic link's defences — no expiry, no single use — so the ones it does have
+have to be kept working:
+
+* **it reaches nothing but a board.** No settings, no email address, nothing
+  that writes. Both routes here are GETs, and both read through a
+  `PostgresStore` scoped to the one family the token named;
+* **rotation is the revocation**, on the settings page, and it is the whole of
+  it;
+* **it must not end up written down.** `Referrer-Policy: no-referrer` is on
+  every response already (DIN-32), the page makes no third-party request, and
+  every response here carries `X-Robots-Tag` and `Cache-Control: no-store`;
+* **the path is in the access log, and that had to be dealt with.** Gunicorn's
+  format is built from `%(U)s` — the path *without* the query string — which is
+  exactly what keeps a magic link's `?t=` out of it. A token in the path is on
+  the other side of that trade, and a panel reloading every five minutes writes
+  it thousands of times. `auth.NoTokens` scrubs `/s/<token>` for the same reason
+  it scrubs `?t=`, and `tests/test_screen.py` fails if it stops.
+
+**The rate limit counts misses, not requests.** A valid token belongs to a
+screen that will ask for this page every few minutes for years, and refusing it
+is an outage on somebody's kitchen wall. A wrong one is a typo or a scan.
+Counting only the misses lets the limiter be strict without ever being in a real
+screen's way — and enumeration was never the real risk, since guessing 59 bits
+at any rate at all is hopeless. What it actually buys is that nobody can make us
+do the looking.
+"""
+
+import logging
+
+from flask import (Blueprint, current_app, make_response, render_template,
+                   request, url_for)
+
+from web import ratelimit
+from web.family import store_for_token
+from web.routes.board import manifest_for, render_board
+
+log = logging.getLogger(__name__)
+
+bp = Blueprint("screen", __name__)
+
+# Wrong tokens per caller address per hour, in this process. Generous, because a
+# family mistyping the URL onto three devices should not be locked out, and
+# small enough that a scan is not free.
+MOST_MISSES = 30
+PER_SECONDS = 3600
+
+# What a screen response always carries, whatever it is.
+SCREEN_HEADERS = {
+    # The URL is a credential, so the page must not be findable. Both halves:
+    # one keeps it out of an index, the other stops a crawler following what is
+    # on it.
+    "X-Robots-Tag": "noindex, nofollow",
+    # A shared cache holding a family's day under a URL anyone downstream can
+    # replay is not a cache, it is a leak. Offline tolerance for a panel on
+    # flaky wifi is a real want and its own job (PLAN.md phase 3): it needs a
+    # service worker, not a weaker header here.
+    "Cache-Control": "no-store, private",
+}
+
+
+@bp.record_once
+def _build_the_limiter(state):
+    """One limiter per app rather than one per process.
+
+    A module-level counter would be shared by every app built in a process,
+    which is fine in production and wrong in a test suite that builds several.
+    The same reasoning as `auth._build_the_limiter`, and the same shape.
+    """
+    state.app.config.setdefault(
+        "SCREEN_LIMITER", ratelimit.Limiter(MOST_MISSES, PER_SECONDS))
+
+
+@bp.route("/s/<token>")
+def board(token):
+    store = store_for_token(token)
+    if store is None:
+        return _refused()
+    return _screen(render_board(
+        store, manifest_url=url_for("screen.manifest", token=token)))
+
+
+@bp.route("/s/<token>/manifest.webmanifest")
+def manifest(token):
+    """The panel's own manifest, so saving it to a home screen gets a name.
+
+    `board.manifest` is behind the session, so a tablet asking for it from a
+    screen URL gets a redirect to `/login` and the saved icon is a browser
+    default. This is the same manifest with the screen URL as its `start_url`
+    and its `id` — which also keeps it distinct from the settings one, and
+    sharing an `id` makes a phone treat the two as a single app.
+    """
+    store = store_for_token(token)
+    if store is None:
+        return _refused()
+    return _screen(
+        manifest_for(store.load_config(), url_for("screen.board", token=token)))
+
+
+def _refused():
+    """What a wrong token gets: a plain page, and never a hint.
+
+    **404, never 403.** "Forbidden" would confirm the token exists and is merely
+    not allowed, which is the one thing a guess must not learn. Mistyped,
+    rotated away this morning and never issued are the same answer.
+
+    The miss is counted here rather than in `store_for_token`, because this is
+    the only place that knows a lookup failed — and only misses are counted, so
+    a real screen asking every five minutes for a year is never refused.
+
+    **The token is not echoed**, into the page or the log. It is a credential
+    even when it is wrong, because a typo of a real one is nearly a real one.
+    """
+    limiter = current_app.config["SCREEN_LIMITER"]
+    caller = ratelimit.client_ip(request)
+    if not limiter.allow(caller):
+        log.warning("Screen lookups from %s are over the limit (%s misses per "
+                    "%s minutes, in this process).",
+                    caller or "an unknown caller",
+                    limiter.most, round(limiter.per / 60))
+        return _screen(render_template(
+            "screen_refused.html",
+            heading="Too many tries",
+            detail="Wait a while, then reload this page."), status=429)
+    return _screen(render_template(
+        "screen_refused.html",
+        heading="This screen link does not work",
+        detail="Check it against the one on your settings page. If the link "
+               "was changed, every screen needs the new one."), status=404)
+
+
+def _screen(body, status=200):
+    """One place where the three rules above are applied."""
+    response = make_response(body, status)
+    for header, value in SCREEN_HEADERS.items():
+        response.headers[header] = value
+    return response

--- a/web/routes/settings.py
+++ b/web/routes/settings.py
@@ -8,6 +8,7 @@ Writes go straight back to config.yaml through ruamel's round-trip mode, so the
 comments in the file survive being edited from a phone.
 """
 
+import io
 import logging
 from datetime import datetime, time, timezone
 
@@ -15,14 +16,15 @@ from flask import (Blueprint, abort, current_app, flash, redirect,
                    render_template, request, url_for)
 
 from dinkydash import config as config_module
-from dinkydash import schedule
+from dinkydash import schedule, screens
 from dinkydash.calendars import FeedError, addresses, describe_feed, feed_label
 from dinkydash.claude_client import GenerationError
 from dinkydash.context import compute_birthday_info, upcoming_for
 from dinkydash.runner import forget_calendar, refresh_calendars
 from dinkydash.runner import run as run_generation
+from web import CLOUD
 from web import manifest as manifest_module
-from web.family import current_store
+from web.family import current_family_id, current_screen_token, current_store
 from web.session import guard
 
 log = logging.getLogger(__name__)
@@ -238,6 +240,9 @@ def home():
         "settings/home.html", config=config, status=status, counts=counts,
         broken=broken, sections=SECTIONS, cadence=cadence_summary(config),
         first_run=looks_untouched(config),
+        # Where "View board" goes. In cloud mode `/` is a redirect back to this
+        # page, so a button pointing at it would be a button that does nothing.
+        board_link=screen_url()["screen_path"] or url_for("board.index"),
     )
 
 
@@ -473,15 +478,106 @@ def section_move(section_name, item_id):
 
 @bp.route("/screen", methods=["GET", "POST"])
 def screen():
+    """Colours, and — in cloud mode — the URL a wall panel opens.
+
+    Both live here because they are the same question from a parent's side:
+    what the screen in the kitchen shows, and how it gets there.
+    """
     config = current_config()
     if request.method == "POST":
+        if request.form.get("action") == "rotate":
+            return rotate_screen_token()
         theme = request.form.get("theme")
         if theme in config_module.THEMES:
             config["theme"] = theme
             save(config)
             flash(f"Board set to {theme}.", "ok")
         return redirect(url_for("settings.screen"))
-    return render_template("settings/screen.html", config=config, themes=config_module.THEMES)
+    return render_template("settings/screen.html", config=config,
+                           themes=config_module.THEMES, **screen_url())
+
+
+def screen_url():
+    """The board's public URL and a QR of it, or empty in single mode.
+
+    Empty rather than absent so the template can ask for it either way. A
+    self-hosted board has no token — it is at `/` on a home network, and the
+    page already says what that means.
+    """
+    nothing = {"screen_link": None, "screen_path": None, "screen_qr": None}
+    if current_app.config["MODE"] != CLOUD:
+        return nothing
+    token = current_screen_token()
+    if token is None:
+        return nothing
+    # Two forms on purpose. The absolute one is what a person copies, types
+    # into a television or scans, so it has to carry the hostname. The path is
+    # what a link on this site uses, because an absolute URL in an `href` would
+    # send somebody through DNS and TLS again to reach the page next door.
+    link = url_for("screen.board", token=token, _external=True)
+    return {"screen_link": link,
+            "screen_path": url_for("screen.board", token=token),
+            "screen_qr": qr_svg(link)}
+
+
+def qr_svg(link):
+    """The link as an inline SVG QR code, or None if it cannot be drawn.
+
+    **Inline, not a file and not a third-party image.** The screen URL is a
+    bearer credential, so handing it to any QR service — or writing it into a
+    filename on disk — would be publishing it. Drawn on the page, it never
+    leaves this response.
+
+    `segno` is a pure-Python encoder with no dependencies of its own, and it
+    lives in `requirements-cloud.txt` rather than `requirements.txt`: a Pi has
+    no screen token and should not install a library it can never use. Hence
+    the import here rather than at the top of the file.
+    """
+    try:
+        import segno
+    except ImportError:  # pragma: no cover - cloud installs it
+        log.warning("segno is not installed, so the screen QR code is missing.")
+        return None
+    # `xmldecl=False` because an `<svg>` inside an HTML document must not carry
+    # one, and `svgns=False` because inline SVG inherits the namespace from the
+    # page. `omitsize` lets the surrounding CSS size it. Nothing here reaches
+    # outside the response.
+    #
+    # **Black modules, and the template puts a white plate behind them** — in
+    # both themes, which is the one place in this UI that ignores the theme
+    # tokens on purpose. A QR follows the same rules a barcode does: scanners
+    # expect dark on light, and an inverted code is read by some phones and not
+    # others. Drawing it in `currentColor` looked better in dark mode and would
+    # have shipped a QR that half the phones in a kitchen could not read.
+    #
+    # `border=4` is the quiet zone the QR specification asks for. Trimming it to
+    # save space is the other classic way to make a code that scans on a desk
+    # and not across a room.
+    #
+    # A bytes buffer, because segno's SVG writer encodes before it writes.
+    out = io.BytesIO()
+    segno.make(link, error="m").save(
+        out, kind="svg", xmldecl=False, svgns=False, omitsize=True, border=4,
+        dark="#000000", light=None, lineclass="qr")
+    return out.getvalue().decode("utf-8")
+
+
+def rotate_screen_token():
+    """Give the board a new URL, and stop the old one working.
+
+    **This is the only revocation a screen token has.** It does not expire and
+    it is not single use, so a parent who has shared a screenshot too widely
+    has exactly this button. It must therefore be honest about the cost: every
+    screen already showing the board goes blank until somebody opens the new
+    URL on it.
+    """
+    token = screens.rotate(current_app.config["POOL"], current_family_id())
+    if token is None:
+        flash("That did not work. Try again.", "error")
+    else:
+        flash("New screen link. Open it on every screen showing this board — "
+              "the old link has stopped working.", "ok")
+    return redirect(url_for("settings.screen"))
 
 
 def describe_minutes(minutes):

--- a/web/templates/board.html
+++ b/web/templates/board.html
@@ -18,7 +18,10 @@
     <link rel="icon" href="{{ url_for('static', filename='favicon.svg') }}" type="image/svg+xml">
     <!-- On a tablet used as the panel, saving this to the home screen gives a
          full-screen board with no browser around it. -->
-    <link rel="manifest" href="{{ url_for('board.manifest') }}">
+    {# Which manifest depends on how this board was reached: the signed-in view
+   has one behind the session, a wall panel needs the token-scoped one, or
+   "save to home screen" gets a redirect to /login instead of a name. #}
+<link rel="manifest" href="{{ manifest_url }}">
     <link rel="apple-touch-icon" href="{{ url_for('static', filename='apple-touch-icon.png') }}">
     <meta name="apple-mobile-web-app-title" content="{{ view.family_name or 'DinkyDash' }}">
     <meta name="apple-mobile-web-app-capable" content="yes">

--- a/web/templates/preview.html
+++ b/web/templates/preview.html
@@ -30,7 +30,7 @@
 {% for label, width, height in sizes %}
 <figure>
     <div class="frame" style="width: {{ (width * 0.62) | round | int }}px;">
-        <iframe src="{{ url_for('board.index') }}" width="{{ width }}" height="{{ height }}"
+        <iframe src="{{ board_url }}" width="{{ width }}" height="{{ height }}"
                 style="transform: scale(0.62); transform-origin: top left;
                        width: {{ width }}px; height: {{ height }}px;
                        margin-bottom: {{ ((height * 0.38) | round | int) * -1 }}px;"></iframe>

--- a/web/templates/screen_refused.html
+++ b/web/templates/screen_refused.html
@@ -1,0 +1,47 @@
+{# What a wrong screen URL shows. Deliberately standalone rather than extending
+   settings/base.html: this is what somebody sees on a television across a
+   kitchen, so it has no app bar, no navigation and nothing to tap. It also has
+   to render for a caller with no session and no family, so it can read nothing.
+
+   No link back into the app, and no mention of what was asked for. The token is
+   a credential even when it is wrong — a typo of a real one is nearly a real one
+   — so it is not echoed here any more than it is in the log. #}
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>{{ heading }} · DinkyDash</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="robots" content="noindex, nofollow">
+    {# The same self-hosted font the board uses, so this does not flash a system
+       face on the wall — and, like the board, it asks nothing of any third
+       party. A page about a bad credential must not tell anybody it was shown. #}
+    <link rel="stylesheet" href="{{ url_for('static', filename='fonts.css') }}">
+    <style>
+        :root { color-scheme: light dark; }
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+        body {
+            font-family: 'Nunito', system-ui, sans-serif;
+            background: #fdfaf6; color: #2d2319;
+            min-height: 100vh; display: flex; align-items: center;
+            justify-content: center; padding: 2rem; text-align: center;
+        }
+        main { max-width: 26rem; display: flex; flex-direction: column; gap: 0.75rem; }
+        h1 { font-size: 1.375rem; font-weight: 800; }
+        p { font-size: 1rem; line-height: 1.55; color: #6f6053; }
+        .mark { font-size: 1rem; font-weight: 800; color: #e85d24; letter-spacing: 0.01em; }
+        @media (prefers-color-scheme: dark) {
+            body { background: #17120f; color: #f6efe7; }
+            p { color: #a1907f; }
+            .mark { color: #ff7a45; }
+        }
+    </style>
+</head>
+<body>
+<main>
+    <div class="mark">DinkyDash</div>
+    <h1>{{ heading }}</h1>
+    <p>{{ detail }}</p>
+</main>
+</body>
+</html>

--- a/web/templates/settings/base.html
+++ b/web/templates/settings/base.html
@@ -11,6 +11,9 @@
          A block, because the login page is behind no session and the manifest
          is: fetching it there would only ever be a redirect. -->
     {% block manifest %}<link rel="manifest" href="{{ url_for('settings.manifest') }}">{% endblock %}
+    {# For the rare page with a rule of its own. Everything shared belongs in
+       the stylesheet below, not here. #}
+    {% block head %}{% endblock %}
     <link rel="apple-touch-icon" href="{{ url_for('static', filename='apple-touch-icon.png') }}">
     <meta name="apple-mobile-web-app-title" content="DinkyDash">
     <meta name="apple-mobile-web-app-capable" content="yes">

--- a/web/templates/settings/home.html
+++ b/web/templates/settings/home.html
@@ -52,7 +52,7 @@
             <button class="btn" type="submit">{{ icons.refresh() }} Refresh calendars</button>
         </form>
         <div style="display:flex;gap:0.625rem;">
-            <a class="btn outline" style="flex:1;" href="{{ url_for('board.index') }}">{{ icons.screen() }} View board</a>
+            <a class="btn outline" style="flex:1;" href="{{ board_link }}">{{ icons.screen() }} View board</a>
             <form class="inline-form" method="post" action="{{ url_for('settings.generate_now') }}" style="flex:1;">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                 <button class="btn outline" type="submit">Rewrite now</button>

--- a/web/templates/settings/screen.html
+++ b/web/templates/settings/screen.html
@@ -1,10 +1,22 @@
 {% extends "settings/base.html" %}
 {% import "settings/_icons.html" as icons %}
-{% block title %}Colours{% endblock %}
+{% block title %}The screen{% endblock %}
+
+{% block head %}
+<style>
+    /* **A white plate, in both themes.** The one place in this UI that ignores
+       the theme tokens, and not an oversight: scanners expect a QR to be dark
+       on light, and an inverted one is read by some phones and not others.
+       Better a code that looks slightly out of place on a dark settings page
+       than one somebody cannot scan from the kitchen doorway. */
+    .qr-code { background: #ffffff; border-radius: 0.875rem; padding: 0.75rem; }
+    .qr-code svg { display: block; width: 100%; height: auto; }
+</style>
+{% endblock %}
 
 {% block appbar %}
 <a class="back" href="{{ url_for('settings.home') }}">{{ icons.back() }}</a>
-<h1>Colours</h1>
+<h1>{{ "The screen" if screen_link else "Colours" }}</h1>
 {% endblock %}
 
 {% block content %}
@@ -41,6 +53,61 @@
     <noscript><button class="btn" type="submit" style="margin-top:0.75rem;">Save</button></noscript>
 </form>
 
+{% if screen_link %}
+{# Cloud mode: the board is not at `/`, because a wall panel cannot sign in.
+   This link is how it gets there, and it is a credential — see the warning
+   below it, which is not boilerplate. #}
+<div>
+    <div class="label">Where the board is</div>
+    <div class="card pad" style="display:flex;flex-direction:column;gap:0.875rem;">
+        <div class="hint">
+            Open this on the TV, tablet or Pi and leave the page up. It redraws itself; how
+            often is under <a href="{{ url_for('settings.refresh') }}">How often it updates</a>.
+        </div>
+        {# `word-break` because the URL must wrap on a phone rather than push the
+           card sideways, and `user-select:all` so one tap selects the whole thing. #}
+        <div style="font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:0.875rem;
+                    background:var(--warm);border-radius:0.875rem;padding:0.75rem 0.875rem;
+                    word-break:break-all;user-select:all;">{{ screen_link }}</div>
+        {% if screen_qr %}
+        <div style="display:flex;flex-direction:column;align-items:center;gap:0.5rem;">
+            {# Drawn here rather than fetched: handing this URL to a QR service
+               would be publishing the credential. `currentColor` is what makes
+               it work in both themes without a second copy.
+
+               **The one `|safe` in `web/`, and it is on machine-generated
+               markup.** `segno` emits the SVG from a URL this app built out of
+               its own alphabet and its own configured hostname — no feed, no
+               form field and no calendar text reaches it. Autoescaping stays on
+               for everything else on this page, and a `|safe` on anything a
+               person or a calendar wrote would be the bug this note exists to
+               keep visible. #}
+            <div class="qr-code" style="width:11rem;">{{ screen_qr | safe }}</div>
+            <div class="hint" style="text-align:center;">Scan it with the tablet's camera.</div>
+        </div>
+        {% endif %}
+    </div>
+</div>
+
+<div class="note-box">
+    <strong>Anyone with this link can see your board.</strong> There is no password on it — that is
+    what lets a screen on the wall show it without anybody signing in. Treat it like a key: do not
+    post it, and crop it out of screenshots.
+</div>
+
+<div>
+    <div class="label">If the link gets out</div>
+    <form method="post" class="card pad" style="display:flex;flex-direction:column;gap:0.875rem;">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+        <input type="hidden" name="action" value="rotate">
+        <div class="hint">
+            Changing it is the only way to stop an old link working. Every screen showing this
+            board will go blank until you open the new link on it.
+        </div>
+        <button class="btn outline" type="submit">Change the link</button>
+    </form>
+</div>
+{% elif not cloud %}
 <div class="note-box">
     The board lives at <strong>{{ url_for('board.index', _external=True) }}</strong> — open that on the
     TV, tablet or Pi and leave the page up. It redraws itself on its own; how often is under
@@ -51,4 +118,5 @@
     There is no password on this. Anyone on your network can see the board and change these settings,
     so keep the port off the public internet.
 </div>
+{% endif %}
 {% endblock %}


### PR DESCRIPTION
Closes DIN-42. A hosted family can now put their board on a screen.

## The gap this closes

`screen_token` has been written at sign-up since #79 and **nothing in the app read it**. In cloud mode the board was at `/` behind `session.guard`, so the only way to see it was to be signed in on that device — and a kitchen tablet cannot sign in. This was the one place where the product did not do the thing it is sold as.

`/` now redirects (signed in → `/settings/`, signed out → `/login`), which is what PLAN.md's URL map always said and what #79 could not do without this.

## The token is a bearer credential, and a worse one than a magic link

No expiry, no single use, sitting in a browser on a shelf for a year. Four things carry the weight:

- **It reaches nothing but a board.** Two GET routes, both reading through a `PostgresStore` scoped to the family the token named.
- **Rotation is the revocation**, and it is the whole of it. The settings page says so in those words, including the cost — every screen goes blank until somebody opens the new link on it.
- **`X-Robots-Tag`, `Cache-Control: no-store`, no third-party request from the page**, and the token never echoed back on a miss. A wrong token is a **404 and never a 403**: "forbidden" would confirm it exists.
- **The path is in the access log, and that needed dealing with.** Gunicorn's format is built from `%(U)s` — the path *without* the query string — which is exactly what keeps a magic link's `?t=` out, and exactly what would write a screen token down thousands of times from one panel. `auth.NoTokens` now scrubs both, matched on `config.ID_ALPHABET` so `/settings` and `/static` survive.

## Rate-limit the misses, not the requests

A valid token belongs to a screen that asks for its board every few minutes for years. Counting *that* would put a rate limit on somebody's kitchen wall. So only wrong tokens are counted — 30 an hour per caller.

Enumeration was never the real risk: 59 bits does not fall to any rate. What the limiter buys is that nobody can make us do the looking.

## The QR is drawn, not fetched

A QR *service* would mean handing a bearer credential to a third party; a CDN script would mean the settings page making an outbound request. `segno` is pure Python with no dependencies of its own, in `requirements-cloud.txt` and imported lazily — a Pi has no screen token and should not install a library it can never use.

**Black on a white plate in both themes.** `currentColor` looked better in dark mode and produced an inverted code, which some phones read and some do not. I rendered the SVG and decoded it to confirm it carries the link rather than assuming segno was right.

## Where this sits in the architecture

`dinkydash/screens.py` is the **third unscoped read** in the product, after `worker.family_ids` and `accounts.py`, and for the same reason: there is no session to scope to. Both doors into `web/family.py` — the session and the token — are now in that one file, with the reasoning next to each.

`board.render_board` is what `/` and `/s/<token>` share, so it is one board reached two ways rather than two that drift.

## Two test changes worth reading rather than skimming

- **The mode-parity test is now precise, not weakened.** The two modes' boards must still be byte-identical apart from the `<link rel=manifest>`, which has to differ because a panel's manifest cannot sit behind the session. That one href is normalised and *everything else still compared*, so a second divergence fails there rather than being quietly absorbed.
- **Two fixtures were issuing tokens this app would never issue** — `"tok" + urandom(6).hex()` and `tok-wilsons`. Neither is in `ID_ALPHABET` (no `0`, `1`, `o`, or hyphen). Fine as unique strings, and useless the moment a malformed token is refused before it reaches a query.

## Testing

- 742 pass with `DINKYDASH_TEST_DATABASE_URL`, 535 with 207 skipped without. `tests/test_screen.py` is 41 of them.
- **Walked end to end in process**: sign up, read the link off the settings page, open it with a client holding no session at all, confirm that client reaches nothing else (`/settings/`, `/settings/people` and `/` all 302 to `/login`), exhaust the miss limiter without touching the real screen, rotate, and watch the old URL 404 while the new one serves.
- QR decoded from the rendered SVG back to the exact link.
- Settings page shot in headless Chrome.

## Deploy

**No spec change and no `doctl apps update` for this one.** `segno` lives in `requirements-cloud.txt`, which the app spec's `build_command` already installs, and the migration list is unchanged — `deploy_on_push` is enough. (The two applies still outstanding from #79 are unrelated and still outstanding.)

## Deliberately not in this change

- **Offline tolerance** for a panel on flaky wifi. `no-store` is correct for a credential-bearing URL; offline needs a service worker, not a weaker header. PLAN.md phase 3.
- **The Cloudflare edge rate-limit rule** on `/s/*`. Worth adding on top, but the app must not depend on it, and the in-process limiter is what actually runs.
- **Renderer to landing-page parity** — person cards with ages. Still phase 3's open box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VqGomc6Y1LYeEA6LaokUdZ