### PR TITLE
Write the first board at once, not at brief_time (DIN-45)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -2,6 +2,8 @@
 
 *Last updated: September 8, 2026. Supersedes `HOSTING_ANALYSIS.md` (deleted — it predated both the AI generation feature and the July 2026 calendar-display repositioning, and its recommended stack and data model no longer matched the product).*
 
+*September 8, newest: **a new family gets a board within five minutes, at any hour** (DIN-45). The one thing DIN-41 left behind: the brief waited for `brief_time`, so signing up at 03:00 meant a waiting screen until 06:00 — which is most of the day, and was every family's first impression. `schedule.brief_due` now treats the **first** brief as owed at once, because `brief_time` is when to replace yesterday's line and there is nothing to replace before the first one. No queue, no column, no call to Anthropic from a web request: a payload with no `generated_for_date` already meant "never had a brief" in both stores, so the worker's existing tick answers it. Pure, so a Pi set up after dinner gets a board that evening too. See [The first board](#the-first-board).*
+
 *September 8, last: **the multi-tenancy is real** (DIN-39). `web/family.py` builds one `PostgresStore` per request from the family on the session, over a pool built once per process; `create_app` holds no store at all in cloud mode, and the environment variable that used to name "the" family is deleted from the code, the app spec and the docs. Nothing a caller can send — path segment, query parameter, form field or header — reaches a query as a family selector, which is a stronger property than checking an id against the session. The ids that do appear in URLs are item ids inside one family's config document, and another family's is not in the list: `tests/test_tenancy.py` walks every section and every write route and asserts a 404, never a 403. **Phase 1's "done when" is met.** `login_link.py` prints a sign-in link without waiting on email, because the preview and the support inbox both need one.*
 
 *September 8, later still: **magic-link auth is built** (DIN-38). `dinkydash/accounts.py` is the token lifecycle — 32 bytes from `secrets`, only the SHA-256 stored, fifteen minutes, spent by one `UPDATE ... WHERE used_at IS NULL RETURNING`; `web/routes/auth.py` is `/login`, `/login/link` and `/logout`; `web/session.py` is the cookie and a CSRF token on every form that writes, in both modes. `/settings` in cloud mode is behind a session. What was deliberately still missing at that point was the **scoping**, which DIN-39 above then did. The token rides in the query string rather than the path because the app runs `gunicorn --access-logfile -` and a login link in a log is a login in a log — see the access log format in `.do/app.yaml`, which is now a security control.*
@@ -195,11 +197,52 @@ else's appointments on a stranger's wall. The settings home says so while the bo
 untouched, which is `settings.looks_untouched` — no calendar and the default family name, a signal
 that is equally true of a freshly cloned Pi, so it needs no mode check.
 
-**Still open, and not this issue's:** the gap between the click and the first board. The worker's
-next tick refreshes the calendars within five minutes, but the brief waits for `brief_time` on the
-family's clock, so a 03:00 sign-up looks at a waiting screen until 06:00. PLAN.md's "**Generate now**
-on signup" line under [Scheduling](#scheduling-cloud-mode) is what closes it, and it is a Phase 2
-worker item — a web request must not call Anthropic.
+**The gap between the click and the first board is closed** (DIN-45). It was the one thing DIN-41
+left: the worker's next tick refreshed the calendars within five minutes, but the brief waited for
+`brief_time` on the family's clock, so a 03:00 sign-up looked at a waiting screen until 06:00.
+`schedule.brief_due` now treats the *first* brief as owed at once — `brief_time` decides when to
+replace yesterday's line, and before the first one there is nothing to replace. Nothing was added
+to make that decision: a payload with no `generated_for_date` is a family that has never had a
+brief, in both stores, and it needed neither a column nor a queue nor a mode check. A web request
+still does not call Anthropic; the worker does, on the next tick, against the same budget. See
+[The first board](#the-first-board).
+
+### The first board
+
+*Built in DIN-45.* The first brief is owed the moment there is a family to write it for, rather than
+at `brief_time`. Every family that has ever signed up has met the old behaviour, because the odds of
+signing up in the hour before six are small — so this was not an edge case, it was the ordinary path.
+
+**The exception belongs in `schedule.brief_due` and nowhere else.** The alternatives were a queue, a
+column, or a call from the sign-up route, and each one would have been a second place that decides
+what a tick owes. The worker's docstring says *nothing about what is owed is decided here*, and that
+is only worth writing if it stays true. So the rule moved instead: `brief_time` is when to **replace**
+yesterday's line, and before the first one there is nothing to replace.
+
+**The signal is exact and it was already stored.** `save_agenda` writes only `store.AGENDA_KEYS`, and
+`PostgresStore.load_payload` adds `generated_for_date` only for a generation with `status = 'ok'`. A
+payload without that key is therefore a family that has never had a brief — never a family whose
+calendars have merely been fetched, which is the state the first tick passes through between its two
+halves. Nothing had to be added to make the question answerable.
+
+**It is a pure change, so a Pi gets it too**, and wanted it: `generate.py --tick` used to write
+nothing at all on a machine set up after dinner. No mode check, and none of the four things mode is
+allowed to gate is involved.
+
+**What it costs is a failing first brief retried around the clock** rather than from `brief_time`
+onwards. The bound is unchanged — the per-family cap of `budget.FAMILY_CALLS_A_DAY`, tripped within
+an hour by a five-minute loop (DIN-43). Charging on the attempt is what makes that true of a revoked
+key as well as a refused one.
+
+**The copy on the waiting screen changed with it**, and had to. `board.html` is byte-identical in
+both modes, and it said "Run `python generate.py` to fill this in" — a Pi's instruction on a hosted
+family's wall panel, and after this the wrong advice on the Pi as well, because the next tick writes
+it. It names no command now, and points at the settings button by name; that button says **Write it
+now** rather than "Rewrite now" when there is nothing written yet, so the two agree. It is the short
+label rather than the clearer one because `.btn` is a fixed `3rem` high and has no second line to
+wrap onto: the half-row it sits in measures **131px on a 375px phone and 103px on a 320px one**,
+against 92px for "Write it now", 95px for "Rewrite now", 118px for "Write the board" and **152px for
+"Write the first board"**. Only the first two survive the small phone.
 
 ### The screen
 
@@ -444,7 +487,9 @@ The board template is shared; only the route that reaches it differs.
 - Synchronous Claude calls; a small thread pool for the fetches. At 1,000 families on the hourly
   default that is 17 fetches a minute and 1,000 API calls a day, spread across the timezones.
 - ~~Fan out via the Batch API~~ — deferred; see the cost model and open questions.
-- **"Generate now"** on signup — a new family sees their dashboard in seconds, not tomorrow
+- ~~**"Generate now"** on signup~~ — done in DIN-45, and by changing what is *owed* rather than by
+  adding a path that generates: the first brief is due at once, so the next tick writes it. A new
+  family sees their board within five minutes, not tomorrow. See [The first board](#the-first-board).
 - Idempotency: unique on `(family_id, generated_for_date)`
 - On failure: keep last-good payload, mark stale, retry on later ticks with backoff, email the
   parent after N consecutive failures
@@ -844,7 +889,7 @@ missing is the multi-tenant half — a schema, auth, and scoping every read and 
 
 - [x] Worker process: the 5-minute tick over every family that is due, per the scheduling section. Running since 8 September; `worker/` and `tests/test_worker.py`.
 - [x] Calendar refresh and daily brief as separate operations, each recorded (`agendas`, `generations`) *(DIN-17, DIN-28)*
-- [x] "Generate now" and "Refresh calendars" for onboarding and manual use — both on the settings home, and both work in cloud mode. **What is still missing is "Generate now" *on signup*:** a family who signs up at 03:00 sees the waiting screen until their `brief_time`, because the brief is not due before then.
+- [x] "Generate now" and "Refresh calendars" for onboarding and manual use — both on the settings home, and both work in cloud mode. **"Generate now" *on signup* is done too** *(DIN-45)*: a family who signs up at 03:00 no longer waits for `brief_time`, because the first brief is owed at once rather than in the morning. See [The first board](#the-first-board).
 - [x] Per-family daily idempotency on the brief — `schedule.due` asks for one brief per local day and `generations` is unique on `(family_id, generated_for_date)`, so a second write for a day replaces rather than adds
 - [x] Per-family and **global** spend caps with a hard breaker *(DIN-43)*. See [The spend breaker](#the-spend-breaker). "Rewrite now" is charged against the same budget as the worker, because it is the same money.
 - [ ] Keep-last-good on failure; retry with backoff on later ticks; consecutive-failure tracking; parent notification after N

--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ the same file, and the UI keeps your comments.
 
 ```
 [cron every 5m] → generate.py --tick → every hour: re-fetches every iCal feed, in time order
-                                     → once a day at 06:00: builds the prompt, calls Claude
+                                     → once a day at 06:00 (and at once on the first run):
+                                       builds the prompt, calls Claude
                                      → saves dashboard_data.json
 
 [browser]       → web/routes/board.py → recomputes chores, countdowns and today's agenda

--- a/dinkydash/CLAUDE.md
+++ b/dinkydash/CLAUDE.md
@@ -253,6 +253,17 @@ Three rules hold this together:
   due when `generated_for_date` is not today *in the family's timezone* and the local clock has
   passed `brief_time`; a refresh is due when `calendars_fetched_at` is missing or older than
   `refresh_minutes`.
+- **The first brief is the one exception, and it is owed at once** (DIN-45). `brief_time` decides
+  when to *replace* yesterday's line, and before the first one there is nothing to replace — a
+  family with no `generated_for_date` at all has the waiting screen on the wall, which is not a
+  board at any hour. So a sign-up at 03:00 gets a board on the worker's next tick rather than at
+  06:00, and a freshly cloned Pi gets one from its first `--tick` rather than the next morning.
+  The condition is exact and needs no mode check and no new column: `save_agenda` writes only
+  `AGENDA_KEYS` and `PostgresStore.load_payload` adds `generated_for_date` only for a successful
+  generation, so the key is absent for a family that has never had a brief and present for one
+  whose calendars have merely been fetched. What it costs is that a *failing* first brief now
+  retries around the clock instead of from `brief_time`; the bound is the same one as before, which
+  is `budget.FAMILY_CALLS_A_DAY`.
 - **A refresh must not touch `headline`, `note` or `generated_for_date`**, and it now cannot: it
   writes through `store.save_agenda`, which only accepts `store.AGENDA_KEYS`. A fresh agenda under
   yesterday's brief is exactly the amber-banner state `board.build_view` already handles, and the

--- a/dinkydash/schedule.py
+++ b/dinkydash/schedule.py
@@ -7,7 +7,9 @@ Pi's cron tick and (later) a worker loop walking every family.
 The two cadences differ because their costs do. Re-fetching the calendars is a
 few HTTP requests and happens every `refresh_minutes`, which is what puts an
 appointment added at 09:00 onto the wall the same day. The brief is an API
-call and happens once a day, after `brief_time` on the family's own clock.
+call and happens once a day, after `brief_time` on the family's own clock —
+**except the first one, which is owed the moment there is a family to write it
+for** (DIN-45).
 
 A brief that fails is simply due again on the next tick. That is the retry.
 """
@@ -52,9 +54,32 @@ def refresh_due(config, payload, now):
 
 
 def brief_due(config, payload, now):
-    """True when today has no brief yet and the family's clock has passed `brief_time`."""
+    """True when today has no brief yet and the family's clock has passed `brief_time`.
+
+    **The first brief does not wait for the morning** (DIN-45). `brief_time`
+    decides when to replace yesterday's line, and there is nothing to replace
+    before the first one: a family with no brief at all has the waiting screen
+    on the wall, which is not a board at any hour. Somebody who signs up at
+    03:00 would otherwise look at it until 06:00, and that is the whole of
+    their first impression of the product.
+
+    **The signal is exact, and it is the same one in both stores.**
+    `save_agenda` writes only the agenda keys and `PostgresStore.load_payload`
+    adds `generated_for_date` only when a successful generation exists, so a
+    payload without that key is a family that has never had a brief rather
+    than one whose calendars have merely been fetched. It needs no mode check
+    and no new column: a freshly cloned Pi is in the same state, and gets the
+    same answer from its first `generate.py --tick`.
+
+    A first brief that keeps *failing* is therefore retried on every tick,
+    around the clock rather than from `brief_time` onwards. The bound is
+    unchanged and is the per-family spend cap, which a five-minute loop trips
+    within an hour (`budget.FAMILY_CALLS_A_DAY`).
+    """
+    if not payload.get("generated_for_date"):
+        return True
     local = now.astimezone(tzinfo_for(config))
-    if payload.get("generated_for_date") == local.date().isoformat():
+    if payload["generated_for_date"] == local.date().isoformat():
         return False
     return local.time() >= brief_time(config)
 

--- a/doc/running-it.md
+++ b/doc/running-it.md
@@ -20,6 +20,10 @@ buys nothing: Google's secret `.ics` link is cached at their end and can lag by 
 the only part that costs money. The same page changes the hour. A brief that fails is simply
 owed again five minutes later, so a network blip at dawn no longer means a day-old line.
 
+**The very first one does not wait for the morning.** That hour says when to replace yesterday's
+line, and on a board nobody has generated yet there is nothing to replace — so a Pi set up after
+dinner writes its board on the next tick rather than showing "Writing … first board" all evening.
+
 Both write atomically to `dashboard_data.json`, and a refresh never touches the written line.
 
 The browser does the rest of the work on every render: ages, countdowns, whose turn it is, and
@@ -35,7 +39,7 @@ so today's times are still there and still right.
 |---|---|---|
 | The board, no banner | Today's run succeeded | Nothing |
 | An amber banner across the top | Today's brief failed or hasn't happened yet. Times, turns and countdowns are still today's; only the written line is older, and it is labelled | Nothing — the next tick retries. Check `generate.log` if it stays. Press **Rewrite now** in settings to force it |
-| "Writing … first board" | Nothing has ever been generated | Press **Rewrite now**, or run `python generate.py` |
+| "Writing … first board" | Nothing has ever been generated | Nothing — the next tick writes it, whatever the hour. Press **Write it now** in settings if you'd rather not wait |
 
 The board never blanks itself. A failed run leaves the previous one up rather than clearing the
 screen, on the grounds that a stale kitchen board beats an empty one.

--- a/tests/test_board.py
+++ b/tests/test_board.py
@@ -6,6 +6,8 @@ countdowns on the wall are still *today's* — only the written line is old.
 
 from datetime import date
 
+import pytest
+
 from dinkydash.board import build_view, computed_headline
 
 CONFIG = {
@@ -246,3 +248,36 @@ class TestReloadInterval:
     def test_an_unreadable_interval_falls_back_to_five_minutes(self):
         config = dict(CONFIG, refresh_minutes="hourly")
         assert build_view(config, payload("2026-09-03"), TODAY)["reload_seconds"] == 300
+
+
+class TestTheWaitingScreen:
+    """What a family reads before their first board arrives.
+
+    `board.html` is rendered from the same file in both modes and
+    `tests/test_cloud_mode.py` asserts the two are byte-identical, so anything
+    written here has to be true of a Raspberry Pi *and* of a wall panel in a
+    kitchen. It used to say "Run `python generate.py`", which was a Pi's
+    instruction on a hosted family's screen and, since DIN-45, the wrong advice
+    on the Pi too — the next tick writes it either way.
+    """
+
+    @pytest.fixture
+    def page(self, tmp_path):
+        from dinkydash.store import FileStore
+        from tests.conftest import client_for
+        from web import create_app
+
+        path = tmp_path / "config.yaml"
+        path.write_text('family_name: "The Wilsons"\ntimezone: "Europe/Berlin"\n')
+        client = client_for(create_app(FileStore(path)))
+        return client.get("/").get_data(as_text=True)
+
+    def test_it_is_the_waiting_screen(self, page):
+        assert "first board" in page
+
+    def test_it_names_no_command(self, page):
+        # A parent reading this has no shell, and after DIN-45 nobody needs one.
+        assert "generate.py" not in page
+
+    def test_it_names_the_button_the_settings_page_actually_has(self, page):
+        assert "Write it now" in page

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -415,6 +415,45 @@ class TestTick:
         assert payload["events"] == EVENTS
         assert payload["headline"] == "Big morning"
 
+    def test_the_first_tick_does_not_wait_for_the_brief_time(self, home, monkeypatch, api_key):
+        """DIN-45, end to end and at the hour that used to fail.
+
+        01:00 UTC is 03:00 Berlin, three hours before `brief_time`. This is a
+        family who signed up in the night, or a Pi somebody set up after
+        dinner: what they have on the wall is the waiting screen, and one
+        tick has to replace it. Before this the tick refreshed the calendars
+        and went back to sleep until 06:00.
+        """
+        monkeypatch.setattr(runner, "fetch_events", fake_fetch(EVENTS, OK_STATUS))
+        client = FakeClient()
+        monkeypatch.setattr(cli, "write_brief",
+                            lambda config, store, **kw: runner.write_brief(
+                                config, store, client=client, **kw))
+        assert self.run_tick(home, monkeypatch, datetime(2026, 9, 3, 1, tzinfo=timezone.utc)) == 0
+        payload = stored(home)
+        assert payload["headline"] == "Big morning"
+        # Written for the family's day, not the server's — and the fetch
+        # happened first, so the first brief is about a real agenda.
+        assert payload["generated_for_date"] == "2026-09-03"
+        assert payload["events"] == EVENTS
+
+    def test_the_next_tick_after_it_is_quiet_again(self, home, monkeypatch):
+        """The exception is for the first board only, not a standing licence.
+
+        Five minutes after the tick above, with the brief written and the
+        calendars just fetched, nothing may be owed — or a family who signed
+        up at 03:00 would be paying for a brief every five minutes until dawn.
+        """
+        write_stored(home, {"generated_for_date": "2026-09-03",
+                            "calendars_fetched_at": "2026-09-03T01:00:00+00:00",
+                            "headline": "Written in the night", "note": "…",
+                            "events": EVENTS})
+        monkeypatch.setattr(cli, "refresh_calendars", refuse("the fetch"))
+        monkeypatch.setattr(cli, "write_brief", refuse("the model call"))
+        assert self.run_tick(home, monkeypatch,
+                             datetime(2026, 9, 3, 1, 5, tzinfo=timezone.utc)) == 0
+        assert stored(home)["headline"] == "Written in the night"
+
     def test_tick_and_date_are_refused(self, home):
         with pytest.raises(SystemExit):
             cli.main(["--tick", "--date", "2026-12-24", "--config", str(home / "config.yaml")])

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -37,17 +37,56 @@ class TestFirstRun:
         # Nothing has ever been stored, so there is nothing to be stale.
         assert due(BERLIN, None, utc("2026-09-03 01:00"))["refresh"] is True
 
-    def test_no_payload_before_the_brief_time_owes_only_the_fetch(self):
-        # 03:00 Berlin. The agenda can be fetched now; the brief waits for 06:00
-        # rather than landing on the wall in the middle of the night.
+    def test_no_payload_before_the_brief_time_owes_both_anyway(self):
+        # 03:00 Berlin, and the first board does not wait for 06:00 (DIN-45).
+        # Somebody who signed up in the night has the waiting screen on the
+        # wall, and that is not a board at any hour.
         owed = due(BERLIN, None, utc("2026-09-03 01:00"))
-        assert owed == {"refresh": True, "brief": False}
+        assert owed == {"refresh": True, "brief": True}
 
     def test_no_payload_after_the_brief_time_owes_both(self):
         assert due(BERLIN, None, utc("2026-09-03 07:00")) == {"refresh": True, "brief": True}
 
     def test_an_empty_payload_is_the_same_as_none(self):
         assert due(BERLIN, {}, utc("2026-09-03 07:00")) == {"refresh": True, "brief": True}
+
+
+class TestTheFirstBrief:
+    """DIN-45: a family that has never had one is owed it now, not at `brief_time`.
+
+    The condition is "the payload holds no `generated_for_date`", which both
+    stores produce for exactly one situation — no successful generation. A
+    calendar refresh does not clear it, and that is the pair of cases below.
+    """
+
+    @pytest.mark.parametrize("moment", ["2026-09-03 01:00",   # 03:00 Berlin
+                                        "2026-09-03 22:30",   # 00:30, the next day
+                                        "2026-09-03 12:00"])  # 14:00, an ordinary afternoon
+    def test_it_is_owed_at_any_hour(self, moment):
+        assert brief_due(BERLIN, {}, utc(moment)) is True
+
+    def test_a_fetched_agenda_is_not_a_brief(self):
+        # The worker's first tick refreshes and writes, in that order. Between
+        # the two the payload holds an agenda and nothing else, and that must
+        # still read as "no brief" or the board it just fetched for stays blank.
+        stored = payload(fetched="2026-09-03T01:00:00+00:00")
+        assert brief_due(BERLIN, stored, utc("2026-09-03 01:00")) is True
+
+    def test_once_the_first_one_is_written_the_next_waits_for_the_morning(self):
+        # The guard against "always due": having written one, the ordinary
+        # rule is back and tomorrow's line waits for 06:00 Berlin.
+        stored = payload(generated_for="2026-09-03")
+        assert brief_due(BERLIN, stored, utc("2026-09-03 22:30")) is False  # 00:30 on the 4th
+        assert brief_due(BERLIN, stored, utc("2026-09-04 03:59")) is False  # 05:59
+        assert brief_due(BERLIN, stored, utc("2026-09-04 04:00")) is True   # 06:00
+
+    def test_the_timezone_still_decides_which_day_it_is(self):
+        # 18:00 UTC on the 14th is 06:00 on the 15th in Auckland. A family with
+        # no brief is owed one either way, and the one written for the 15th
+        # then holds — the first-run exception must not outlive the first run.
+        assert brief_due(AUCKLAND, {}, utc("2026-06-14 17:59")) is True
+        assert brief_due(AUCKLAND, payload(generated_for="2026-06-15"),
+                         utc("2026-06-14 18:00")) is False
 
 
 class TestRefresh:

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -231,12 +231,33 @@ class TestTheClockOnTheStatusLine:
         assert "Calendars refreshed 18:00" in client.get("/settings/").get_data(as_text=True)
 
     def test_an_agenda_with_no_brief_yet_is_still_waiting(self, client, board, today):
-        # The state after a first `--tick` before brief_time: events, no words.
+        # Events, no words. Since DIN-45 a first tick writes both, so this is
+        # the state between the two halves of one — or after a brief that
+        # failed. Either way the page must not claim a board it hasn't got.
         board({"calendars_fetched_at": f"{today}T05:00:00+00:00", "events": []})
         page = client.get("/settings/").get_data(as_text=True)
         assert "No board has been generated yet." in page
         assert "Calendars refreshed 10:30" in page
         assert "from None" not in page
+
+    def test_the_button_offers_a_first_board_rather_than_a_rewrite(self, client, board, today):
+        """The waiting screen points at this button by name, so they must agree.
+
+        "Rewrite now" is the wrong word for a board nobody has written, and
+        `board.html` — which is byte-identical in both modes — tells a family
+        to press "Write it now" (DIN-45).
+        """
+        board({"calendars_fetched_at": f"{today}T05:00:00+00:00", "events": []})
+        page = client.get("/settings/").get_data(as_text=True)
+        assert "Write it now" in page
+        assert "Rewrite now" not in page
+
+    def test_and_goes_back_to_a_rewrite_once_there_is_one(self, client, board, today):
+        board({"generated_for_date": today, "generated_at": f"{today}T04:00:00+00:00",
+               "headline": "Hi", "note": "There", "events": []})
+        page = client.get("/settings/").get_data(as_text=True)
+        assert "Rewrite now" in page
+        assert "Write it now" not in page
 
     def test_an_unreadable_stamp_does_not_break_the_page(self, client, board, today):
         board({"generated_for_date": today, "generated_at": "who knows",

--- a/web/CLAUDE.md
+++ b/web/CLAUDE.md
@@ -116,6 +116,15 @@ single-column layout (an iPad in portrait) has no side column to hide behind and
 full price, around 13-18%. Everything fits at all three sizes in every case. Raising either
 constant spends more type size, so measure at `/preview` before you do.
 
+**The waiting screen may not name a command, and that is a mode rule rather than a style one.**
+`board.html` is one file rendered by both modes and `tests/test_cloud_mode.py` asserts the two are
+byte-identical, so `python generate.py` on it was a Pi's instruction sitting on a hosted family's
+wall panel — where nobody has a shell, and where the token in the address bar is the only thing
+that page is for. Since DIN-45 the first brief is owed at once, so what it says instead is true in
+both: the next tick writes it. It points at the settings button by name, and that button reads
+**Write it now** rather than "Rewrite now" while `status.state == "waiting"`, so the two
+agree; `tests/test_board.py` and `tests/test_settings.py` fail if they stop.
+
 In two-column mode the body is a grid, and **the note sits under the agenda, not across the
 bottom**. The agenda is short on a quiet day while chores plus countdowns are not, so a full-width
 note left the lower left quarter of an 800x480 panel empty. Under the agenda it balances the two

--- a/web/routes/settings.py
+++ b/web/routes/settings.py
@@ -219,7 +219,12 @@ def home():
     payload = current_store().load_payload(config)
 
     tzinfo = config_module.tzinfo_for(config)
-    status = {"state": "waiting", "detail": "No board has been generated yet."}
+    # "The next run" rather than a number of minutes: it is a worker tick in
+    # cloud mode and a cron line on a Pi, and only one of those is ours to
+    # promise. Either way the first brief is owed at once rather than at
+    # `brief_time` (DIN-45), so there is no morning to wait for.
+    status = {"state": "waiting",
+              "detail": "No board has been generated yet. The next run writes it."}
     if payload:
         generated_for = payload.get("generated_for_date")
         written = _clock(payload.get("generated_at"), tzinfo)

--- a/web/templates/board.html
+++ b/web/templates/board.html
@@ -268,9 +268,16 @@
     <div class="family">DinkyDash</div>
     <div class="waiting-head">Writing {{ view.family_name or "your" }}{{ "'s" if view.family_name else "" }} first board&hellip;</div>
     <div class="bar"><span></span></div>
+    {# Named no command since DIN-45. This template is byte-identical in both
+       modes, so an instruction to run `python generate.py` was a Pi's
+       instruction on a hosted family's wall panel — and it is no longer the
+       thing to do in either: the first brief is owed at once, so the next
+       tick writes it. The button below is the same in both modes and is
+       there for somebody who would rather not wait for one. #}
     <div class="waiting-sub">
-        Run <strong>python generate.py</strong> to fill this in, or open the settings
-        page and press &ldquo;Rewrite now&rdquo;. This page refreshes itself.
+        The next run writes it, usually within a few minutes, and this page fills
+        itself in. To have it now, open the settings page and press
+        &ldquo;Write it now&rdquo;.
     </div>
 </div>
 

--- a/web/templates/settings/home.html
+++ b/web/templates/settings/home.html
@@ -53,9 +53,14 @@
         </form>
         <div style="display:flex;gap:0.625rem;">
             <a class="btn outline" style="flex:1;" href="{{ board_link }}">{{ icons.screen() }} View board</a>
+            {# "Rewrite" is the wrong word when there is nothing written yet,
+               and the waiting screen on the board points at this button by
+               name, so the two have to agree (DIN-45). #}
             <form class="inline-form" method="post" action="{{ url_for('settings.generate_now') }}" style="flex:1;">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                <button class="btn outline" type="submit">Rewrite now</button>
+                <button class="btn outline" type="submit">
+                    {{ "Write it now" if status.state == "waiting" else "Rewrite now" }}
+                </button>
             </form>
         </div>
     </div>


### PR DESCRIPTION
A family is created when the emailed link is clicked, but the brief then waited for `brief_time` on their own clock — so signing up at 03:00 meant looking at the waiting screen until 06:00, which was every new family's first impression (DIN-45).

`schedule.brief_due` now treats the *first* brief as owed at once: `brief_time` decides when to **replace** yesterday's line, and before the first one there is nothing to replace. Nothing was added to decide that — a payload with no `generated_for_date` already meant "has never had a brief" in both stores, so the worker's existing tick answers it with no queue, no column, and no call to Anthropic from a web request; being pure, a Pi set up after dinner gets a board that evening too. The one cost is that a *failing* first brief now retries around the clock rather than from `brief_time`, bounded by the same per-family cap of twelve calls a day (DIN-43).

The copy went with it: `board.html` is byte-identical in both modes and told a hosted family's wall panel to "Run `python generate.py`", so it now names no command and points at the settings button, which reads **Write it now** rather than "Rewrite now" when nothing is written — the short label because the half-row it sits in measures 131px on a 375px phone against 152px for "Write the first board". 821 tests pass against Postgres and 568 pass as a self-hoster runs them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
