### PR TITLE
Switch GitHub Pages off, and write down what it was still doing

### DIFF
--- a/doc/operations.md
+++ b/doc/operations.md
@@ -365,6 +365,37 @@ transaction.
 **No spec change and no `doctl apps update` for this one** — no new environment variable, no
 migration. `deploy_on_push` is enough.
 
+## GitHub Pages, switched off 8 September 2026
+
+**Pages was still enabled, still set to build `main:/docs`, and still serving.** DIN-27 deleted that
+directory and moved the marketing site onto App Platform, but nobody turned the setting off — so
+every push to `main` ran `pages-build-deployment`, failed, and left a red X beside a green CI run.
+That is what "the Jekyll build keeps failing" was: no workflow file in this repo, a repository
+setting.
+
+**The failing build was the smaller half.** Pages keeps serving the last *successful* deployment
+when a later one errors, so `caspii.github.io/dinkydash/` was quietly serving a **complete, stale
+copy of the marketing site** — the pre-rewrite homepage, on a second domain, for a product whose
+whole strategy is search. It was not a disaster only because the old build's `<link rel="canonical">`
+and its `robots.txt` sitemap both already pointed at `dinkydash.co`.
+
+Nothing depended on it, which was checked before switching it off: **no custom domain** on the Pages
+site (`cname: null` — `dinkydash.co` resolves to Cloudflare and DigitalOcean, not to GitHub), no link
+to `caspii.github.io` anywhere in the repo, and the repository's own homepage field already reads
+`https://dinkydash.co`.
+
+```bash
+gh api repos/caspii/dinkydash/pages          # was: status errored, source main:/docs, build_type legacy
+gh api -X DELETE repos/caspii/dinkydash/pages
+```
+
+`has_pages` is now false. GitHub's CDN keeps answering for a little while afterwards; the URL 404s
+once that expires.
+
+**The lesson worth keeping:** a build that fails on every push is noise somebody stops reading, and
+this one was hiding a live duplicate of the site. When a deployment target is retired, turn off the
+thing that deploys to it in the same change.
+
 ## GitHub's own secret scanning
 
 **Do not rely on it yet.** Minutes after it was enabled, a correctly shaped fake

--- a/website/CLAUDE.md
+++ b/website/CLAUDE.md
@@ -18,6 +18,11 @@ Guidance for `website/`. The root `CLAUDE.md` holds the rules that apply to ever
   `website/site.py` is a Flask app rendering `content/*.md` through `templates/` on request,
   deployed on the same App Platform container as the board with `wsgi.py` routing on the
   `Host` header. **Adding a page is writing a Markdown file, and nothing else.**
+- **GitHub Pages is switched off**, and it took until 8 September to notice. The setting outlived
+  the directory: it kept failing on every push *and* kept serving the last good build, so a stale
+  copy of this whole site sat on `caspii.github.io` for a fortnight. See
+  [doc/operations.md](../doc/operations.md). Nothing here should ever be written to be served from
+  two places at once.
 - **Nunito lives here twice on purpose.** `website/static/fonts/` and `web/static/fonts/`
   are separate deployables, so editing one means editing both. The site's copy carries the
   italic pair as well; the board's does not, because the board never sets italic.


### PR DESCRIPTION
The failing "Jekyll build" is **not a workflow in this repo** — there is no Jekyll config and no Pages workflow file. It was the repository setting, and it is now off.

## What was actually happening

```json
"status": "errored", "build_type": "legacy",
"source": {"branch": "main", "path": "/docs"}, "cname": null
```

DIN-27 deleted `docs/` and moved the marketing site onto App Platform, but nobody turned Pages off. So every push to `main` ran `pages-build-deployment`, failed, and left a red X beside a green CI run.

## The failing build was the smaller half

**Pages keeps serving the last *successful* deployment when a later one errors.** So `caspii.github.io/dinkydash/` has been quietly serving a complete, stale copy of the marketing site — the pre-rewrite homepage, on a second domain, for a product whose entire strategy is search.

It was not worse than that only because the old build's `<link rel="canonical">` and its `robots.txt` sitemap both already pointed at `dinkydash.co`.

## Checked before switching it off

Turning off something that is answering 200s deserves a look first:

- **No custom domain** on the Pages site (`cname: null`). `dinkydash.co` resolves to Cloudflare and DigitalOcean, not GitHub — verified.
- **No link to `caspii.github.io`** anywhere in the repo.
- The repository's own homepage field already reads `https://dinkydash.co`.

```bash
gh api -X DELETE repos/caspii/dinkydash/pages
```

`has_pages` is now false. GitHub's CDN keeps answering for a little while; the URL 404s once that expires.

## This PR

No code. It is the note — `doc/operations.md` for the state of the running system, and a line in `website/CLAUDE.md` so the next person does not wonder where the Pages site went.

The lesson worth keeping: **a build that fails on every push is noise somebody stops reading, and this one was hiding a live duplicate of the site.** When a deployment target is retired, turn off the thing that deploys to it in the same change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VqGomc6Y1LYeEA6LaokUdZ