### PR TITLE
A hard spend breaker: per family, and globally (DIN-43)

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -110,6 +110,24 @@ envs:
     scope: RUN_TIME
     type: SECRET
 
+  # The spend breaker (DIN-43), in model calls a day. Written out at their
+  # defaults rather than left implicit, because a ceiling nobody can see is a
+  # ceiling nobody raises — and because **this spec is the whole app**: a value
+  # changed in the dashboard is undone by the next `doctl apps update`, so an
+  # emergency change made there belongs here as well, the same day.
+  #
+  # `0` everywhere is the brake. It refuses every model call and leaves every
+  # board exactly as it is, which is the right shape for "stop the bill now".
+  - key: DINKYDASH_FAMILY_CALLS_A_DAY
+    scope: RUN_TIME
+    value: "12"
+  - key: DINKYDASH_GLOBAL_CALL_FLOOR
+    scope: RUN_TIME
+    value: "50"
+  - key: DINKYDASH_GLOBAL_CALLS_PER_FAMILY
+    scope: RUN_TIME
+    value: "4"
+
 services:
   # Named `site` rather than `web` because renaming a component destroys and
   # recreates it, and the name is not worth an outage on the pages that rank.

--- a/.env.example
+++ b/.env.example
@@ -32,3 +32,20 @@ ANTHROPIC_API_KEY=
 # Who the mail comes from. Must be on the authenticated sending domain, or
 # DKIM does not sign it. Defaults to hello@dinkydash.co.
 # DINKYDASH_MAIL_FROM=
+
+# The spend breaker (DIN-43), in **model calls a day**, not money — a price
+# table goes stale silently and in the wrong direction. The defaults in
+# dinkydash/budget.py are what runs with these unset; they are here so a
+# ceiling can be raised or slammed shut without a deploy.
+#
+# One family's calls in a UTC day. The product makes one; the rest is headroom
+# for somebody pressing "Rewrite now" after fixing a calendar. `0` stops that
+# family entirely.
+# DINKYDASH_FAMILY_CALLS_A_DAY=12
+#
+# Everybody's, as a floor plus an allowance per family, so the ceiling grows
+# with the product instead of quietly starving real boards one day. `0` and `0`
+# together stop all spending, which is the brake to reach for if a bill starts
+# running away.
+# DINKYDASH_GLOBAL_CALL_FLOOR=50
+# DINKYDASH_GLOBAL_CALLS_PER_FAMILY=4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,8 +178,14 @@ mode is a different product on the same code.
   goes in the line is chosen: the caller's address in full, the *domain* of the address asked about
   and never the address, and nothing at all for an address with no account. `tests/test_auth.py`
   asserts each of those, because a log policy nobody tests is a log policy that drifts.
-- **Spend caps are a security control.** The per-family and global breaker (PLAN.md phase 2) is what
-  stops a bug or an abusive account becoming an unbounded Anthropic bill.
+- **Spend caps are a security control, and they exist now** (DIN-43). `dinkydash/budget.py` counts
+  **calls, not money** — a price table goes stale silently and in the wrong direction — per family
+  and globally, in one statement that decides and records before the call. Three rules to keep:
+  **charge on the attempt**, because a revoked key that fails every time reports no usage and would
+  otherwise retry for ever; **a refusal is an `OverBudget`, which is a `GenerationError`**, so every
+  caller's existing keep-last-good path handles it and no second such path gets written; and
+  **anything new that calls Anthropic takes a budget**, the way it takes a store. "Rewrite now" was
+  the one path with no limit on it at all, and it is charged now too.
 
 ### The safety net, and what it does not cover
 
@@ -284,6 +290,7 @@ dinkydash/
 ├── mail.py            one transactional email, over SendGrid (cloud only)
 ├── accounts.py        users, the links that sign them in, and sign-up (cloud only)
 ├── screens.py         the token that puts a board on a wall (cloud only)
+├── budget.py          what a family may spend on the model, and what everybody may
 └── runner.py          the two halves of the day, reading and writing through a store
 
 web/

--- a/PLAN.md
+++ b/PLAN.md
@@ -8,6 +8,11 @@
 
 *September 8, later: **one service, not two.** The board joins the marketing site in the existing `dinkydash-site` app rather than getting its own, because that is how `qrpage.co` and `abc-league` already run in this account — one container, one gunicorn, everything in it. Staging is dropped until there is a paying family to protect. The `worker` is the one genuine addition, because the tick has no lock and two web instances would tick twice. See [Hosting and deployment](#hosting-and-deployment).*
 
+*September 8, and this is the one that was overdue: **there is a spend breaker** (DIN-43). Per
+family and globally, checked and recorded in one statement before the call. Nothing bounded the
+Anthropic bill until now — not the worker, and not "Rewrite now", which was a browser button with
+an unlimited API call behind it. See [The spend breaker](#the-spend-breaker).*
+
 *September 8, later still: **the board is on a wall** (DIN-42). `/s/<token>` serves it with no
 session, `/settings/screen` shows the link and a QR of it and rotates the token, and `/` in cloud
 mode is now the way in to the settings rather than the board — the URL map below, finally. See
@@ -226,6 +231,44 @@ is drawn black on a white plate in **both** themes: scanners expect dark on ligh
 tolerance for a panel on flaky wifi, which needs a service worker rather than a weaker cache header;
 and the edge rate-limit rule at Cloudflare, which is a sturdier version of the in-process limiter
 rather than a replacement for it.
+
+### The spend breaker
+
+*Built in DIN-43.* `model_spend` holds calls and tokens per family per UTC day, and
+`budget.PostgresBudget.allow()` decides and records in one statement before every model call. Single
+mode passes `NoBudget` and is untouched: a self-hoster's key is their own bill.
+
+**Calls, not money.** A price table in the code goes stale silently and in the wrong direction — it
+under-counts after a price rise, which is exactly when a breaker matters. A call is exact and is
+knowable *before* it is made. The multiplication into money lives in
+[doc/operations.md](doc/operations.md) and in the cost model above, where a wrong number is a wrong
+note rather than a broken control.
+
+**Charged on the attempt.** A revoked API key fails every call, pays for input tokens each time, and
+reports no usage at all; a breaker counting successes would watch a five-minute retry loop do that
+for ever.
+
+**The per-family cap is exact and the global one is approximate**, and the difference is written
+down rather than glossed. Per family it is enforced in the `ON CONFLICT ... DO UPDATE ... WHERE`,
+which Postgres evaluates against the locked row. Globally it is a sum read before the write, so
+simultaneous callers can overshoot by their own number — bounded, and much cheaper than serialising
+every family's tick behind one row.
+
+**The global cap scales with the number of families** (`floor + per_family × families`). A fixed
+ceiling is a control that starts starving real boards on the day the product grows into it, and the
+failure looks exactly like a quiet morning.
+
+**A refusal is an `OverBudget`, which is a `GenerationError`**, so every caller's existing
+keep-last-good path handles it with no new branch: the board on the wall stays, labelled stale, and
+the next tick asks again. Inventing a second kind of failure would have meant a second such path,
+and the one written second is the one that eventually blanks somebody's screen. The **calendar
+refresh is deliberately outside the budget** — a fetch costs requests, not money, so a family who
+cannot afford a new headline today still gets an accurate agenda under yesterday's.
+
+`0` everywhere is the brake, and it works: it refuses every call and changes no board. It had to be
+made to work — the first version let every family through once a day even at zero, because the first
+call of a day takes the insert path where the per-family check never ran. A test found that, not a
+reading.
 
 ### Three clocks, one setting
 
@@ -790,13 +833,13 @@ missing is the multi-tenant half — a schema, auth, and scoping every read and 
 
 ### Phase 2 — Generation pipeline
 
-- [ ] Worker process: the 5-minute tick over every family that is due, per the scheduling section
-- [ ] Calendar refresh and daily brief as separate operations, each recorded (`agendas`, `generations`)
-- [ ] "Generate now" and "Refresh calendars" for onboarding and manual use
-- [ ] Per-family daily idempotency on the brief
-- [ ] Per-family and **global** spend caps with a hard breaker
+- [x] Worker process: the 5-minute tick over every family that is due, per the scheduling section. Running since 8 September; `worker/` and `tests/test_worker.py`.
+- [x] Calendar refresh and daily brief as separate operations, each recorded (`agendas`, `generations`) *(DIN-17, DIN-28)*
+- [x] "Generate now" and "Refresh calendars" for onboarding and manual use — both on the settings home, and both work in cloud mode. **What is still missing is "Generate now" *on signup*:** a family who signs up at 03:00 sees the waiting screen until their `brief_time`, because the brief is not due before then.
+- [x] Per-family daily idempotency on the brief — `schedule.due` asks for one brief per local day and `generations` is unique on `(family_id, generated_for_date)`, so a second write for a day replaces rather than adds
+- [x] Per-family and **global** spend caps with a hard breaker *(DIN-43)*. See [The spend breaker](#the-spend-breaker). "Rewrite now" is charged against the same budget as the worker, because it is the same money.
 - [ ] Keep-last-good on failure; retry with backoff on later ticks; consecutive-failure tracking; parent notification after N
-- [ ] Per-generation token/cost recording
+- [x] Per-generation token/cost recording — `generations.input_tokens`/`output_tokens` for the latest board, and `model_spend` for the running daily total per family *(DIN-43)*
 - [ ] Dead-man's switch pinged from the tick, alerting if it stops
 
 **Done when:** families in three timezones each get a correct dashboard at their own brief time, a calendar change reaches each screen within its interval, and killing the Anthropic key degrades gracefully instead of blanking screens.

--- a/dinkydash/CLAUDE.md
+++ b/dinkydash/CLAUDE.md
@@ -118,6 +118,36 @@ starter config in the transaction that spent it. Five things about that are deli
   backstop rather than the error path. A collision at 59 bits is not something anyone will see, but
   an unhandled one would spend somebody's sign-up link and hand them a 500.
 
+## What a call is allowed to cost
+
+`budget.py` is the breaker, and it is injected the way a store is: `write_brief(config, store,
+budget=...)`. Single mode passes nothing and gets `NoBudget`, because a self-hoster's key is their
+own bill; cloud mode passes `budget.for_family(pool, family_id)`, built in the one place that knows
+both the pool and the family — `worker.tick_all` and `web/family.current_budget()`.
+
+Five things in it are load-bearing, and `tests/test_budget.py` asserts each:
+
+- **Calls, not money.** A price table in code goes stale silently and in the wrong direction: it
+  under-counts after a price rise, which is exactly when a breaker matters. A call is exact and is
+  knowable before it is made.
+- **Charged on the attempt, not on success.** A revoked API key fails every call and reports no
+  usage. Counting successes would let a five-minute retry loop pay for input tokens for ever.
+- **The per-family cap appears in the statement twice, and that is not redundant.** An upsert has
+  two paths: `DO UPDATE ... WHERE` covers the update and is evaluated against the locked row, which
+  is what makes it exact — and the source `WHERE` covers the *first call of the day*, when there is
+  no row to conflict with. Written with only the first, a cap of `0` let every family through once
+  daily, so the brake that exists to stop all spending was the one setting that could not.
+- **The global cap is approximate and says so**, by at most the number of simultaneous callers.
+  Making it exact means serialising every family's tick behind one row, which is not worth it for a
+  ceiling set well above legitimate use.
+- **A refusal is an `OverBudget`, a subclass of `GenerationError`.** That is what lets every caller
+  keep the board on the wall with no new branch — "a failure is not handled, it is simply due again"
+  already covers it. A second kind of failure would mean a second keep-last-good path.
+
+The **calendar refresh is outside the budget**. A fetch costs HTTP requests to somebody else's
+server, not money, and a family who cannot afford a new headline today should still have an
+accurate agenda under yesterday's.
+
 ## Cloud mode: schema, migrations, connections
 
 `migrations/*.sql` is plain SQL applied in filename order by `migrate.py`, which records each one in

--- a/dinkydash/budget.py
+++ b/dinkydash/budget.py
@@ -1,0 +1,246 @@
+"""What a family is allowed to spend on the model, and what everybody is.
+
+    NoBudget()                        single mode: no ceiling, and no database
+    PostgresBudget(pool, family_id)   cloud mode: the breaker
+    for_family(pool, family_id)       the same, with the caps read from the environment
+
+    budget.allow()                    charge one call, or raise OverBudget
+    budget.record(input, output)      what that call actually used
+
+Nothing bounded the Anthropic bill before this (DIN-43). The worker walks every
+non-lapsed family and calls Claude, "Rewrite now" calls it from a web request,
+and a bug that ticks in a loop costs exactly what an abusive account would. The
+rate limits elsewhere in this codebase raise the cost of causing that; **this is
+the only thing that bounds the damage once somebody pays it.**
+
+**Calls, not money.** A price table would go stale silently and in the wrong
+direction — it under-counts after a price rise, which is precisely when a
+breaker matters. A call is exact, is knowable *before* it is made, and the
+product already says how many there should be: one brief a day per family.
+`doc/operations.md` carries the multiplication into pounds, where a wrong number
+is a wrong note rather than a broken control.
+
+**Charged on the attempt, not on success.** An expired API key retried every
+five minutes pays for input tokens every time and reports no usage at all. A
+breaker that counted successes would watch that happen for ever.
+
+**One statement decides and records**, the way `accounts.issue_link` does its
+rate limit, so two callers arriving together cannot both read "one call today"
+and both make a second. The two halves are not equally exact, and the
+difference is written down rather than glossed:
+
+* **the per-family cap is exact.** It is enforced in the `ON CONFLICT ... DO
+  UPDATE ... WHERE`, which Postgres evaluates against the locked, current row;
+* **the global cap is approximate**, by at most the number of callers arriving
+  in the same instant. It is a sum read before the write, and making it exact
+  would mean serialising every family's tick behind one row. For a ceiling set
+  well above what anybody legitimately uses, an overshoot of a handful of calls
+  is not worth that.
+
+**The global cap scales with the number of families**, and that is deliberate: a
+fixed number is a control that silently starts starving real boards on the day
+the product grows into it, and nobody notices because the failure looks like a
+quiet morning. `GLOBAL_FLOOR + GLOBAL_PER_FAMILY × families` stays generous at
+every size while still catching a runaway, which is what a breaker is for.
+
+This module imports no driver — it is handed a pool and asks it for connections,
+like `accounts.py` and `screens.py`.
+"""
+
+import logging
+import os
+from datetime import datetime, timezone
+
+from .claude_client import GenerationError
+
+log = logging.getLogger(__name__)
+
+# What one family may spend in a UTC day. The product makes **one** call a day;
+# the rest is headroom for somebody pressing "Rewrite now" a few times after
+# fixing a calendar, which is a reasonable thing to do and not worth refusing.
+# A loop trips this within an hour.
+FAMILY_CALLS_A_DAY = 12
+
+# The global ceiling, as a floor plus an allowance per family. The floor is what
+# lets a brand-new install with two families still absorb a day of somebody
+# experimenting; the per-family part is what stops the whole thing needing to be
+# re-tuned at every order of magnitude.
+GLOBAL_FLOOR = 50
+GLOBAL_PER_FAMILY = 4
+
+
+class OverBudget(GenerationError):
+    """The call was refused because it would cost more than is allowed.
+
+    **A `GenerationError` on purpose.** Every caller already handles one of
+    those by keeping the board that is on the wall and trying again later — a
+    failure here is "not handled, simply due again", which is how the whole tick
+    treats failure. Inventing a second kind of failure would mean a second
+    keep-last-good path, and the one that got written second is the one that
+    blanks somebody's screen.
+    """
+
+
+class NoBudget:
+    """No ceiling. What single mode passes, which is to say: nothing.
+
+    A self-hoster brings their own API key, so the bill is theirs and a limit we
+    invented would be a nuisance rather than a protection. The two things that
+    actually bound a Pi are already there and are not about money: `schedule.due`
+    asks for one brief a day, and `generate.only_one_tick` stops a slow tick
+    being paid for twice.
+    """
+
+    def allow(self):
+        return None
+
+    def record(self, input_tokens, output_tokens):
+        return None
+
+
+class PostgresBudget:
+    """The breaker, for one family, over the shared pool."""
+
+    def __init__(self, pool, family_id, family_a_day=FAMILY_CALLS_A_DAY,
+                 global_floor=GLOBAL_FLOOR, global_per_family=GLOBAL_PER_FAMILY):
+        self.pool = pool
+        self.family_id = family_id
+        self.family_a_day = family_a_day
+        self.global_floor = global_floor
+        self.global_per_family = global_per_family
+
+    def allow(self):
+        """Charge one call, or raise `OverBudget`. Returns how many are now used.
+
+        The whole decision is the one statement below, and the per-family cap
+        appears in it **twice**, which is not redundant. There are two paths
+        through an upsert and each needs its own check:
+
+        * the **insert** path is the first call of the day, when there is no row
+          to conflict with and `DO UPDATE` never runs. The row's count is zero
+          there, so the condition is `0 < cap`;
+        * the **update** path carries the check in `DO UPDATE ... WHERE`, where
+          Postgres evaluates it against the locked, current row — which is what
+          makes the per-family cap exact rather than a stale read.
+
+        Written with only the second, a cap of **0** let every family make one
+        call a day: the brake that exists to stop all spending was the one
+        setting that could not. Caught by a test, not by reading it.
+        """
+        day = _today()
+        with self.pool.connection() as conn, conn.transaction():
+            with conn.cursor() as cur:
+                cur.execute(
+                    """INSERT INTO model_spend (day, family_id, calls)
+                       SELECT %(day)s, %(family)s, 1
+                       WHERE (SELECT coalesce(sum(calls), 0) FROM model_spend
+                              WHERE day = %(day)s)
+                             < (SELECT %(floor)s + %(per)s * count(*)
+                                FROM families WHERE status <> 'lapsed')
+                         -- The insert path: no row yet, so this family has made
+                         -- nothing today. Without it a cap of 0 allows one.
+                         AND 0 < %(family_cap)s
+                       ON CONFLICT (day, family_id) DO UPDATE
+                          SET calls = model_spend.calls + 1, updated_at = now()
+                          WHERE model_spend.calls < %(family_cap)s
+                       RETURNING calls""",
+                    {"day": day, "family": self.family_id,
+                     "floor": self.global_floor, "per": self.global_per_family,
+                     "family_cap": self.family_a_day},
+                )
+                row = cur.fetchone()
+
+        if row is None:
+            # **Which of the two limits tripped is deliberately not worked
+            # out.** It would be a second query on the path that is already
+            # refusing, and it would change nothing: the caller keeps the board
+            # that is on the wall either way. The numbers are in the line so
+            # that whoever reads it can tell at a glance which one it must have
+            # been, and `used_today()` answers it exactly if anybody needs it.
+            log.warning("Refused a model call for family %s: over the daily "
+                        "budget (%s a family, %s + %s a family globally).",
+                        self.family_id, self.family_a_day,
+                        self.global_floor, self.global_per_family)
+            raise OverBudget(
+                "Today's limit on rewriting the board has been reached. "
+                "The board on the screen is unchanged, and this will work "
+                "again tomorrow.")
+        return row[0]
+
+    def record(self, input_tokens, output_tokens):
+        """Add what the call used. Never raises.
+
+        Bookkeeping rather than control: the breaker already counted the call,
+        and losing a token count must not turn a written board into a failure.
+        The row exists by now — `allow()` made it — so this only ever updates.
+        """
+        try:
+            with self.pool.connection() as conn, conn.transaction():
+                with conn.cursor() as cur:
+                    cur.execute(
+                        """UPDATE model_spend
+                           SET input_tokens = input_tokens + %s,
+                               output_tokens = output_tokens + %s,
+                               updated_at = now()
+                           WHERE day = %s AND family_id = %s""",
+                        (int(input_tokens or 0), int(output_tokens or 0),
+                         _today(), self.family_id),
+                    )
+        except Exception:
+            log.exception("Could not record what a model call used; the call "
+                          "itself was counted and the board was written.")
+
+    def used_today(self):
+        """(this family's calls, everybody's calls) today. For the settings page
+        and for anybody looking at a bill and wondering."""
+        day = _today()
+        with self.pool.connection() as conn, conn.cursor() as cur:
+            cur.execute(
+                """SELECT coalesce(max(calls) FILTER (WHERE family_id = %s), 0),
+                          coalesce(sum(calls), 0)
+                   FROM model_spend WHERE day = %s""",
+                (self.family_id, day),
+            )
+            return cur.fetchone()
+
+
+def for_family(pool, family_id):
+    """A budget with the caps read from the environment.
+
+    **Raisable without a deploy**, which is most of what you want from a breaker
+    at two in the morning: the numbers are App Platform environment variables,
+    and a bad one falls back to the constant above rather than to no limit at
+    all. A breaker that fails open because somebody typed `twelve` is not one.
+    """
+    return PostgresBudget(
+        pool, family_id,
+        family_a_day=_number("DINKYDASH_FAMILY_CALLS_A_DAY", FAMILY_CALLS_A_DAY),
+        global_floor=_number("DINKYDASH_GLOBAL_CALL_FLOOR", GLOBAL_FLOOR),
+        global_per_family=_number("DINKYDASH_GLOBAL_CALLS_PER_FAMILY",
+                                  GLOBAL_PER_FAMILY),
+    )
+
+
+def _number(name, fallback):
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return fallback
+    try:
+        value = int(raw)
+    except ValueError:
+        log.warning("%s is not a number; using %s.", name, fallback)
+        return fallback
+    if value < 0:
+        log.warning("%s is negative; using %s.", name, fallback)
+        return fallback
+    return value
+
+
+def _today():
+    """The UTC date. Not the family's, and that is the point.
+
+    `generations.generated_for_date` is the family's local date, which is right
+    for "is today's board written" and wrong for a global total: a day summed
+    over a dozen local dates is not a day.
+    """
+    return datetime.now(timezone.utc).date()

--- a/dinkydash/runner.py
+++ b/dinkydash/runner.py
@@ -18,6 +18,12 @@ whole payload. That is what makes a refresh landing during the model call
 survive rather than being overwritten by the stale keys the brief read minutes
 earlier (DIN-28). A fresh agenda under yesterday's headline is exactly the
 amber-banner state `board.build_view` already handles.
+
+**`write_brief` takes a budget as well as a store**, and for the same reason it
+takes a store: what a call is allowed to cost is the caller's business, not the
+engine's (DIN-43). Single mode passes nothing and gets `NoBudget`; cloud mode
+passes one backed by Postgres. A refusal arrives as a `GenerationError`, so
+every caller's existing keep-last-good path handles it with no new branch.
 """
 
 import logging
@@ -25,6 +31,7 @@ import os
 from datetime import datetime, timedelta, timezone
 
 from . import config as config_module
+from .budget import NoBudget
 from .calendars import fetch_events, sort_key
 from .claude_client import GenerationError
 from .generate import generate
@@ -127,17 +134,21 @@ def forget_calendar(config, store, labels):
     log.info("Forgot the stored events of %s; a refresh is due", ", ".join(sorted(labels)))
 
 
-def write_brief(config, store, today=None, client=None):
+def write_brief(config, store, today=None, client=None, budget=None):
     """Ask Claude for today's headline and note, and store them. Costs one call.
 
     The events come from the stored payload rather than a second fetch, so the
     brief always describes the agenda the board is showing, and a tick that
     owes both does one fetch rather than two.
 
-    Raises GenerationError if the model call fails — the caller decides what to
-    do, and the previous payload is left untouched either way.
+    Raises GenerationError if the model call fails **or if the budget refuses
+    it** — the caller decides what to do, and the previous payload is left
+    untouched either way. That sameness is the point: a board that is too
+    expensive to rewrite and a board whose rewrite failed should both leave the
+    screen on the wall showing yesterday, labelled stale.
     """
     require_api_key()
+    budget = budget or NoBudget()
     today = today or config_module.today_for(config)
 
     stored = store.load_payload(config) or {}
@@ -145,9 +156,16 @@ def write_brief(config, store, today=None, client=None):
     keep = int(config.get("history_days") or 30)
     recent = store.recent_notes(config, keep)
 
+    # **Charged before the call, not after.** A key that has been revoked fails
+    # every time and reports no usage, so counting successes would let a
+    # five-minute retry loop run for ever. Raises `OverBudget` if it will not
+    # pay for this one, and nothing below has run.
+    budget.allow()
+
     payload = generate(
         config, today, stored.get("events") or [], recent_notes=recent, client=client
     )
+    budget.record(payload.get("input_tokens"), payload.get("output_tokens"))
     # Only the brief. `stored` was read before a model call that takes seconds,
     # so anything of the agenda's in it is already potentially out of date — a
     # refresh may well have landed in the meantime, and writing this copy back
@@ -170,11 +188,17 @@ def write_brief(config, store, today=None, client=None):
     return payload
 
 
-def run(config, store, today=None, client=None):
-    """Both halves: fetch the calendars, then write the brief. Returns the payload."""
+def run(config, store, today=None, client=None, budget=None):
+    """Both halves: fetch the calendars, then write the brief. Returns the payload.
+
+    The refresh is deliberately outside the budget: fetching calendars costs a
+    few HTTP requests to somebody else's server, not money, and a family whose
+    board cannot be rewritten today should still have an accurate agenda under
+    yesterday's headline.
+    """
     require_api_key()  # before the fetch, so a missing key fails in a second
     refresh_calendars(config, store, today=today)
-    return write_brief(config, store, today=today, client=client)
+    return write_brief(config, store, today=today, client=client, budget=budget)
 
 
 def require_api_key():

--- a/doc/operations.md
+++ b/doc/operations.md
@@ -267,6 +267,64 @@ knowing are:
 A Cloudflare rate-limit rule on `/s/*` was the original plan (DIN-29) and is still worth adding. It
 is not what the app depends on, and the in-process limiter is what actually runs today.
 
+## The spend breaker, 8 September 2026 (DIN-43)
+
+**There is now a ceiling on the Anthropic bill**, and there was not one before. `model_spend` counts
+calls and tokens per family per UTC day; `budget.PostgresBudget.allow()` charges one call before it
+is made and refuses when either cap is reached.
+
+**The numbers, and what they cost.** The caps are in **model calls**, not money — a price table in
+code goes stale silently and the wrong way. The multiplication lives here instead, from the cost
+model in PLAN.md: roughly **2,500 input and 350 output tokens a call**, which on `claude-haiku-4-5`
+is about **$0.0043 a call**, or about $0.13 per family per month at the one-a-day the product
+actually makes.
+
+| Setting | Default | What it costs a day if fully spent |
+|---|---|---|
+| `DINKYDASH_FAMILY_CALLS_A_DAY` | 12 | ~$0.05 per family |
+| `DINKYDASH_GLOBAL_CALL_FLOOR` | 50 | ~$0.22 |
+| `DINKYDASH_GLOBAL_CALLS_PER_FAMILY` | 4 | ~$0.017 per family |
+
+So the global ceiling is `50 + 4 × families` calls a day — about **$0.22 + $0.017 a family**, against
+a legitimate spend of about $0.0043 a family. Roughly four times headroom, and it grows with the
+product rather than needing to be re-tuned.
+
+**If a bill starts running away, this is the brake:**
+
+```
+DINKYDASH_FAMILY_CALLS_A_DAY=0
+DINKYDASH_GLOBAL_CALL_FLOOR=0
+DINKYDASH_GLOBAL_CALLS_PER_FAMILY=0
+```
+
+Every call is refused, every board on every wall stays exactly as it is, and calendars keep
+refreshing — the refresh costs requests rather than money and is deliberately outside the budget.
+Set it in the App Platform dashboard for immediate effect, then **put the same value in
+`.do/app.yaml` the same day**: the spec is the whole app, so the next `doctl apps update` undoes a
+dashboard-only change.
+
+**Where to look.** The refusals are `WARNING` lines from `dinkydash.budget`:
+
+```bash
+doctl apps logs <id> worker --type run | grep "over the daily budget"
+```
+
+and the running total is one query:
+
+```sql
+SELECT day, sum(calls) AS calls, sum(input_tokens) AS tok_in, sum(output_tokens) AS tok_out
+FROM model_spend GROUP BY day ORDER BY day DESC LIMIT 14;
+```
+
+**Two things it does not do.** It does not know about money, so a model change (Haiku to Sonnet is
+three times the cost) moves the real spend without moving the ceiling — the table above is what has
+to be corrected then. And the global half is approximate by the number of simultaneous callers,
+which with one worker and two web processes is a handful of calls, not a category of problem.
+
+**Applied by the pre-deploy job**, like every migration, so this needs no separate step. The app
+spec *did* change — three new environment variables — so it joins the applies already outstanding
+below.
+
 ## GitHub's own secret scanning
 
 **Do not rely on it yet.** Minutes after it was enabled, a correctly shaped fake

--- a/generate.py
+++ b/generate.py
@@ -111,8 +111,15 @@ def only_one_tick(path):
         handle.close()  # releases the lock, and so does the process exiting
 
 
-def tick(config, store):
-    """Do what the clock and the config say is owed, and no more."""
+def tick(config, store, budget=None):
+    """Do what the clock and the config say is owed, and no more.
+
+    `budget` is the ceiling on what the model call may cost and defaults to
+    none, which is what a self-hoster's own API key deserves. The worker passes
+    a Postgres-backed one per family (DIN-43); a refusal arrives here as an
+    ordinary `GenerationError` and takes the keep-last-good path below without
+    needing a branch of its own.
+    """
     now = datetime.now(timezone.utc)
     payload = store.load_payload(config)
     owed = due(config, payload, now)
@@ -124,14 +131,19 @@ def tick(config, store):
         return 0
 
     if owed["refresh"]:
+        # Outside the budget on purpose: a fetch costs requests, not money, and
+        # a family who cannot afford a new headline today should still have an
+        # accurate agenda under yesterday's.
         refresh_calendars(config, store, now=now)
 
     if owed["brief"]:
         today = now.astimezone(config_module.tzinfo_for(config)).date()
         try:
-            report(write_brief(config, store, today=today))
+            report(write_brief(config, store, today=today, budget=budget))
         except GenerationError as exc:
-            # Not fatal: the brief is simply due again on the next tick.
+            # Not fatal: the brief is simply due again on the next tick. That
+            # covers a refused call too — the next tick asks again, gets the
+            # same refusal until the day turns over, and writes nothing.
             log.error("%s", exc)
             log.error("Keeping the previous board; the next tick will try again.")
             return 1

--- a/migrations/003_model_spend.sql
+++ b/migrations/003_model_spend.sql
@@ -1,0 +1,52 @@
+-- The hard breaker on what the model costs (DIN-43).
+--
+-- Nothing bounded the Anthropic bill before this. The worker walks every
+-- non-lapsed family and calls Claude; "Rewrite now" calls it from a web
+-- request. A bug that ticks in a loop, a bad deploy, or somebody who signed up
+-- ten thousand mailboxes all cost the same, and none of them met a ceiling.
+--
+-- **Calls, not money.** A price table in the schema would go stale silently and
+-- in the wrong direction — it under-counts after a price rise, which is exactly
+-- when a breaker matters. A call is exact, is knowable *before* it is made, and
+-- the product's design already says how many there should be: one brief a day
+-- per family. Turning calls into pounds is a multiplication somebody does in a
+-- query, and the rate lives in the docs where it can be corrected.
+--
+-- **One row per family per day, not one per call.** A daily cap needs a
+-- counter, not an audit log, and an aggregate never needs a retention sweep.
+-- Token counts ride along because they cost nothing to add and answer "what did
+-- last month actually cost" without a second table.
+--
+-- **UTC, not the family's clock.** `generations.generated_for_date` is the
+-- family's local date, which is right for "is today's board written" and wrong
+-- here: a global daily total summed over a dozen different local dates is not a
+-- day. A family near midnight has their allowance split across two UTC days,
+-- which is fine for a limit set well above what anybody legitimately uses.
+
+CREATE TABLE model_spend (
+    day           DATE NOT NULL,
+    family_id     UUID NOT NULL REFERENCES families (id) ON DELETE CASCADE,
+
+    -- Incremented on the **attempt**, in the same statement that checks the
+    -- limit. Counting successes instead would mean an expired API key retried
+    -- every five minutes for ever, paying for input tokens each time, and
+    -- never tripping anything.
+    calls         INTEGER NOT NULL DEFAULT 0 CHECK (calls >= 0),
+
+    -- Added afterwards, when the response says what it used. Nullable in
+    -- effect — a call that failed leaves these at whatever they were, because
+    -- a failure reports no usage.
+    input_tokens  BIGINT NOT NULL DEFAULT 0 CHECK (input_tokens >= 0),
+    output_tokens BIGINT NOT NULL DEFAULT 0 CHECK (output_tokens >= 0),
+
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    PRIMARY KEY (day, family_id)
+);
+
+-- **No second index.** The global half of the breaker sums one day across every
+-- family, and the primary key already leads on `day` — so `WHERE day = %s` is
+-- served by the index Postgres built for the key. An explicit
+-- `model_spend (day)` beside it would be a second copy of the same thing, kept
+-- up to date on every write, answering nothing new.

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -1,0 +1,419 @@
+"""The hard breaker on what the model costs (DIN-43).
+
+Five claims:
+
+* **a call is charged before it is made**, so a key that fails every time still
+  runs out rather than retrying for ever;
+* **the per-family cap is exact**, because it is enforced against the locked row
+  rather than a value read a moment earlier;
+* **the global cap scales with the number of families**, so it does not quietly
+  start starving real boards as the product grows;
+* **a refusal keeps the board that is on the wall.** It arrives as a
+  `GenerationError`, which every caller already handles that way, and nothing is
+  written;
+* **single mode is untouched.** A self-hoster's key is their own bill.
+
+The Postgres half skips without `DINKYDASH_TEST_DATABASE_URL`. What can be
+tested without a database — `NoBudget`, the environment parsing, and that a
+refusal writes nothing — is tested without one.
+"""
+
+import os
+import sys
+from datetime import date, datetime, timezone
+
+import pytest
+import yaml
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+from dinkydash import budget as budget_module      # noqa: E402
+from dinkydash import runner                       # noqa: E402
+from dinkydash.budget import (FAMILY_CALLS_A_DAY, GLOBAL_FLOOR,  # noqa: E402
+                              GLOBAL_PER_FAMILY, NoBudget, OverBudget,
+                              PostgresBudget)
+from dinkydash.claude_client import GenerationError  # noqa: E402
+from dinkydash.store import FileStore              # noqa: E402
+from test_generate import FakeClient               # noqa: E402
+
+CONFIG = '''\
+family_name: "The Wilsons"
+timezone: "Europe/Berlin"
+people:
+  - id: mia12345
+    name: "Mia"
+    date_of_birth: "2017-03-15"
+'''
+
+
+@pytest.fixture
+def key(monkeypatch):
+    """`write_brief` refuses without one before it reaches anything else."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-not-a-real-key")
+
+
+@pytest.fixture
+def store(tmp_path):
+    (tmp_path / "config.yaml").write_text(CONFIG)
+    return FileStore(tmp_path / "config.yaml")
+
+
+def spend_rows(pg_pool, family_id):
+    with pg_pool.connection() as conn, conn.cursor() as cur:
+        cur.execute("""SELECT calls, input_tokens, output_tokens FROM model_spend
+                       WHERE family_id = %s AND day = %s""",
+                    (family_id, datetime.now(timezone.utc).date()))
+        return cur.fetchone()
+
+
+@pytest.fixture
+def clean(pg_pool):
+    yield
+    with pg_pool.connection() as conn, conn.transaction():
+        with conn.cursor() as cur:
+            cur.execute("DELETE FROM model_spend")
+
+
+# -- single mode has no ceiling ---------------------------------------------
+
+class TestNoBudget:
+    def test_it_allows_everything_for_ever(self):
+        empty = NoBudget()
+        for _ in range(1000):
+            assert empty.allow() is None
+
+    def test_and_recording_is_a_no_op(self):
+        assert NoBudget().record(999, 999) is None
+
+    def test_write_brief_needs_no_budget_at_all(self, store, key):
+        """A self-hoster brings their own API key, so the bill is theirs. The
+        two things that bound a Pi are `schedule.due` and the tick lock, and
+        neither is about money."""
+        payload = runner.write_brief(store.load_config(), store,
+                                     today=date(2026, 9, 3), client=FakeClient())
+        assert payload["headline"] == "Big morning"
+
+
+# -- the caps read from the environment -------------------------------------
+
+class TestTheNumbersComeFromTheEnvironment:
+    """Raisable without a deploy, which is most of what you want at 2am."""
+
+    def test_unset_is_the_constant(self, monkeypatch):
+        monkeypatch.delenv("DINKYDASH_FAMILY_CALLS_A_DAY", raising=False)
+        assert budget_module._number("DINKYDASH_FAMILY_CALLS_A_DAY", 12) == 12
+
+    def test_a_number_wins(self, monkeypatch):
+        monkeypatch.setenv("DINKYDASH_FAMILY_CALLS_A_DAY", "40")
+        assert budget_module._number("DINKYDASH_FAMILY_CALLS_A_DAY", 12) == 40
+
+    @pytest.mark.parametrize("typed", ["twelve", "", "  ", "12.5", "-3"])
+    def test_anything_else_falls_back_to_the_limit_and_never_to_none(
+            self, monkeypatch, typed):
+        """**A breaker that fails open because somebody typed `twelve` is not
+        one.** Zero is allowed on purpose — it is a way to stop all spending —
+        but a negative or unparseable value is a typo, not an intention."""
+        monkeypatch.setenv("DINKYDASH_FAMILY_CALLS_A_DAY", typed)
+        assert budget_module._number("DINKYDASH_FAMILY_CALLS_A_DAY", 12) == 12
+
+    def test_zero_is_a_real_answer(self, monkeypatch):
+        """Stopping every call is a thing somebody might genuinely want to do."""
+        monkeypatch.setenv("DINKYDASH_FAMILY_CALLS_A_DAY", "0")
+        assert budget_module._number("DINKYDASH_FAMILY_CALLS_A_DAY", 12) == 0
+
+
+# -- counting, in Postgres --------------------------------------------------
+
+class TestCountingCalls:
+    def test_the_first_call_is_allowed_and_recorded(self, pg_pool, pg_family, clean):
+        assert PostgresBudget(pg_pool, pg_family).allow() == 1
+        assert spend_rows(pg_pool, pg_family)[0] == 1
+
+    def test_each_one_adds_to_the_count(self, pg_pool, pg_family, clean):
+        budget = PostgresBudget(pg_pool, pg_family)
+        assert [budget.allow() for _ in range(3)] == [1, 2, 3]
+
+    def test_it_is_charged_on_the_attempt_not_on_success(
+            self, pg_pool, pg_family, clean):
+        """An expired key fails every call and reports no usage, so a breaker
+        counting successes would watch a five-minute retry loop for ever."""
+        budget = PostgresBudget(pg_pool, pg_family)
+        budget.allow()          # and then the call fails; nothing recorded
+        assert spend_rows(pg_pool, pg_family) == (1, 0, 0)
+
+    def test_tokens_are_added_afterwards(self, pg_pool, pg_family, clean):
+        budget = PostgresBudget(pg_pool, pg_family)
+        budget.allow()
+        budget.record(1200, 90)
+        assert spend_rows(pg_pool, pg_family) == (1, 1200, 90)
+
+    def test_recording_twice_adds_up(self, pg_pool, pg_family, clean):
+        budget = PostgresBudget(pg_pool, pg_family)
+        budget.allow()
+        budget.record(100, 10)
+        budget.allow()
+        budget.record(200, 20)
+        assert spend_rows(pg_pool, pg_family) == (2, 300, 30)
+
+    def test_recording_never_raises(self, pg_pool, pg_family, clean):
+        """Bookkeeping, not control. Losing a token count must not turn a board
+        that was written into a failure that gets retried and paid for again."""
+        budget = PostgresBudget(pg_pool, pg_family)
+        budget.allow()
+        assert budget.record(None, None) is None
+        assert budget.record("nonsense", 3) is None
+
+    def test_used_today_reports_mine_and_everybody_s(
+            self, pg_pool, pg_family, clean):
+        PostgresBudget(pg_pool, pg_family).allow()
+        mine, everyone = PostgresBudget(pg_pool, pg_family).used_today()
+        assert mine == 1 and everyone == 1
+
+
+# -- the per-family cap -----------------------------------------------------
+
+class TestThePerFamilyCap:
+    def test_it_refuses_the_one_past_the_limit(self, pg_pool, pg_family, clean):
+        budget = PostgresBudget(pg_pool, pg_family, family_a_day=3)
+        for _ in range(3):
+            budget.allow()
+        with pytest.raises(OverBudget):
+            budget.allow()
+
+    def test_and_the_count_does_not_keep_climbing(self, pg_pool, pg_family, clean):
+        """A refused call is not a call, so it must not be charged for. Otherwise
+        a loop hammering a tripped breaker would make the number meaningless."""
+        budget = PostgresBudget(pg_pool, pg_family, family_a_day=2)
+        budget.allow()
+        budget.allow()
+        for _ in range(5):
+            with pytest.raises(OverBudget):
+                budget.allow()
+        assert spend_rows(pg_pool, pg_family)[0] == 2
+
+    def test_a_cap_of_zero_refuses_everything(self, pg_pool, pg_family, clean):
+        with pytest.raises(OverBudget):
+            PostgresBudget(pg_pool, pg_family, family_a_day=0).allow()
+
+    def test_the_refusal_is_a_generation_error(self, pg_pool, pg_family, clean):
+        """So every caller's existing keep-last-good path handles it. A second
+        kind of failure would mean a second such path, and the one written
+        second is the one that blanks somebody's screen."""
+        budget = PostgresBudget(pg_pool, pg_family, family_a_day=0)
+        with pytest.raises(GenerationError):
+            budget.allow()
+
+    def test_and_says_the_board_is_unchanged(self, pg_pool, pg_family, clean):
+        budget = PostgresBudget(pg_pool, pg_family, family_a_day=0)
+        with pytest.raises(OverBudget, match="unchanged"):
+            budget.allow()
+
+    def test_yesterday_does_not_count_against_today(
+            self, pg_pool, pg_family, clean):
+        """The row is per UTC day, so a family that spent everything yesterday
+        starts again rather than staying refused."""
+        with pg_pool.connection() as conn, conn.transaction():
+            with conn.cursor() as cur:
+                cur.execute("""INSERT INTO model_spend (day, family_id, calls)
+                               VALUES (%s, %s, 99)""",
+                            (date(2020, 1, 1), pg_family))
+        assert PostgresBudget(pg_pool, pg_family, family_a_day=3).allow() == 1
+
+
+# -- the global cap ---------------------------------------------------------
+
+class TestTheGlobalCap:
+    def test_it_refuses_a_family_that_is_within_its_own_limit(
+            self, pg_pool, pg_family, clean):
+        """The point of having a global one at all: one family behaving normally
+        is not what a runaway looks like, and the total is."""
+        budget = PostgresBudget(pg_pool, pg_family, family_a_day=1000,
+                                global_floor=2, global_per_family=0)
+        budget.allow()
+        budget.allow()
+        with pytest.raises(OverBudget):
+            budget.allow()
+
+    def test_it_counts_every_family_together(self, pg_pool, pg_family, clean):
+        from dinkydash import config as config_module
+
+        with pg_pool.connection() as conn, conn.transaction():
+            with conn.cursor() as cur:
+                cur.execute("""INSERT INTO families (screen_token, config)
+                               VALUES (%s, '{}'::jsonb) RETURNING id""",
+                            (config_module.new_screen_token(),))
+                other = cur.fetchone()[0]
+
+        caps = {"family_a_day": 1000, "global_floor": 2, "global_per_family": 0}
+        PostgresBudget(pg_pool, pg_family, **caps).allow()
+        PostgresBudget(pg_pool, other, **caps).allow()
+        # Neither family is near its own limit; together they are at the global.
+        with pytest.raises(OverBudget):
+            PostgresBudget(pg_pool, other, **caps).allow()
+
+        with pg_pool.connection() as conn, conn.transaction():
+            with conn.cursor() as cur:
+                cur.execute("DELETE FROM families WHERE id = %s", (other,))
+
+    def test_it_scales_with_how_many_families_there_are(
+            self, pg_pool, pg_family, clean):
+        """A fixed ceiling starts starving real boards on the day the product
+        grows into it, and the failure looks like a quiet morning."""
+        budget = PostgresBudget(pg_pool, pg_family, family_a_day=1000,
+                                global_floor=0, global_per_family=3)
+        # One family exists, so the ceiling is three.
+        for _ in range(3):
+            budget.allow()
+        with pytest.raises(OverBudget):
+            budget.allow()
+
+    def test_the_defaults_are_generous_enough_for_the_product_as_designed(self):
+        """One brief a day per family is the design. If the shipped numbers ever
+        stop leaving room for that, this is where it should be noticed."""
+        assert FAMILY_CALLS_A_DAY > 1
+        assert GLOBAL_PER_FAMILY > 1
+        assert GLOBAL_FLOOR >= FAMILY_CALLS_A_DAY
+
+
+# -- what a refusal does to the board ---------------------------------------
+
+class TestARefusalKeepsTheBoard:
+    class Broke:
+        """A budget that refuses everything, with no database behind it."""
+
+        def allow(self):
+            raise OverBudget("no")
+
+        def record(self, *_):  # pragma: no cover - never reached
+            raise AssertionError("recorded a call that was refused")
+
+    def test_write_brief_raises_rather_than_writing(self, store, key):
+        with pytest.raises(OverBudget):
+            runner.write_brief(store.load_config(), store, today=date(2026, 9, 3),
+                               client=FakeClient(), budget=self.Broke())
+        assert not store.load_payload(store.load_config())
+
+    def test_the_model_is_never_called(self, store, key):
+        """Charged before, so a refusal costs nothing at all — which is the
+        whole point of checking first rather than counting afterwards."""
+        client = FakeClient()
+        with pytest.raises(OverBudget):
+            runner.write_brief(store.load_config(), store, today=date(2026, 9, 3),
+                               client=client, budget=self.Broke())
+        assert client.messages.calls == []
+
+    def test_an_existing_board_is_left_exactly_as_it_was(self, store, key):
+        config = store.load_config()
+        runner.write_brief(config, store, today=date(2026, 9, 3), client=FakeClient())
+        before = store.load_payload(config)
+
+        with pytest.raises(OverBudget):
+            runner.write_brief(config, store, today=date(2026, 9, 4),
+                               client=FakeClient(), budget=self.Broke())
+        assert store.load_payload(config) == before
+
+    def test_a_tick_keeps_the_last_good_board_and_says_so(self, store, key, caplog):
+        """The refusal takes the path a failed generation already takes. There
+        is no second keep-last-good branch, which is why there is nothing new
+        here to get wrong."""
+        from generate import tick
+
+        config = store.load_config()
+        runner.refresh_calendars(config, store, today=date(2026, 9, 3))
+        with caplog.at_level("ERROR"):
+            assert tick(config, store, budget=self.Broke()) == 1
+        assert "Keeping the previous board" in caplog.text
+
+    def test_the_refresh_still_happens(self, store, key):
+        """Fetching calendars costs requests, not money. A family who cannot
+        afford a new headline today should still have an accurate agenda under
+        yesterday's."""
+        config = store.load_config()
+        with pytest.raises(OverBudget):
+            runner.run(config, store, today=date(2026, 9, 3),
+                       client=FakeClient(), budget=self.Broke())
+        assert store.load_payload(config).get("calendars_fetched_at")
+
+
+# -- and the browser path, which was the unbounded one ----------------------
+
+class TestRewriteNowIsChargedToo:
+    """`POST /settings/generate` was the one route to Anthropic with no limit on
+    it at all — a signed-in parent holding the button down is an unbounded bill
+    from one browser. It spends the same money out of the same account as the
+    worker, so it is counted in the same place."""
+
+    @pytest.fixture
+    def cloud(self, pg_pool, pg_family, monkeypatch, key):
+        from dinkydash.pgstore import PostgresStore
+        from web import create_app
+
+        PostgresStore(pg_pool, pg_family).save_config(yaml.safe_load(CONFIG))
+        monkeypatch.setenv("DINKYDASH_MODE", "cloud")
+        monkeypatch.setenv("DINKYDASH_SECRET_KEY", "a-real-one")
+        # The model call itself, replaced. Everything before it — the budget
+        # check — is what this is about, and no test may cost money.
+        monkeypatch.setattr(runner, "generate", lambda *a, **k: {
+            "headline": "Big morning", "note": "An octopus fact.",
+            "note_kind": "fact", "generated_for_date": "2026-09-03",
+            "generated_at": "2026-09-03T04:00:00+00:00",
+            "model": "claude-haiku-4-5", "input_tokens": 1200, "output_tokens": 90})
+        return create_app(pool=pg_pool)
+
+    @pytest.fixture
+    def parent(self, cloud, pg_family):
+        from tests.conftest import client_for
+
+        client = client_for(cloud)
+        with client.session_transaction() as stored:
+            stored["user_id"] = 1
+            stored["family_id"] = str(pg_family)
+        return client
+
+    def test_pressing_it_is_counted(self, parent, pg_pool, pg_family, clean):
+        parent.post("/settings/generate")
+        assert spend_rows(pg_pool, pg_family) == (1, 1200, 90)
+
+    def test_pressing_it_repeatedly_runs_out(self, parent, pg_pool, pg_family,
+                                             monkeypatch, clean):
+        monkeypatch.setenv("DINKYDASH_FAMILY_CALLS_A_DAY", "2")
+        for _ in range(5):
+            parent.post("/settings/generate")
+        assert spend_rows(pg_pool, pg_family)[0] == 2
+
+    def test_and_says_so_rather_than_failing(self, parent, monkeypatch, clean):
+        monkeypatch.setenv("DINKYDASH_FAMILY_CALLS_A_DAY", "0")
+        landed = parent.post("/settings/generate", follow_redirects=True)
+        assert landed.status_code == 200
+        assert "limit on rewriting the board" in landed.get_data(as_text=True)
+
+    def test_a_refused_press_leaves_the_written_board_alone(
+            self, parent, pg_pool, pg_family, monkeypatch, clean):
+        """**The brief half, not the whole payload.** "Rewrite now" refreshes
+        the calendars first and that is deliberately outside the budget — a
+        fetch costs requests rather than money — so `calendars_fetched_at`
+        moves and should. What must not change is the model's words, and this
+        asserts exactly that rather than the looser thing."""
+        from dinkydash.pgstore import PostgresStore
+
+        brief = ("headline", "note", "note_kind", "generated_for_date",
+                 "generated_at", "input_tokens", "output_tokens")
+        store = PostgresStore(pg_pool, pg_family)
+        parent.post("/settings/generate")
+        before = {k: store.load_payload(store.load_config()).get(k) for k in brief}
+
+        monkeypatch.setenv("DINKYDASH_FAMILY_CALLS_A_DAY", "1")
+        parent.post("/settings/generate")
+        after = {k: store.load_payload(store.load_config()).get(k) for k in brief}
+        assert after == before
+
+    def test_but_the_calendars_are_still_refreshed(self, parent, pg_pool,
+                                                   pg_family, monkeypatch, clean):
+        """A family who cannot afford a new headline today should still have an
+        accurate agenda under yesterday's."""
+        from dinkydash.pgstore import PostgresStore
+
+        monkeypatch.setenv("DINKYDASH_FAMILY_CALLS_A_DAY", "0")
+        parent.post("/settings/generate")
+        store = PostgresStore(pg_pool, pg_family)
+        assert store.load_payload(store.load_config()).get("calendars_fetched_at")

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -49,23 +49,44 @@ class FakeStore:
         return {"family_id": self.family_id}
 
 
-def run(ids, tick, stopping=None):
-    return tick_all(FakePool(ids), store_factory=FakeStore, tick=tick, stopping=stopping)
+class FakeBudget:
+    """A budget that allows everything and remembers it was asked."""
+
+    def __init__(self, family_id):
+        self.family_id = family_id
+
+    def allow(self):
+        return None
+
+    def record(self, input_tokens, output_tokens):
+        return None
+
+
+def run(ids, tick, stopping=None, budget_factory=FakeBudget):
+    """`tick_all` with every seam filled by a fake.
+
+    The tick signature is `(config, store, budget=...)`, so the lambdas below
+    take a `budget` keyword whether or not they look at it — the point of
+    passing one at all is that a family's spend is decided per family, out here
+    where the pool and the id are both known (DIN-43).
+    """
+    return tick_all(FakePool(ids), store_factory=FakeStore, tick=tick,
+                    stopping=stopping, budget_factory=budget_factory)
 
 
 class TestWalkingTheFamilies:
     def test_every_family_is_ticked(self):
         seen = []
-        done = run(["a", "b", "c"], lambda config, store: seen.append(store.family_id))
+        done = run(["a", "b", "c"], lambda config, store, budget=None: seen.append(store.family_id))
         assert seen == ["a", "b", "c"]
         assert done == 3
 
     def test_no_families_is_not_an_error(self):
-        assert run([], lambda config, store: None) == 0
+        assert run([], lambda config, store, budget=None: None) == 0
 
     def test_the_config_comes_from_that_family_s_store(self):
         configs = []
-        run(["a", "b"], lambda config, store: configs.append(config))
+        run(["a", "b"], lambda config, store, budget=None: configs.append(config))
         assert configs == [{"family_id": "a"}, {"family_id": "b"}]
 
     def test_lapsed_families_are_excluded_by_the_query(self):
@@ -80,7 +101,7 @@ class TestOneBadFamily:
         """A shared worker that dies on the noisiest tenant serves the quietest worst."""
         seen = []
 
-        def tick(config, store):
+        def tick(config, store, budget=None):
             seen.append(store.family_id)
             if store.family_id == "b":
                 raise RuntimeError("their calendar feed is down")
@@ -90,14 +111,14 @@ class TestOneBadFamily:
         assert done == 2
 
     def test_every_family_can_fail_without_raising(self):
-        def tick(config, store):
+        def tick(config, store, budget=None):
             raise RuntimeError("everything is down")
 
         assert run(["a", "b"], tick) == 0
 
     def test_the_failure_log_names_the_id_and_not_the_config(self, caplog):
         """A config holds children's names, and a calendar URL is a password."""
-        def tick(config, store):
+        def tick(config, store, budget=None):
             raise RuntimeError("failed fetching https://cal.example/private-abc123/basic.ics")
 
         with caplog.at_level(logging.DEBUG):
@@ -113,7 +134,7 @@ class TestStopping:
         stopping = Stopping()
         seen = []
 
-        def tick(config, store):
+        def tick(config, store, budget=None):
             seen.append(store.family_id)
             stopping.request()
 

--- a/web/family.py
+++ b/web/family.py
@@ -65,6 +65,22 @@ def current_family_id():
     return _family_on_the_session()
 
 
+def current_budget():
+    """What this request's family may still spend on the model.
+
+    `NoBudget` in single mode — a self-hoster's key is their own bill, and the
+    board is not multi-tenant. In cloud mode a Postgres-backed breaker for the
+    family on the session, which is the same money the worker spends and so is
+    counted in the same place (DIN-43).
+    """
+    from dinkydash import budget as budget_module
+    from . import CLOUD
+
+    if current_app.config["MODE"] != CLOUD:
+        return budget_module.NoBudget()
+    return budget_module.for_family(_the_pool(), _family_on_the_session())
+
+
 def current_screen_token():
     """The screen token of the family on the session. Cloud mode only.
 

--- a/web/routes/settings.py
+++ b/web/routes/settings.py
@@ -24,7 +24,8 @@ from dinkydash.runner import forget_calendar, refresh_calendars
 from dinkydash.runner import run as run_generation
 from web import CLOUD
 from web import manifest as manifest_module
-from web.family import current_family_id, current_screen_token, current_store
+from web.family import (current_budget, current_family_id, current_screen_token,
+                        current_store)
 from web.session import guard
 
 log = logging.getLogger(__name__)
@@ -306,9 +307,19 @@ def manifest():
 
 @bp.route("/generate", methods=["POST"])
 def generate_now():
+    """"Rewrite now" — a person asking for a board, and paying for it.
+
+    **Charged against the same budget as the worker**, because it is the same
+    money out of the same account (DIN-43). Without that, a signed-in parent
+    holding this button down is an unbounded bill from one browser, and it was
+    the one path to Anthropic with no limit on it at all.
+
+    A refusal is an `OverBudget`, which is a `GenerationError`, so it arrives in
+    the branch below that already existed and the person is told plainly.
+    """
     config = current_config()
     try:
-        payload = run_generation(config, current_store())
+        payload = run_generation(config, current_store(), budget=current_budget())
     except GenerationError as exc:
         flash(str(exc), "error")
     except Exception as exc:  # a broken feed or an unreadable file shouldn't 500 the UI

--- a/worker/__init__.py
+++ b/worker/__init__.py
@@ -77,7 +77,8 @@ def family_ids(pool):
         return [row[0] for row in cur.fetchall()]
 
 
-def tick_all(pool, store_factory=None, tick=None, stopping=None):
+def tick_all(pool, store_factory=None, tick=None, stopping=None,
+             budget_factory=None):
     """Tick every family once. Returns how many were ticked without raising.
 
     One family's bad calendar feed, missing config or Anthropic outage must not
@@ -85,9 +86,18 @@ def tick_all(pool, store_factory=None, tick=None, stopping=None):
     worker that serves the quietest ones worst. Each family is therefore its
     own try, and a failure is logged and left — the next pass simply finds the
     same thing still due, which is how the whole tick handles failure already.
+
+    **Every family is ticked against a budget** (DIN-43), and it is built here
+    rather than inside the tick for the same reason the store is: this is the
+    only place that knows both the pool and which family. A refusal is an
+    ordinary `GenerationError` inside `tick`, so it is already handled — the
+    board on the wall stays, and the next pass asks again.
     """
     from dinkydash.pgstore import PostgresStore
     store_factory = store_factory or (lambda fid: PostgresStore(pool, fid))
+    if budget_factory is None:
+        from dinkydash import budget as budget_module
+        budget_factory = lambda fid: budget_module.for_family(pool, fid)  # noqa: E731
     if tick is None:
         from generate import tick
 
@@ -98,7 +108,7 @@ def tick_all(pool, store_factory=None, tick=None, stopping=None):
             break
         try:
             store = store_factory(family_id)
-            tick(store.load_config(), store)
+            tick(store.load_config(), store, budget=budget_factory(family_id))
             done += 1
         except Exception:
             # The id, never the config: a family's config holds children's


### PR DESCRIPTION
Closes DIN-43. There is now a ceiling on the Anthropic bill. There was not one before.

## What was open

`grep -rn "spend\|breaker\|budget"` over `dinkydash/`, `web/` and `worker/` returned rate limits on sign-in and nothing else.

- `worker.tick_all` walked every non-lapsed family and called Claude with no counter and no ceiling.
- **`POST /settings/generate` was a browser button with an unlimited API call behind it.** A signed-in parent holding "Rewrite now" down was an unbounded bill from one tab.

Sign-up being open (#79) and the app being live made this worth doing now, but the argument needs no attacker: a `due()` regression, a restart loop or a bad deploy costs exactly the same and needs nobody to try. CLAUDE.md already named the breaker as the thing that "stops a bug **or** an abusive account becoming an unbounded Anthropic bill."

## Calls, not money

A price table in code goes stale silently and **in the wrong direction** — it under-counts after a price rise, which is precisely when a breaker matters. A call is exact and is knowable *before* it is made, and the product already says how many there should be: one a day per family.

The multiplication into pounds lives in `doc/operations.md`, where a wrong number is a wrong note rather than a broken control. At Haiku prices the defaults leave roughly four times headroom over legitimate use.

## Charged on the attempt, not on success

A revoked API key fails every call, pays for input tokens each time, and reports no usage at all. A breaker counting successes would watch a five-minute retry loop do that for ever.

## One statement decides and records

The same shape as `accounts.issue_link`'s rate limit, so two callers cannot both read "one call today" and both make a second. The two halves are **not equally exact**, and both say so:

- **Per family: exact.** Enforced in `ON CONFLICT ... DO UPDATE ... WHERE`, which Postgres evaluates against the locked, current row.
- **Globally: approximate**, by at most the number of simultaneous callers. It is a sum read before the write. Making it exact means serialising every family's tick behind one row, which is not worth it for a ceiling set well above legitimate use.

**The global cap scales with the number of families** (`floor + per_family × families`). A fixed ceiling starts starving real boards on the day the product grows into it, and the failure looks exactly like a quiet morning.

## A refusal keeps the board on the wall

`OverBudget` subclasses `GenerationError`, so every caller's existing keep-last-good path handles it with **no new branch** — "a failure is not handled, it is simply due again" already covers it. A second kind of failure would have meant a second keep-last-good path, and the one written second is the one that eventually blanks somebody's screen.

The **calendar refresh is deliberately outside the budget**: a fetch costs HTTP requests rather than money, so a family who cannot afford a new headline today still gets an accurate agenda under yesterday's.

## A test found a real hole

`0` everywhere is meant to be the brake — the thing you reach for when a bill is running away. It was the one setting that could not work.

The first call of a day takes the **insert** path, where `DO UPDATE ... WHERE` never runs, so every family got one free call daily even at a cap of zero. The per-family cap now appears in the statement twice, once for each path through the upsert. That came from a test, not from re-reading it.

## Single mode is untouched

It passes no budget at all and gets `NoBudget`. A self-hoster's key is their own bill, and `schedule.due` plus the tick lock already hold a Pi to one call a day.

## Testing

- 780 pass with `DINKYDASH_TEST_DATABASE_URL`, 552 with 228 skipped without. `tests/test_budget.py` is 38 of them.
- **Exercised end to end**, two families signed up through the product: one holds "Rewrite now" down and stops at its own cap; the second is stopped by the **global** ceiling while still well inside its own; both boards come out unchanged with their calendars still refreshing.
- Migrations applied from scratch and re-checked idempotent.

## Deploy

The migration goes out with the pre-deploy job, so it needs no separate step. **The spec did change** — three environment variables, written out at their defaults so the ceiling is visible and can be raised, or slammed to zero, without a deploy. That joins the applies already outstanding from #79.

Worth knowing: the spec is the whole app, so a cap changed in the App Platform dashboard in an emergency is undone by the next `doctl apps update`. `doc/operations.md` says so next to the brake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VqGomc6Y1LYeEA6LaokUdZ