### PR TITLE
Phase 5: a privacy policy, terms, export and hard delete (DIN-44)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,13 @@ ANTHROPIC_API_KEY=
 # DKIM does not sign it. Defaults to hello@dinkydash.co.
 # DINKYDASH_MAIL_FROM=
 
+# Where a reply goes, which is deliberately not the From address:
+# dinkydash.co has no MX records, so a reply to it reaches nobody and the
+# bounce goes nowhere either. Defaults to hi@keepthescore.com, which is the
+# same person and is what the privacy policy gives as the contact address.
+# Move both together when DinkyDash gets a mailbox of its own.
+# DINKYDASH_MAIL_REPLY_TO=
+
 # The spend breaker (DIN-43), in **model calls a day**, not money — a price
 # table goes stale silently and in the wrong direction. The defaults in
 # dinkydash/budget.py are what runs with these unset; they are here so a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,8 +124,12 @@ Relative links like `[PLAN.md](PLAN.md)` break once a document is in Linear. Rew
   socket a hostile resolver can answer differently, and closing it means connecting to the checked
   address with an explicit `Host` header.
 - **Calendar contents leave the machine.** They go to Anthropic to write the daily line. A fair
-  trade, but it has to be *said* — in the privacy policy, the sub-processor list, and the UI
-  (PLAN.md phase 5).
+  trade, and it *is* said now (DIN-44): in `website/content/privacy.md`, in the sub-processor list
+  on it, on `/settings/account`, and — the one that matters — in the blurb beside the field where
+  somebody pastes a calendar link. **Those pages are claims about what this code does.** A retention
+  period is a promise that a `DELETE` exists; a sub-processor list is a promise that nothing else is
+  called. Change what the app stores, sends, or sends it to, and the policy changes in the same
+  commit.
 - **Log the label, not the URL.** `fetch_events` logs `entry["label"]` on purpose. The exception
   text does not follow that rule by itself — see the gotcha below.
 
@@ -291,6 +295,7 @@ dinkydash/
 ├── accounts.py        users, the links that sign them in, and sign-up (cloud only)
 ├── screens.py         the token that puts a board on a wall (cloud only)
 ├── budget.py          what a family may spend on the model, and what everybody may
+│                     (`accounts.delete_family` is the hard delete; see phase 5)
 └── runner.py          the two halves of the day, reading and writing through a store
 
 web/

--- a/PLAN.md
+++ b/PLAN.md
@@ -8,6 +8,15 @@
 
 *September 8, later: **one service, not two.** The board joins the marketing site in the existing `dinkydash-site` app rather than getting its own, because that is how `qrpage.co` and `abc-league` already run in this account — one container, one gunicorn, everything in it. Staging is dropped until there is a paying family to protect. The `worker` is the one genuine addition, because the tick has no lock and two web instances would tick twice. See [Hosting and deployment](#hosting-and-deployment).*
 
+*September 8, last: **the legal and trust work** (DIN-44). A privacy policy and terms at
+`dinkydash.co/privacy/` and `/terms/`, linked from every page; a sub-processor list that names the
+four who actually receive something and says Stripe is not one of them yet; the Anthropic disclosure
+beside the calendar field as well as in the policy; and export and hard delete as buttons on
+`/settings/account`. **Phase 5's own rule was the hard part** — a retention period is a claim that a
+`DELETE` exists, so the two sweeps that are not written are not promised. Also found and fixed on the
+way: `dinkydash.co` has no MX records, so every sign-in email had a reply address that reached
+nobody.*
+
 *September 8, and this is the one that was overdue: **there is a spend breaker** (DIN-43). Per
 family and globally, checked and recorded in one statement before the call. Nothing bounded the
 Anthropic bill until now — not the worker, and not "Rewrite now", which was a browser button with
@@ -765,12 +774,12 @@ These are latent on a single Pi and actively harmful hosted.
 
 **Still open:**
 
-6. **Stale `.env` keys.** `DATABASE_URL`, `SECRET_KEY`, `UPLOAD_FOLDER`, `MAX_CONTENT_LENGTH` are leftovers from an abandoned plan. No code reads any of them, so removing them changes nothing — but `.env` is not in git, so each copy has to be edited where it lives: the main checkout, and the Pi, whose `.env` `deploy_to_pi.sh` no longer overwrites. There is still no `.env.example`.
-7. **No CI.** The suite runs in under a second and nothing runs it on push.
+6. **Stale `.env` keys.** `DATABASE_URL` and `SECRET_KEY` are now real keys with real meanings (the pool, and the session in cloud mode); `UPLOAD_FOLDER` and `MAX_CONTENT_LENGTH` are still leftovers from an abandoned plan and no code reads either. `.env` is not in git, so each copy has to be edited where it lives: the main checkout, and the Pi, whose `.env` `deploy_to_pi.sh` no longer overwrites. **`.env.example` exists** and documents every key that is read.
+7. ~~**No CI.**~~ Done in DIN-16. `.github/workflows/test.yml` runs pytest and gitleaks on every push and pull request, and the suite runs twice — once against Postgres and once as a self-hoster sees it.
 8. ~~**A failed fetch puts the secret URL in the error text.**~~ Fixed in DIN-32. `calendars._why` reduces a `requests` failure to a category and a status code, leaving out the host as well as the path, and the parse error is scrubbed too — a parser quotes the line it choked on, which is an appointment. Tested.
-9. **`generated_at` is the server's clock.** `generate.py` stamps `datetime.now().astimezone()` and the settings home prints `stamp[11:16]` as "written 06:02". On a UTC host that is the wrong time for every family. Stamp in UTC; render in the family's timezone.
+9. ~~**`generated_at` is the server's clock.**~~ Fixed. Both stamps are written in UTC (`generate.py`, `runner.refresh_calendars`) and `settings._clock` renders them on the family's own clock. It used to slice the characters out of the ISO string, which showed the server's hour.
 10. **`describe_feed` falls back to `date.today()`.** Never reached — the settings route passes the date — but it is the one clock left inside `dinkydash/`.
-11. **No CSRF protection on any form.** Harmless with no accounts; the moment a session exists, a page elsewhere can submit "Rewrite now" or a delete on the parent's behalf. Every POST needs a token in cloud mode.
+11. ~~**No CSRF protection on any form.**~~ Fixed in DIN-38, and in **both** modes with no switch to turn it off — a Pi on a home network has a guessable address too. `tests/test_auth.py` walks the templates and fails on a form without a token.
 
 ---
 
@@ -778,15 +787,15 @@ These are latent on a single Pi and actively harmful hosted.
 
 Each of these is under an hour, needs no database, and ships to the Pi as well as the cloud. Do them before anything in Phase 1.
 
-1. **CI.** A GitHub Actions workflow that runs `pytest` on push and pull request; a `gitleaks` step beside it; push protection switched on in the repo settings. About twenty lines and one toggle.
-2. **`.env.example`** — one line: `ANTHROPIC_API_KEY=`.
-3. **Pin `requirements.txt`.** An unpinned dependency in an app holding other families' calendars is the supply-chain decision CLAUDE.md warns about, made by omission.
-4. **Rotate the Anthropic key.** Five minutes, no code, overdue. Edit it on the Pi in place — `deploy_to_pi.sh` no longer copies `.env`.
+1. ~~**CI.**~~ Done in DIN-16 — pytest and gitleaks on every push, and the suite run both ways.
+2. ~~**`.env.example`.**~~ Done, and it is no longer one line: it documents the session key, the database, SendGrid and the spend caps as well.
+3. ~~**Pin `requirements.txt`.**~~ Done in DIN-16. Every requirements file is pinned with `==` to what CI passes on.
+4. ~~**Rotate the Anthropic key.**~~ Done in DIN-20.
 5. ~~**Self-host Nunito.**~~ Done in DIN-32 — one variable font per subset in `web/static/fonts/`, and its own copy in `website/static/`. Removes a third-party request from every screen, a GDPR sub-processor (a Munich court ruled against dynamically loaded Google Fonts in 2022), the `Referer` path for screen tokens, and it makes a Pi's board render the same when the internet is down.
 6. ~~**Scrub the URL out of `FeedError`**~~ (bug 8). Done in DIN-32.
 7. ~~**`Referrer-Policy: no-referrer`**~~. Done in DIN-32, on every response rather than two templates, so it covers redirects and errors too.
 8. ~~**`/healthz`.**~~ Done in DIN-32. Returns `ok` and the git SHA from the environment, and deliberately reads no config and no database.
-9. **`generated_at` in UTC**, rendered in the family's timezone (bug 9).
+9. ~~**`generated_at` in UTC**, rendered in the family's timezone~~ (bug 9). Done.
 10. ~~**A `Dockerfile`.**~~ Dropped on 7 September, having been built and then removed. App Platform's Python buildpack needs none, and Docker was machinery with nothing here to earn it. `.python-version` and a `build_command` in the app spec are what replaced it *(DIN-30, cancelled)*.
 
 ---
@@ -848,7 +857,7 @@ missing is the multi-tenant half — a schema, auth, and scoping every read and 
 
 - [x] Public tokenized dashboard route, `noindex`, no referrer, no third-party requests *(DIN-42)*. Rate-limited **in the app rather than at the edge**, and on the misses rather than the requests — see [The screen](#the-screen). A Cloudflare rule is still worth adding on top and is not a blocker.
 - [x] Token rotation; QR code display *(DIN-42)*
-- [ ] Renderer to landing-page parity: person cards with ages, time-ordered agenda for today
+- [x] Renderer to landing-page parity *(nothing to build — the parity is there)*. **This box was stale and the correction matters.** It was written when the homepage showed a mockup with person cards on it. The homepage was rewritten around the real board (#72) and now says "every screen on this page shows the real board", promising the time-ordered agenda, tomorrow underneath, whose turn each chore is, the birthday countdowns and one written line — which is exactly what `board.html` renders. Building person cards now would be building something nobody was promised. If they are ever wanted, they are a feature, not parity.
 - [x] Staleness indicator when the brief isn't from today *(built for single mode in #28; DIN-42 renders the same `build_view` from `PostgresStore`, and `tests/test_cloud_mode.py` asserts the two boards are byte-identical apart from the manifest link)*
 - [ ] Offline tolerance and sensible cache headers. `no-store` is deliberate for now: the URL is a credential and a shared cache holding it is a leak, so offline needs a service worker rather than a weaker header.
 - [ ] Verify on the target surfaces: TV browser, old iPad, Pi kiosk
@@ -868,14 +877,14 @@ missing is the multi-tenant half — a schema, auth, and scoping every read and 
 
 ### Phase 5 — Legal & trust
 
-- [ ] Privacy policy and ToS, forked from KeepTheScore
-- [ ] Sub-processor list — Anthropic, DigitalOcean, Stripe, **SendGrid** (decision 13), Cloudflare. **Not Google Fonts**: self-hosted since DIN-32, and nothing on the board, the settings UI or the marketing site requests anything from them.
-- [ ] **DigitalOcean's DPA signed, with standard contractual clauses.** They are a US company; the app and database sit in Frankfurt. Say both — where the data lives, and who the company is. Cloudflare needs the same treatment.
-- [ ] Plain statement that calendar contents are sent to Anthropic for generation
-- [ ] Say what SendGrid receives, which is **the email address and the login link, never the calendar**. The two disclosures are different in kind and should not be merged into one sentence: Anthropic sees a family's appointments, SendGrid sees only who is logging in.
-- [ ] Data export and hard delete — the delete cascades through users, tokens, agendas, generations, history and calendar health; the Stripe customer record stays, as accounting requires
-- [ ] Retention, with numbers: `agendas` is one overwritten row; `content_history` keeps 30 entries of the model's words; `generations` keeps token counts indefinitely and drops the `brief` column after 90 days; a lapsed family is deleted 90 days after lapse
-- [ ] Cookie/analytics review
+- [x] Privacy policy and ToS, forked from KeepTheScore *(DIN-44)*. `website/content/privacy.md` and `terms.md`, linked from the footer of every page and in the sitemap. Same controller, same Berlin address, same supervisory authority.
+- [x] Sub-processor list — Anthropic, DigitalOcean, **SendGrid** (decision 13), Cloudflare *(DIN-44)*. **Not Google Fonts**: self-hosted since DIN-32, and nothing on the board, the settings UI or the marketing site requests anything from them. **Stripe is not on it either, and must not be until payment exists** — the page says so in as many words, because a sub-processor list naming somebody who receives nothing is the same kind of untrue as one omitting somebody who does.
+- [ ] **DigitalOcean's DPA signed, with standard contractual clauses.** *(The policy already says where the data lives and who the company is; what is outstanding is the signature.)* They are a US company; the app and database sit in Frankfurt. Say both — where the data lives, and who the company is. Cloudflare needs the same treatment.
+- [x] Plain statement that calendar contents are sent to Anthropic for generation *(DIN-44)*, and **in three places rather than one**: the policy, the settings page under *Your data*, and — the one that matters — the blurb on the calendars page, beside the field where somebody is about to paste a link.
+- [x] Say what SendGrid receives, which is **the email address and the login link, never the calendar** *(DIN-44)*. The two disclosures are different in kind and should not be merged into one sentence: Anthropic sees a family's appointments, SendGrid sees only who is logging in.
+- [x] Data export and hard delete *(DIN-44)*, both buttons on `/settings/account` rather than requests. The delete cascades through users, tokens, agendas, generations, history, calendar health and `model_spend` — **and one row it cannot cascade to**: a sign-up token has no `user_id`, so it is deleted by address in the same transaction. `tests/test_account.py` asserts every table. The Stripe customer record will stay when there is one, as accounting requires.
+- [ ] Retention, with numbers. **The policy states what is true today** and no more: `agendas` is one overwritten row, `content_history` keeps 30 entries, expired sign-in tokens are swept, and everything else lives until the family is deleted. The two sweeps that do *not* exist — dropping `generations.brief` after 90 days, and deleting a lapsed family after 90 days — are deliberately **not** promised, because a retention period in a policy is a claim that a `DELETE` exists. Write the sweeps, then write the sentence.
+- [x] Cookie/analytics review *(DIN-44)*. One cookie on the hosted app and it is the session; no analytics, no advertising and no third-party script on the board or the settings pages. The marketing site uses Ahrefs Web Analytics, which is cookieless. All of that is in the policy.
 
 **Done when:** you could take money from an EU customer without wincing.
 

--- a/dinkydash/accounts.py
+++ b/dinkydash/accounts.py
@@ -328,6 +328,56 @@ def _domain(address):
     return f"@{domain}" if domain else "@?"
 
 
+def address_for(pool, user_id):
+    """The address on that account, or None. For showing somebody their own.
+
+    Deliberately a query rather than a session value: `web/session.py` puts two
+    ids in the cookie and no email, because Flask signs the cookie and does not
+    encrypt it.
+    """
+    with pool.connection() as conn, conn.cursor() as cur:
+        cur.execute("SELECT email FROM users WHERE id = %s", (user_id,))
+        row = cur.fetchone()
+        return row[0] if row else None
+
+
+def delete_family(pool, family_id):
+    """Delete a family and everything belonging to it. Returns True if there was one.
+
+    **The cascade does most of this, and there is exactly one thing it cannot
+    reach.** `families` is the root and every other table references it with
+    `ON DELETE CASCADE` — users, agendas, generations, content_history,
+    calendar_health, model_spend — and `login_tokens` follows its user. But a
+    **sign-up token has no user** (DIN-41): it carries an address instead,
+    precisely so that it can exist before the family does. Nothing cascades to
+    it, so it is deleted here by address, in the same transaction.
+
+    Left alone it would expire in fifteen minutes and be swept, so this is not a
+    security hole — it is the difference between "deleted" meaning what the
+    privacy policy says it means and meaning nearly that.
+
+    One transaction, so a half-deleted family is not a state that can exist.
+    """
+    with pool.connection() as conn, conn.transaction():
+        with conn.cursor() as cur:
+            cur.execute("SELECT email FROM users WHERE family_id = %s", (family_id,))
+            addresses = [row[0] for row in cur.fetchall()]
+            if addresses:
+                cur.execute(
+                    "DELETE FROM login_tokens WHERE user_id IS NULL AND email = ANY(%s)",
+                    (addresses,),
+                )
+            cur.execute("DELETE FROM families WHERE id = %s RETURNING id",
+                        (family_id,))
+            gone = cur.fetchone() is not None
+    if gone:
+        # The id, never the address. A deletion is worth a line — it is the one
+        # thing nobody can undo — and the line must not be the record of who
+        # left that the deletion was supposed to remove.
+        log.info("Deleted family %s and everything belonging to it.", family_id)
+    return gone
+
+
 def sweep(pool):
     """Delete every token that has expired. Returns how many went.
 

--- a/dinkydash/mail.py
+++ b/dinkydash/mail.py
@@ -40,6 +40,17 @@ DEFAULT_TIMEOUT = 10
 DEFAULT_FROM = "hello@dinkydash.co"
 DEFAULT_FROM_NAME = "DinkyDash"
 
+# **Where a reply goes, which is not the `From` address.** `dinkydash.co` has no
+# MX records — it is authenticated for *sending* and nothing receives on it — so
+# anybody replying to a sign-in email was writing to a mailbox that does not
+# exist, and the bounce went nowhere either. That is a poor thing to discover
+# from the person who was trying to tell you their link did not work.
+#
+# `keepthescore.com` is on Google Workspace and is the same person, which is
+# also what the privacy policy gives as the contact address. When DinkyDash gets
+# MX records of its own, this moves and the policy moves with it.
+DEFAULT_REPLY_TO = "hi@keepthescore.com"
+
 
 class MailError(Exception):
     """A message did not go out.
@@ -77,6 +88,7 @@ def send(to, subject, text, html=None, transport=None, api_key=None,
     body = {
         "personalizations": [{"to": [{"email": recipient}]}],
         "from": {"email": sender or _sender(), "name": sender_name or DEFAULT_FROM_NAME},
+        "reply_to": {"email": _reply_to(), "name": DEFAULT_FROM_NAME},
         "subject": subject,
         "content": _content(text, html),
     }
@@ -182,6 +194,11 @@ def _clean_key(key):
 
 def _sender():
     return os.environ.get("DINKYDASH_MAIL_FROM") or DEFAULT_FROM
+
+
+def _reply_to():
+    """Where a reply lands. Overridable, and never the send-only address."""
+    return os.environ.get("DINKYDASH_MAIL_REPLY_TO") or DEFAULT_REPLY_TO
 
 
 def _why(exc):

--- a/doc/operations.md
+++ b/doc/operations.md
@@ -325,6 +325,46 @@ which with one worker and two web processes is a handful of calls, not a categor
 spec *did* change — three new environment variables — so it joins the applies already outstanding
 below.
 
+## Legal and trust, 8 September 2026 (DIN-44)
+
+**There is a privacy policy and there are terms**, at `dinkydash.co/privacy/` and `/terms/`, linked
+from the footer of every page. Forked from KeepTheScore's: same controller, same Berlin address,
+same supervisory authority.
+
+**Treat both as code.** They state what the app stores, who receives it and how long it is kept —
+each of which is a claim that some behaviour exists. A change to what is stored or sent is a change
+to those pages in the same commit.
+
+**Two things are deliberately *not* promised**, and it matters that they stay unpromised until they
+are built: dropping `generations.brief` after 90 days, and deleting a lapsed family after 90 days.
+Both are in PLAN.md phase 5. Neither sweep is written, so neither is in the policy.
+
+**`dinkydash.co` has no MX records.** It is an authenticated *sending* domain and nothing receives
+on it, so every sign-in email had a reply address that reached nobody and a bounce that went
+nowhere. `dinkydash/mail.py` now sets `Reply-To: hi@keepthescore.com`, which is what the policy also
+gives as the contact address. Three things move together the day DinkyDash gets a mailbox:
+`DEFAULT_REPLY_TO`, `privacy.md` and `terms.md`.
+
+**Export and delete are buttons** on `/settings/account`, not requests to answer by hand:
+
+```sql
+-- what a delete should leave behind, for any family id
+SELECT 'families' t, count(*) FROM families WHERE id = :id
+UNION ALL SELECT 'users', count(*) FROM users WHERE family_id = :id
+UNION ALL SELECT 'agendas', count(*) FROM agendas WHERE family_id = :id
+UNION ALL SELECT 'generations', count(*) FROM generations WHERE family_id = :id
+UNION ALL SELECT 'content_history', count(*) FROM content_history WHERE family_id = :id
+UNION ALL SELECT 'calendar_health', count(*) FROM calendar_health WHERE family_id = :id
+UNION ALL SELECT 'model_spend', count(*) FROM model_spend WHERE family_id = :id;
+```
+
+All zeroes. The cascade does most of it; the one row it cannot reach is a **sign-up token**, which
+has no `user_id` by design, and `accounts.delete_family` deletes those by address in the same
+transaction.
+
+**No spec change and no `doctl apps update` for this one** — no new environment variable, no
+migration. `deploy_on_push` is enough.
+
 ## GitHub's own secret scanning
 
 **Do not rely on it yet.** Minutes after it was enabled, a correctly shaped fake

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -1,0 +1,284 @@
+"""Export and hard delete: the two rights the privacy policy promises (DIN-44).
+
+A policy is a claim about what the code does, so these are the assertions that
+keep the two in step:
+
+* **delete means gone**, out of every table, including the one row no cascade
+  reaches — a sign-up token has no user to hang off;
+* **delete is hard to do by accident** and impossible to do to somebody else;
+* **export is everything.** The family's own data comes from the store, which is
+  the only thing that knows what it is; the two things the store deliberately
+  cannot answer — the platform's bookkeeping, and the *full* written history
+  rather than the note text the prompt needs — are read directly and named;
+* **export carries no live credential.** It is a file that gets emailed to
+  somebody and forgotten;
+* **a self-hoster sees none of it.** There is no account to delete and their
+  data is three files they already have.
+
+Skips without `DINKYDASH_TEST_DATABASE_URL`.
+"""
+
+import json
+
+import pytest
+import yaml
+
+from dinkydash import accounts, screens
+from dinkydash.store import FileStore
+from tests.conftest import client_for
+from web import create_app
+
+CONFIG = '''\
+family_name: "The Wilsons"
+timezone: "Europe/Berlin"
+people:
+  - id: mia12345
+    name: "Mia"
+    date_of_birth: "2017-03-15"
+calendars:
+  - id: cal12345
+    label: "School"
+    url: "https://example.com/private-xxxx/basic.ics"
+    enabled: true
+'''
+
+ADDRESS = "parent@example.com"
+
+
+@pytest.fixture
+def family(pg_pool, pg_family):
+    """One family with a parent, a board and a written line behind it."""
+    from dinkydash.pgstore import PostgresStore
+
+    store = PostgresStore(pg_pool, pg_family)
+    store.save_config(yaml.safe_load(CONFIG))
+    config = store.load_config()
+    store.save_brief(config, {"generated_for_date": "2026-09-08",
+                              "generated_at": "2026-09-08T04:00:00+00:00",
+                              "headline": "Swimming, then football",
+                              "note": "An octopus fact."})
+    store.save_agenda(config, {"events": [],
+                               "calendars_fetched_at": "2026-09-08T04:00:00+00:00"})
+    store.record_note(config, {"date": "2026-09-08",
+                               "headline": "Swimming, then football",
+                               "note": "An octopus fact.", "note_kind": "fact"})
+    with pg_pool.connection() as conn, conn.transaction():
+        with conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO users (family_id, email) VALUES (%s, %s) RETURNING id",
+                (pg_family, ADDRESS),
+            )
+            user_id = cur.fetchone()[0]
+    return pg_family, user_id
+
+
+@pytest.fixture
+def cloud(pg_pool, monkeypatch):
+    monkeypatch.setenv("DINKYDASH_MODE", "cloud")
+    monkeypatch.setenv("DINKYDASH_SECRET_KEY", "a-real-one")
+    return create_app(pool=pg_pool)
+
+
+@pytest.fixture
+def parent(cloud, family):
+    family_id, user_id = family
+    client = client_for(cloud)
+    with client.session_transaction() as stored:
+        stored["user_id"] = user_id
+        stored["family_id"] = str(family_id)
+    return client
+
+
+def rows(pg_pool, sql, args=()):
+    with pg_pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(sql, args)
+        return cur.fetchall()
+
+
+# -- export -----------------------------------------------------------------
+
+class TestExport:
+    def test_it_comes_back_as_a_file(self, parent):
+        got = parent.get("/settings/account/export")
+        assert got.status_code == 200
+        assert "attachment" in got.headers["Content-Disposition"]
+        assert "dinkydash-export.json" in got.headers["Content-Disposition"]
+
+    def test_and_is_not_cached_anywhere(self, parent):
+        """The most concentrated copy of a family's data the app ever makes."""
+        got = parent.get("/settings/account/export")
+        assert got.headers["Cache-Control"] == "no-store"
+        assert got.headers["X-Robots-Tag"] == "noindex"
+
+    def test_it_holds_the_settings_the_board_and_the_written_lines(self, parent):
+        export = json.loads(parent.get("/settings/account/export").get_data())
+        assert export["settings"]["family_name"] == "The Wilsons"
+        assert export["settings"]["people"][0]["name"] == "Mia"
+        assert export["board"]["headline"] == "Swimming, then football"
+        assert export["written_lines"][0]["note"] == "An octopus fact."
+        # The date and the headline with it. `recent_notes` returns note text
+        # alone because that is all the prompt needs; an export that did the
+        # same would hand somebody a list of sentences with no days on them.
+        assert export["written_lines"][0]["date"] == "2026-09-08"
+        assert export["written_lines"][0]["headline"] == "Swimming, then football"
+
+    def test_including_the_calendar_links(self, parent):
+        """Portability means the links too — they are the thing that would take
+        longest to reassemble by hand."""
+        export = json.loads(parent.get("/settings/account/export").get_data())
+        assert export["settings"]["calendars"][0]["url"].endswith("basic.ics")
+
+    def test_and_the_platform_s_own_facts(self, parent):
+        export = json.loads(parent.get("/settings/account/export").get_data())
+        assert export["family"]["plan"] == "standard"
+        assert export["family"]["status"] == "trialing"
+
+    def test_but_never_the_screen_token(self, parent, pg_pool, family):
+        """A live credential must not ride along in a file that gets emailed to
+        somebody and forgotten. It is on the screen page, where reading it and
+        rotating it are one gesture."""
+        token = screens.token_for(pg_pool, family[0])
+        body = parent.get("/settings/account/export").get_data(as_text=True)
+        assert token not in body
+
+    def test_a_signed_out_visitor_gets_nothing(self, cloud):
+        landed = client_for(cloud).get("/settings/account/export")
+        assert landed.status_code == 302
+        assert landed.headers["Location"].endswith("/login")
+
+
+# -- delete -----------------------------------------------------------------
+
+class TestDelete:
+    TABLES = ("agendas", "generations", "content_history", "calendar_health",
+              "model_spend")
+
+    def test_typing_the_address_deletes_the_family(self, parent, pg_pool, family):
+        parent.post("/settings/account", data={"confirm": ADDRESS})
+        assert rows(pg_pool, "SELECT id FROM families WHERE id = %s", (family[0],)) == []
+
+    def test_and_the_user_with_it(self, parent, pg_pool):
+        parent.post("/settings/account", data={"confirm": ADDRESS})
+        assert rows(pg_pool, "SELECT id FROM users WHERE email = %s", (ADDRESS,)) == []
+
+    @pytest.mark.parametrize("table", TABLES)
+    def test_every_table_cascades(self, parent, pg_pool, family, table):
+        """The foreign keys promise this. Asserting it is what turns the promise
+        into something the privacy policy can say out loud."""
+        parent.post("/settings/account", data={"confirm": ADDRESS})
+        assert rows(pg_pool, f"SELECT 1 FROM {table} WHERE family_id = %s",
+                    (family[0],)) == []
+
+    def test_a_signup_token_goes_too_and_nothing_cascades_to_it(
+            self, parent, pg_pool, family):
+        """**The one row outside every cascade.** A sign-up token has no
+        `user_id` — that is the whole point of it (DIN-41) — so deleting the
+        family does not reach it. Left alone it would expire in fifteen minutes
+        and be swept, which makes this the difference between "deleted" meaning
+        what the policy says and meaning nearly that."""
+        assert accounts.issue_signup_link(pg_pool, ADDRESS) is not None
+        parent.post("/settings/account", data={"confirm": ADDRESS})
+        assert rows(pg_pool, "SELECT id FROM login_tokens WHERE email = %s",
+                    (ADDRESS,)) == []
+
+    def test_a_sign_in_token_goes_with_its_user(self, parent, pg_pool, family):
+        assert accounts.issue_link(pg_pool, family[1]) is not None
+        parent.post("/settings/account", data={"confirm": ADDRESS})
+        assert rows(pg_pool, "SELECT id FROM login_tokens WHERE user_id = %s",
+                    (family[1],)) == []
+
+    def test_it_signs_them_out(self, parent, pg_pool):
+        parent.post("/settings/account", data={"confirm": ADDRESS})
+        with parent.session_transaction() as stored:
+            assert "user_id" not in stored
+            assert "family_id" not in stored
+
+    def test_and_the_board_stops_working(self, parent, pg_pool, family):
+        """"Every screen showing your board stops working" is what the page
+        promises, and a screen that kept serving a deleted family's day would be
+        the worst possible way to find out otherwise."""
+        path = f"/s/{screens.token_for(pg_pool, family[0])}"
+        assert parent.get(path).status_code == 200
+        parent.post("/settings/account", data={"confirm": ADDRESS})
+        assert parent.get(path).status_code == 404
+
+
+class TestDeleteIsHardToDoByAccident:
+    def test_the_wrong_address_deletes_nothing(self, parent, pg_pool, family):
+        parent.post("/settings/account", data={"confirm": "someone@else.example"})
+        assert rows(pg_pool, "SELECT id FROM families WHERE id = %s", (family[0],))
+
+    def test_an_empty_confirmation_deletes_nothing(self, parent, pg_pool, family):
+        parent.post("/settings/account", data={"confirm": ""})
+        assert rows(pg_pool, "SELECT id FROM families WHERE id = %s", (family[0],))
+
+    def test_and_says_what_to_type(self, parent):
+        landed = parent.post("/settings/account", data={"confirm": "nope"},
+                             follow_redirects=True)
+        assert "Type the email address on this account" in landed.get_data(as_text=True)
+
+    def test_case_and_spaces_are_forgiven(self, parent, pg_pool, family):
+        """Somebody typing their own address on a phone is not the threat."""
+        parent.post("/settings/account", data={"confirm": f"  {ADDRESS.upper()} "})
+        assert rows(pg_pool, "SELECT id FROM families WHERE id = %s", (family[0],)) == []
+
+    def test_it_needs_a_csrf_token_like_every_other_write(self, cloud, family):
+        bare = cloud.test_client()
+        with bare.session_transaction() as stored:
+            stored["user_id"] = family[1]
+            stored["family_id"] = str(family[0])
+        assert bare.post("/settings/account",
+                         data={"confirm": ADDRESS}).status_code == 400
+
+    def test_a_signed_out_visitor_cannot_reach_it(self, cloud):
+        landed = client_for(cloud).post("/settings/account", data={"confirm": ADDRESS})
+        assert landed.status_code == 302
+
+
+class TestOneFamilyCannotDeleteAnother:
+    def test_the_session_decides_and_nothing_else_can(self, cloud, pg_pool, family):
+        """There is no family id in the URL or the form to get wrong. The
+        confirmation is the *session's* address, so holding one family's cookie
+        and typing another family's address deletes neither."""
+        from dinkydash import config as config_module
+
+        with pg_pool.connection() as conn, conn.transaction():
+            with conn.cursor() as cur:
+                cur.execute("""INSERT INTO families (screen_token, config)
+                               VALUES (%s, '{}'::jsonb) RETURNING id""",
+                            (config_module.new_screen_token(),))
+                other = cur.fetchone()[0]
+                cur.execute("INSERT INTO users (family_id, email) VALUES (%s, %s)",
+                            (other, "other@example.com"))
+
+        mine = client_for(cloud)
+        with mine.session_transaction() as stored:
+            stored["user_id"] = family[1]
+            stored["family_id"] = str(family[0])
+        mine.post("/settings/account", data={"confirm": "other@example.com"})
+
+        assert rows(pg_pool, "SELECT id FROM families WHERE id = %s", (other,))
+        assert rows(pg_pool, "SELECT id FROM families WHERE id = %s", (family[0],))
+
+        with pg_pool.connection() as conn, conn.transaction():
+            with conn.cursor() as cur:
+                cur.execute("DELETE FROM families WHERE id = %s", (other,))
+
+
+# -- and a self-hoster sees none of it --------------------------------------
+
+class TestSingleModeHasNoAccount:
+    @pytest.fixture
+    def single(self, tmp_path):
+        (tmp_path / "config.yaml").write_text(CONFIG)
+        return create_app(FileStore(tmp_path / "config.yaml"))
+
+    def test_there_is_no_account_page(self, single):
+        assert single.test_client().get("/settings/account").status_code == 404
+
+    def test_and_no_export(self, single):
+        assert single.test_client().get("/settings/account/export").status_code == 404
+
+    def test_the_settings_home_does_not_offer_one(self, single):
+        page = single.test_client().get("/settings/").get_data(as_text=True)
+        assert "Your data" not in page

--- a/web/routes/settings.py
+++ b/web/routes/settings.py
@@ -9,12 +9,14 @@ comments in the file survive being edited from a phone.
 """
 
 import io
+import json
 import logging
 from datetime import datetime, time, timezone
 
 from flask import (Blueprint, abort, current_app, flash, redirect,
                    render_template, request, url_for)
 
+from dinkydash import accounts
 from dinkydash import config as config_module
 from dinkydash import schedule, screens
 from dinkydash.calendars import FeedError, addresses, describe_feed, feed_label
@@ -26,6 +28,7 @@ from web import CLOUD
 from web import manifest as manifest_module
 from web.family import (current_budget, current_family_id, current_screen_token,
                         current_store)
+from web import session as session_module
 from web.session import guard
 
 log = logging.getLogger(__name__)
@@ -105,8 +108,12 @@ SECTIONS = {
         "title": "Calendars",
         "singular": "calendar",
         "add_label": "Add a calendar",
+        # **The disclosure where somebody is actually about to paste a calendar
+        # link**, not only in a policy nobody opens. It says what leaves and
+        # what does not, in the same breath as the field that causes it.
         "blurb": "Every calendar you switch on is merged into one agenda. Titles and times are "
-                 "sent to Claude each morning; an event kept off the board by a guest list is not.",
+                 "sent to Anthropic each morning so Claude can write the day's line; an event "
+                 "kept off the board by a guest list is never stored and never sent.",
         "fields": [
             ("label", "Call it", "text", True, ""),
             ("url", "iCal link", "url", True,
@@ -690,6 +697,126 @@ def refresh_now():
                     f"{', '.join(sorted(s['label'] for s in broken))}.")
     flash(message, "error" if broken else "ok")
     return redirect(url_for("settings.home"))
+
+
+@bp.route("/account", methods=["GET", "POST"])
+def account():
+    """Your data, and getting rid of it. Cloud mode only.
+
+    Not registered behind a mode check but hidden behind one: a self-hoster has
+    no account to delete and no export to want — their data is a YAML file and
+    two JSON files they already have, in a directory they chose.
+    """
+    if current_app.config["MODE"] != CLOUD:
+        abort(404)
+    if request.method == "POST":
+        return delete_account()
+    return render_template(
+        "settings/account.html", config=current_config(),
+        address=accounts.address_for(current_app.config["POOL"],
+                                     session_module.current_user_id()))
+
+
+@bp.route("/account/export")
+def export_account():
+    """Everything we hold about this family, as one JSON file.
+
+    **The family's own data comes from the store**, which is the only thing that
+    knows what it is. Two things it deliberately cannot answer are read directly
+    and named as such:
+
+    * the plan, the trial and when the account was made, which are the
+      platform's bookkeeping rather than the family's data;
+    * the **full** written history. `recent_notes` returns note *text* and
+      nothing else, because it exists to stop the model repeating itself — an
+      export needs the date and the headline with it, and widening the store's
+      operation to suit one caller would make every other caller carry it.
+
+    `Cache-Control: no-store` because this is the most concentrated copy of a
+    family's data the app ever produces, and a shared cache holding it is worse
+    than any single page.
+    """
+    if current_app.config["MODE"] != CLOUD:
+        abort(404)
+    store = current_store()
+    config = store.load_config()
+    payload = store.load_payload(config) or {}
+    export = {
+        "exported_at": datetime.now(timezone.utc).isoformat(),
+        "family": _family_facts(),
+        "settings": config,
+        "board": payload,
+        # Everything the model has written, not the 30 the board keeps for
+        # itself: `history_days` is a prompt setting, not a retention rule, and
+        # an export that quietly truncated would be the wrong answer to "give me
+        # my data".
+        "written_lines": _written_lines(),
+    }
+    body = json.dumps(export, indent=2, ensure_ascii=False, default=str)
+    return body, 200, {
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Disposition": 'attachment; filename="dinkydash-export.json"',
+        "Cache-Control": "no-store",
+        "X-Robots-Tag": "noindex",
+    }
+
+
+def _written_lines():
+    """Every line the model has written for this family, with its date.
+
+    Read directly rather than through `store.recent_notes`, which returns note
+    text alone — see `export_account`. Scoped to the session's family like
+    everything else, and that id never comes from the request.
+    """
+    with current_app.config["POOL"].connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            """SELECT date, headline, note, note_kind, created_at
+               FROM content_history WHERE family_id = %s ORDER BY date, id""",
+            (current_family_id(),),
+        )
+        keys = ("date", "headline", "note", "note_kind", "created_at")
+        return [dict(zip(keys, row)) for row in cur.fetchall()]
+
+
+def _family_facts():
+    """The platform's own bookkeeping about a family, for the export."""
+    with current_app.config["POOL"].connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            """SELECT plan, status, trial_ends_at, created_at
+               FROM families WHERE id = %s""",
+            (current_family_id(),),
+        )
+        row = cur.fetchone()
+    if row is None:
+        return {}
+    # **The screen token is not in here.** An export is a file that gets emailed
+    # to somebody, saved to a downloads folder and forgotten; a live credential
+    # should not ride along in one. It is on the screen page, where it can be
+    # rotated in the same breath as being read.
+    return dict(zip(("plan", "status", "trial_ends_at", "created_at"), row))
+
+
+def delete_account():
+    """Delete this family for good, if they typed their own address back.
+
+    **The confirmation is the address on the account**, the way a repository
+    host asks for the repository name. A button alone is one mis-tap from a
+    family losing a board they set up; typing an address they had to know is
+    friction that only the right person can pass.
+
+    The family comes from the session and from nowhere else, so there is no id
+    to get wrong and no way to be handed somebody else's.
+    """
+    pool = current_app.config["POOL"]
+    address = accounts.address_for(pool, session_module.current_user_id())
+    typed = (request.form.get("confirm") or "").strip().lower()
+    if not address or typed != address.lower():
+        flash("Type the email address on this account to confirm.", "error")
+        return redirect(url_for("settings.account"))
+
+    accounts.delete_family(pool, current_family_id())
+    session_module.sign_out()
+    return redirect(url_for("auth.login", deleted=1))
 
 
 @bp.route("/system", methods=["GET", "POST"])

--- a/web/session.py
+++ b/web/session.py
@@ -85,6 +85,17 @@ def signed_in():
     return bool(session.get(USER_ID))
 
 
+def current_user_id():
+    """Who is signed in, or None. The person, as opposed to the family.
+
+    Almost everything is scoped to the family and reads `web/family.py`
+    instead. This is for the two things that are about the *person*: showing
+    somebody their own address, and confirming that they typed it back before
+    deleting the account.
+    """
+    return session.get(USER_ID)
+
+
 def guard():
     """Cloud mode: no session, no family. Returns a redirect, or None.
 

--- a/web/templates/settings/account.html
+++ b/web/templates/settings/account.html
@@ -1,0 +1,95 @@
+{# Your data, and getting rid of it. Cloud mode only — a self-hoster has no
+   account to delete, and their data is three files they already have.
+
+   The two halves are deliberately far apart on the page and look nothing like
+   each other: one is a link, the other is a form that will not submit until an
+   address has been typed into it. #}
+{% extends "settings/base.html" %}
+{% import "settings/_icons.html" as icons %}
+{% block title %}Your data{% endblock %}
+
+{% block head %}
+<style>
+    /* `.field > label` uppercases every label in the settings UI, which is
+       right for "EMAIL ADDRESS" and wrong for an address somebody has to copy
+       character by character. This is the most dangerous button in the app;
+       the string beside it should look exactly like the one they will type. */
+    .confirm-field > label { text-transform: none; letter-spacing: 0; font-size: 0.8125rem; }
+    .confirm-field > label strong { word-break: break-all; }
+</style>
+{% endblock %}
+
+{% block appbar %}
+<a class="back" href="{{ url_for('settings.home') }}">{{ icons.back() }}</a>
+<h1>Your data</h1>
+{% endblock %}
+
+{% block content %}
+<div>
+    <div class="label">Signed in as</div>
+    <div class="card pad">
+        <div style="font-weight:800;word-break:break-all;">{{ address or "—" }}</div>
+        <div class="hint" style="margin-top:0.1875rem;">
+            There is no password on this account. Whoever can read that mailbox can sign in,
+            so look after it the way you would a password.
+        </div>
+    </div>
+</div>
+
+<div>
+    <div class="label">Take it with you</div>
+    <div class="card pad" style="display:flex;flex-direction:column;gap:0.875rem;">
+        <div class="hint">
+            Everything we hold about your family in one file: your details, your calendar
+            links, the agenda we last fetched, and every line the model has written.
+        </div>
+        <a class="btn outline" href="{{ url_for('settings.export_account') }}">Download my data</a>
+    </div>
+</div>
+
+<div>
+    <div class="label">Where it goes</div>
+    <div class="card pad" style="display:flex;flex-direction:column;gap:0.625rem;">
+        {# Said here as well as in the policy, because this is the page somebody
+           opens when they are actually wondering. #}
+        <div class="hint">
+            <strong>Anthropic</strong> sees your family's day. Once each morning the agenda,
+            names and interests go to Claude so it can write the headline and the one line.
+        </div>
+        <div class="hint">
+            <strong>SendGrid</strong> sees who is signing in, and nothing else — your address
+            and the link, never a calendar.
+        </div>
+        <div class="hint">
+            The full list is in the <a href="https://dinkydash.co/privacy/">privacy policy</a>.
+        </div>
+    </div>
+</div>
+
+<div>
+    <div class="label">Delete everything</div>
+    <div class="card pad" style="display:flex;flex-direction:column;gap:0.875rem;">
+        <div class="note-box">
+            This removes your family, this account, your calendar links, the stored agenda and
+            every written line. <strong>Every screen showing your board stops working.</strong>
+            It cannot be undone, and we cannot get it back for you.
+        </div>
+        <form method="post" style="display:flex;flex-direction:column;gap:0.875rem;">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+            <div class="field confirm-field">
+                {# The account's own address, typed back — the way a repository
+                   host asks for the repository name. A button on its own is one
+                   mis-tap away from losing a board somebody spent an evening
+                   setting up. #}
+                <label for="confirm">Type <strong>{{ address }}</strong> to confirm</label>
+                <input type="text" id="confirm" name="confirm" autocomplete="off"
+                       autocapitalize="off" autocorrect="off" spellcheck="false" required>
+            </div>
+            <button class="btn" type="submit"
+                    style="background:var(--danger);border-color:var(--danger);">
+                Delete my account
+            </button>
+        </form>
+    </div>
+</div>
+{% endblock %}

--- a/web/templates/settings/home.html
+++ b/web/templates/settings/home.html
@@ -136,6 +136,22 @@
     </div>
 </div>
 
+{# Hosted only. A self-hoster has no account to delete and nothing to export —
+   their data is a YAML file and two JSON files, in a directory they chose. #}
+{% if cloud %}
+<div>
+    <div class="label">Your account</div>
+    <div class="card">
+        <a class="row" href="{{ url_for('settings.account') }}">
+            <div class="row-main">
+                <div class="row-title">Your data</div>
+                <div class="row-sub">Download it, or delete everything</div>
+            </div>{{ icons.chevron() }}
+        </a>
+    </div>
+</div>
+{% endif %}
+
 {# Only hosted. Self-hosted has no accounts, so there is nothing to sign out of. #}
 {% if cloud %}
 <form method="post" action="{{ url_for('auth.logout') }}">

--- a/website/CLAUDE.md
+++ b/website/CLAUDE.md
@@ -6,17 +6,33 @@ Guidance for `website/`. The root `CLAUDE.md` holds the rules that apply to ever
 
 **`website/` never runs on the board**, and that is what settles most questions here.
 
-- **Its dependencies go in `requirements-dev.txt`, never `requirements.txt`.** The runtime
+- **Its dependencies go in `requirements-site.txt`, never `requirements.txt`.** The runtime
   list is what `deploy_to_pi.sh` installs on a Pi, and a Pi serves no marketing site. The
-  site generator needs `jinja2`, `markdown` and `pyyaml`; the two image scripts need
-  `Pillow`, and `generate_social_preview.py` also wants Chrome, which pip cannot install.
-- **`docs/` is the build output, not a place to put documentation.** `build.py` deletes and
-  rewrites it on every run, so a markdown file left there dies at the next build. It is
-  committed because GitHub Pages serves it, which means a template change is not finished
-  until the site is rebuilt.
+  site needs `markdown`, `pyyaml` and `gunicorn`; the two image scripts need `Pillow` and
+  live in `requirements-dev.txt`, and `generate_social_preview.py` also wants Chrome, which
+  pip cannot install. `requirements-cloud.txt` pulls in the site's list, because one
+  container serves both hostnames.
+- **There is no build step and no `docs/` directory.** This said the opposite until DIN-27:
+  `build.py` used to write `docs/` and GitHub Pages served it, so a template change was not
+  finished until the site was rebuilt and the output committed. None of that is true now.
+  `website/site.py` is a Flask app rendering `content/*.md` through `templates/` on request,
+  deployed on the same App Platform container as the board with `wsgi.py` routing on the
+  `Host` header. **Adding a page is writing a Markdown file, and nothing else.**
 - **Nunito lives here twice on purpose.** `website/static/fonts/` and `web/static/fonts/`
   are separate deployables, so editing one means editing both. The site's copy carries the
   italic pair as well; the board's does not, because the board never sets italic.
+
+## The legal pages
+
+`content/privacy.md` and `content/terms.md` are the hosted service's, and they are **claims
+about what the code does**. A retention period is a promise that a `DELETE` exists; a
+sub-processor list is a promise that nothing else is called. Changing what the app stores,
+what it sends, or who it sends it to means changing those pages in the same commit — a
+policy that has drifted from the code is worse than no policy, because somebody relied on it.
+
+The contact address is `hi@keepthescore.com` on purpose: **`dinkydash.co` has no MX records**,
+so it sends email and receives none. `dinkydash/mail.py` sets the same address as `Reply-To`
+for that reason. When DinkyDash gets a mailbox, all three move together.
 
 ## The two image generators
 

--- a/website/README.md
+++ b/website/README.md
@@ -114,4 +114,12 @@ after creation, so an app made with a plain git URL has to be recreated rather t
 
 ## Deployment
 
-The website is automatically deployed via GitHub Pages from the `docs/` directory when changes are pushed to the main branch.
+Pushed to `main`, and DigitalOcean App Platform rebuilds from the commit — `deploy_on_push` in
+`.do/app.yaml`. There is no build step and nothing to commit but the source: `website/site.py`
+renders `content/*.md` through `templates/` on request.
+
+**It shares one container with the board.** `wsgi.py` routes on the `Host` header —
+`dinkydash.co` here, `app.dinkydash.co` to the board — so a change to either deploys both.
+
+This section used to say GitHub Pages served `docs/`. That was true until DIN-27 and is not
+now; the directory is gone.

--- a/website/content/privacy.md
+++ b/website/content/privacy.md
@@ -1,0 +1,163 @@
+---
+title: Privacy policy
+seo_title: "Privacy Policy — DinkyDash"
+template: page.html
+description: What DinkyDash stores, who it is sent to, how long it is kept, and how to get it back or delete it.
+---
+
+*Last updated: 8 September 2026.*
+
+DinkyDash puts a family's day on a screen. That means the things it holds are a
+household's names, dates of birth and movements — which is about as personal as
+data gets, and children's data at that. This page says exactly what happens to
+it.
+
+**If you run DinkyDash yourself**, most of this does not apply to us at all.
+Your config, your calendar links and your board stay on your machine, and the
+only thing that leaves it is the day's agenda, sent to Anthropic so Claude can
+write the daily line — with your own API key, under your own agreement with
+them. We hold nothing. This page describes the **hosted** version at
+`app.dinkydash.co`.
+
+## What we collect
+
+Nothing is bought, sold, or gathered from anywhere else. Everything below is
+either something you typed or something the software produced.
+
+| What | Where it comes from | Why |
+|---|---|---|
+| **Your email address** | You type it to sign in | It is the whole of the account. There is no password |
+| **Your family's details** | You type them: names, dates of birth, emoji, chores, special dates | They are what the board shows |
+| **Your calendar links** | You paste them | To fetch the events the board shows |
+| **Your calendar events** | Fetched from those links | The agenda on the board |
+| **The written line** | Written by Claude each morning | The board's headline and note |
+| **Sign-in links** | Generated when you ask for one | Hashed, never stored as a working link |
+| **Counts of model calls** | Recorded when the board is written | So one account cannot run up an unbounded bill |
+
+**We do not use cookies for tracking.** The hosted app sets one cookie, and it
+is the session that keeps you signed in. There is no analytics on
+`app.dinkydash.co`, no advertising, and no third-party script on the board or
+the settings pages. The marketing site at `dinkydash.co` uses Ahrefs Web
+Analytics, which is cookieless and collects no personal data.
+
+## Where it goes
+
+Two things leave our servers, they are different in kind, and it matters which
+is which.
+
+**Anthropic sees your family's day.** Once each morning the day's agenda — the
+event titles and times, your family's names and interests — is sent to
+Anthropic so Claude can write the headline and the one written line. That is
+the feature. Nothing else about you is sent, and it is not used to train
+models.
+
+**SendGrid sees who is signing in, and nothing else.** When you ask for a sign-in
+link, your email address and the link go to SendGrid to be delivered. SendGrid
+never sees a calendar, a name or a date of birth.
+
+If you would rather Anthropic saw nothing, self-host: the board works with no
+API key at all, and simply goes without the written line.
+
+### Sub-processors
+
+| Who | What they do | Where |
+|---|---|---|
+| **Anthropic** | Writes the daily line from the day's agenda | United States |
+| **DigitalOcean** | Runs the app and the database | Frankfurt, Germany (US company) |
+| **SendGrid** (Twilio) | Delivers sign-in emails | United States |
+| **Cloudflare** | DNS, and TLS at the edge | Global (US company) |
+
+The app and the database are in **Frankfurt**. DigitalOcean and Cloudflare are
+United States companies operating them, so transfers outside the EU are covered
+by standard contractual clauses.
+
+**Google Fonts is not on this list, and that is deliberate.** The typeface is
+served from our own servers, so no page of DinkyDash — not the board, not the
+settings, not this site — asks Google for anything or tells them you were here.
+
+Payment processing will be added to this list when payment exists. It does not
+yet.
+
+## How long it is kept
+
+We would rather hold less, so most of this expires on its own.
+
+- **Your calendar events**: one rolling fourteen-day window per family,
+  overwritten every time the calendars are refreshed. Nothing accumulates — the
+  most we ever hold about your calendar is that one window.
+- **The written lines**: the last 30 are kept, so the model does not repeat
+  itself. Older ones are deleted as new ones arrive.
+- **Sign-in links**: deleted once expired, which is fifteen minutes. A link that
+  has been used is deleted on the same schedule.
+- **Your account, your family's details and the record of boards written**: kept
+  while the account exists, and deleted when you delete it.
+
+**Backups.** DigitalOcean takes daily backups of the database and keeps seven
+days of point-in-time recovery. Deleted data can therefore persist in a backup
+for up to seven days before it ages out.
+
+## Getting it back, and getting rid of it
+
+Both are buttons, not requests, and both are on your settings page.
+
+- **Export** gives you everything we hold about your family as one JSON file:
+  your details, your calendar links, the stored agenda, and every written line.
+- **Delete** removes your family, your account, your calendar links, the stored
+  agenda, every written line and every sign-in link. It cannot be undone and we
+  cannot restore it for you.
+
+You also have the right to correct what we hold — which the settings page does
+directly — to object to processing, and to ask for your data in a portable form,
+which is what the export is.
+
+## Children
+
+DinkyDash is for parents to use, and holds children's names and dates of birth
+because that is what a family calendar is. **Accounts are for adults.** A child
+does not sign up, and nothing on the board asks a child for anything.
+
+## Security
+
+Sign-in links are hashed before they are stored, work once, and expire in
+fifteen minutes. The board's own screen URL is unguessable and can be changed at
+any time from the settings page, which stops the old one working. Everything
+travels over HTTPS. Every form that changes anything carries a token that stops
+another site submitting it on your behalf.
+
+**We will tell you** if a breach affects your data, and the Berlin supervisory
+authority within 72 hours, as the GDPR requires.
+
+## Automated decisions
+
+Claude writes a sentence about your day. That is the whole of the automation,
+and nothing is decided about you by it — no profiling, no scoring, and no
+decision with any legal or similar effect.
+
+## Complaints
+
+If we have got something wrong, tell us first — but you have the right to go
+straight to a supervisory authority. Ours is the **Berliner Beauftragte für
+Datenschutz und Informationsfreiheit**, and you may also complain to the
+authority where you live.
+
+## Changes
+
+If this policy changes in a way that affects what happens to your data, we will
+email the address on your account before it takes effect. The date at the top
+is when it last changed.
+
+## Who we are
+
+**Caspar von Wrede**
+Argentinische Allee 2
+14163 Berlin
+Germany
+
+Data protection enquiries: **hi@keepthescore.com**, with "privacy" in the
+subject. That is the same person — DinkyDash and Keep The Score are both run by
+Caspar, and `dinkydash.co` sends email but does not yet receive it, so writing
+to an address there would reach nobody. We answer within one month, and will say
+so if a request needs longer.
+
+**Our domains** are `dinkydash.co` and `app.dinkydash.co`. Anything else is not
+us.

--- a/website/content/terms.md
+++ b/website/content/terms.md
@@ -1,0 +1,125 @@
+---
+title: Terms of service
+seo_title: "Terms of Service — DinkyDash"
+template: page.html
+description: The terms for the hosted version of DinkyDash at app.dinkydash.co. Self-hosting is MIT-licensed and covered by the licence, not by these.
+---
+
+*Last updated: 8 September 2026.*
+
+These terms cover the **hosted** service at `app.dinkydash.co`. If you run
+DinkyDash yourself from the source code, the [MIT
+licence](https://github.com/caspii/dinkydash/blob/main/LICENSE) is what applies
+to you and none of this does.
+
+## What the service does
+
+DinkyDash reads calendars you point it at, works out whose turn each chore is
+and how many days until the things you are counting down to, and once each
+morning asks Claude to write a headline and one line about the day. It renders
+all of that as a web page you can leave on a screen.
+
+**It is a display, not a source of truth.** It shows what your calendar says.
+Do not use it as the only place an appointment exists, and do not rely on it
+for anything where being wrong matters — a hospital appointment, a flight, a
+medication. It is a kitchen wall, not a system of record.
+
+## What you need
+
+A modern browser, and an iCal link from a calendar that publishes one — Google
+Calendar, Apple iCloud and Outlook all do. There is no app to install and no
+account to connect: you paste a link.
+
+## Your account
+
+Signing in is a link sent to your email address. There is no password, so
+**whoever can read that mailbox can get into your account** — look after it the
+way you would a password.
+
+One account is one family. Accounts are for adults.
+
+## The screen link
+
+Your board is served at an unguessable URL so that a screen on a wall can show
+it without anybody signing in. **Anyone who has that link can see your board.**
+That is the trade that makes a wall panel possible.
+
+You can change the link at any time from your settings page, which immediately
+stops the old one working. If you share a screenshot, crop it out.
+
+## What you may not do
+
+- Put anything unlawful on it, or use it to harass, impersonate or abuse anyone
+- Try to reach another family's board, account or data
+- Script, scrape or automate the service beyond ordinary use, or try to work
+  around the limits that stop one account spending our money
+- Resell the hosted service, or present it as your own
+
+Self-hosting is not on this list, and never will be. The code is MIT-licensed:
+run it, change it, run it for other people.
+
+## Money
+
+**The first fourteen days are free and we do not ask for a card.** After that
+the hosted service is $39 a year, or $6 a month if you would rather.
+
+Payment is not built yet. Until it is, nobody is charged anything and nothing
+is collected. When it arrives, this section will say who processes it and these
+terms will be updated before it takes effect.
+
+## Ending it
+
+**You can stop at any time.** Deleting your account is a button on your settings
+page, it takes effect immediately, and it removes your data — see the [privacy
+policy](/privacy/) for exactly what goes.
+
+We may end an account without notice if it is being used for something on the
+list above. Otherwise, if we ever have to close a paid account, you get thirty
+days' notice and the unused part of anything paid back.
+
+**We may stop offering the hosted service.** If that happens you will get
+reasonable notice and your data in a portable form. The code is open source, so
+the board itself can keep running on your own machine.
+
+## What we do not promise
+
+The service is provided as it is. We do not promise it will be uninterrupted or
+error-free, that a calendar provider's feed will always answer, or that the
+written line will always be sensible — it is written by a language model and
+occasionally it will be odd.
+
+To the extent the law allows, we are not liable for indirect or consequential
+loss, and our total liability is limited to what you have paid us in the
+preceding twelve months. Nothing here limits liability for death, personal
+injury, or anything else that cannot lawfully be limited — including your
+statutory rights as a consumer, which these terms do not affect.
+
+## Your data
+
+The [privacy policy](/privacy/) is part of these terms. The short version: your
+family's day goes to Anthropic each morning so Claude can write a line, your
+email address goes to SendGrid so a sign-in link can be delivered, and nothing
+is sold to anybody.
+
+## Changes
+
+If these terms change in a way that affects you, we will email the address on
+your account before it takes effect. The date at the top is when they last
+changed.
+
+## Law, and who we are
+
+These terms are governed by German law, and the courts of Berlin have exclusive
+jurisdiction — except where you are a consumer and the law gives you the right
+to bring a claim where you live, which it does.
+
+**Caspar von Wrede**
+Argentinische Allee 2
+14163 Berlin
+Germany
+
+Contact: **hi@keepthescore.com**. DinkyDash and Keep The Score are run by the
+same person; `dinkydash.co` sends email but does not yet receive it.
+
+**Our domains** are `dinkydash.co` and `app.dinkydash.co`. Anything else is not
+us.

--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -367,6 +367,13 @@
         <div class="footer-row">
             <span>&copy; 2026 DinkyDash</span>
             <span class="footer-links">
+                {# Reachable from every page, which is most of the point of
+                   having them: a policy nobody can find is a policy nobody
+                   agreed to. #}
+                <a href="/privacy/">Privacy</a>
+                <span class="footer-sep">&middot;</span>
+                <a href="/terms/">Terms</a>
+                <span class="footer-sep">&middot;</span>
                 <a href="https://github.com/caspii/dinkydash/issues/new">Feedback</a>
                 <span class="footer-sep">&middot;</span>
                 <a href="https://casparwre.de">Built by Caspar</a>


### PR DESCRIPTION
Closes DIN-44. PLAN.md says **"nothing ships without 5"**, and this is 5.

## What was open

`website/content/` had sixteen pages and **not one of them was legal**. No footer link to one either. Meanwhile `app.dinkydash.co/login` is public, a click creates a family (#79), and that family's calendar goes to Anthropic and their address to SendGrid — with nothing written down that they can read.

Forked from KeepTheScore's as decision 8 says: same controller, same Berlin address, same supervisory authority.

## The rule that shaped it

**A policy is a claim about what the code does.** A retention period is a promise that a `DELETE` exists; a sub-processor list is a promise that nothing else is called.

So the two sweeps PLAN.md plans but nobody has written — dropping `generations.brief` after 90 days, and deleting a lapsed family after 90 days — are **deliberately not promised**. The policy states what is true today, and the phase 5 box now says: write the sweep, then write the sentence.

The same rule trimmed the sub-processor list to the four who actually receive something. **Stripe is named as not on it**, because a list including somebody who receives nothing is the same kind of untrue as one omitting somebody who does. Google Fonts is named as not on it too, and why.

**The Anthropic disclosure is in three places**, and the one that matters is not the policy — it is the blurb beside the field where somebody is about to paste a calendar link.

## Export and hard delete

Buttons on `/settings/account`, not requests to answer by hand.

**Export** is the family's data from the store, plus the two things the store deliberately cannot answer: the platform's bookkeeping, and the *full* written history (`recent_notes` returns note text alone, because that is all the prompt needs — an export of sentences with no dates on them is the wrong answer to "give me my data"). It carries **no live screen token**: an export is a file that gets emailed and forgotten.

**Delete** needs the account's own address typed back, the way a repository host asks for the repository name. A bare button is one mis-tap from losing a board somebody spent an evening setting up.

The cascade does most of the work, and **there is exactly one row it cannot reach**: a sign-up token has no `user_id` — that is the whole point of it — so `accounts.delete_family` removes those by address in the same transaction. Left alone it would expire in fifteen minutes and be swept, which makes this the difference between "deleted" meaning what the policy says and meaning nearly that.

## Found on the way

**`dinkydash.co` has no MX records.** It is an authenticated *sending* domain and nothing receives on it, so every sign-in email had a reply address that reached nobody and a bounce that went nowhere — which you would find out from the person trying to tell you their link was broken. `mail.py` now sets a `Reply-To` a human reads, and the policy gives the same address.

## Stale documentation, corrected in the same pass

It was actively misleading, and one piece of it would have caused work:

- **Phase 3's "person cards with ages" box was stale.** It predates the homepage rewrite (#72). The homepage now says "every screen on this page shows the real board" and promises exactly what ships. There is no parity gap — building person cards from that box would have been building something nobody was promised.
- PLAN.md bug 7 said "no CI", bug 9 said `generated_at` used the server clock, bug 11 said no CSRF, and four "small jobs" were long done. All ticked, with what actually closed them.
- `website/CLAUDE.md` and `website/README.md` still described `build.py` writing `docs/` for GitHub Pages, which DIN-27 removed.
- The terms said £39. The price is $39.
- DIN-37's premise is corrected in a comment on the issue: `CF-IPCountry` is not available on `app.dinkydash.co` (our zone entries are DNS-only), so "use the Cloudflare header to find the country" does not work. `DO-Connecting-IP` is what exists.

## Testing

- 808 pass with `DINKYDASH_TEST_DATABASE_URL`, 555 with 253 skipped without. `tests/test_account.py` is 28 of them — one per table, plus the row that cascades to nothing, plus the checks that one family cannot delete another.
- **Walked end to end in process**: sign up, leave an unclicked sign-up token behind, read the account page, export, try the wrong address, then the right one — and watch every table come back empty and the board go from 200 to 404.
- Both new pages shot in headless Chrome. The confirmation label needed a fix: the settings CSS uppercases every label, which mangled the address people have to copy.

## Still yours

The **DigitalOcean and Cloudflare DPAs** need signing — the policy already says where the data lives and who the companies are; what is outstanding is the signature.

## Deploy

No migration, no spec change, no new environment variable. `deploy_on_push` is enough. (The three applies outstanding from #79 and #81 are unaffected and still outstanding.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VqGomc6Y1LYeEA6LaokUdZ