### PR TITLE
Consolidate auth and URL handling and simplify app setup

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -2,7 +2,8 @@
 
 *Last updated: September 8, 2026. Supersedes `HOSTING_ANALYSIS.md` (deleted — it predated both the AI generation feature and the July 2026 calendar-display repositioning, and its recommended stack and data model no longer matched the product).*
 
-*September 8, newest: **a new family gets a board within five minutes, at any hour** (DIN-45). The one thing DIN-41 left behind: the brief waited for `brief_time`, so signing up at 03:00 meant a waiting screen until 06:00 — which is most of the day, and was every family's first impression. `schedule.brief_due` now treats the **first** brief as owed at once, because `brief_time` is when to replace yesterday's line and there is nothing to replace before the first one. No queue, no column, no call to Anthropic from a web request: a payload with no `generated_for_date` already meant "never had a brief" in both stores, so the worker's existing tick answers it. Pure, so a Pi set up after dinner gets a board that evening too. See [The first board](#the-first-board).*
+*September 8: the first brief is due immediately in both modes (DIN-45).
+See [The first board](#the-first-board).*
 
 *September 8, last: **the multi-tenancy is real** (DIN-39). `web/family.py` builds one `PostgresStore` per request from the family on the session, over a pool built once per process; `create_app` holds no store at all in cloud mode, and the environment variable that used to name "the" family is deleted from the code, the app spec and the docs. Nothing a caller can send — path segment, query parameter, form field or header — reaches a query as a family selector, which is a stronger property than checking an id against the session. The ids that do appear in URLs are item ids inside one family's config document, and another family's is not in the list: `tests/test_tenancy.py` walks every section and every write route and asserts a 404, never a 403. **Phase 1's "done when" is met.** `login_link.py` prints a sign-in link without waiting on email, because the preview and the support inbox both need one.*
 
@@ -145,8 +146,9 @@ recent_notes  / record_note
 
 One object with those six methods, in `dinkydash/store.py`. `FileStore` is what
 exists now, gathered up; `PostgresStore` is the cloud one. The runner, the board
-route and the settings routes take a store and never learn which — `create_app`
-accepts one, and every route reads `app.config["STORE"]`. In single mode the
+route and the settings routes use the same storage interface. `create_app`
+accepts a store in single mode or a shared pool in cloud mode; routes call
+`web.family.current_store()` to get the store for their authenticated family. In single mode the
 payload is `dashboard_data.json`. In cloud mode it is composed from two rows —
 the brief in `generations`, the fetched calendar window in `agendas` — and
 comes back as the same dict.
@@ -177,10 +179,9 @@ sweep that already deletes expired tokens is the cleanup. It also makes "signing
 *is* email verification" true of sign-up as well — otherwise a family exists for an address nobody
 has proved they can read.
 
-That is a rate limit's worth of protection and not a cap. The cap is the **global spend breaker**,
-which is Phase 2 and still to come. A CAPTCHA is deliberately last: it puts a third-party script on
-the page where a parent types their email, and friction on the one conversion step that matters, so
-it waits until abuse actually appears.
+The **global spend breaker** now caps model calls (DIN-43). A CAPTCHA is deliberately last: it puts
+a third-party script on the page where a parent types their email, and friction on the one
+conversion step that matters, so it waits until abuse actually appears.
 
 **The cost was a schema change, and it bought one table rather than two.** `login_tokens.user_id` is
 now nullable, with an `email` column beside it and a CHECK that exactly one of the two is set. A
@@ -197,52 +198,22 @@ else's appointments on a stranger's wall. The settings home says so while the bo
 untouched, which is `settings.looks_untouched` — no calendar and the default family name, a signal
 that is equally true of a freshly cloned Pi, so it needs no mode check.
 
-**The gap between the click and the first board is closed** (DIN-45). It was the one thing DIN-41
-left: the worker's next tick refreshed the calendars within five minutes, but the brief waited for
-`brief_time` on the family's clock, so a 03:00 sign-up looked at a waiting screen until 06:00.
-`schedule.brief_due` now treats the *first* brief as owed at once — `brief_time` decides when to
-replace yesterday's line, and before the first one there is nothing to replace. Nothing was added
-to make that decision: a payload with no `generated_for_date` is a family that has never had a
-brief, in both stores, and it needed neither a column nor a queue nor a mode check. A web request
-still does not call Anthropic; the worker does, on the next tick, against the same budget. See
-[The first board](#the-first-board).
-
 ### The first board
 
-*Built in DIN-45.* The first brief is owed the moment there is a family to write it for, rather than
-at `brief_time`. Every family that has ever signed up has met the old behaviour, because the odds of
-signing up in the hour before six are small — so this was not an edge case, it was the ordinary path.
+*Built in DIN-45.* `schedule.brief_due` owes the first brief immediately. This prevents a sign-up
+before `brief_time` from waiting until morning. The existing cloud worker attempts it on its next
+five-minute tick; self-hosters get it on their next cron tick.
 
-**The exception belongs in `schedule.brief_due` and nowhere else.** The alternatives were a queue, a
-column, or a call from the sign-up route, and each one would have been a second place that decides
-what a tick owes. The worker's docstring says *nothing about what is owed is decided here*, and that
-is only worth writing if it stays true. So the rule moved instead: `brief_time` is when to **replace**
-yesterday's line, and before the first one there is nothing to replace.
+The signal is an absent `generated_for_date`. Fetching calendars alone leaves it absent in both
+stores; a successful generation supplies it. This keeps scheduling in one pure function without
+adding a queue, a database column or a model call to signup. Later briefs follow `brief_time` in
+the family's timezone.
 
-**The signal is exact and it was already stored.** `save_agenda` writes only `store.AGENDA_KEYS`, and
-`PostgresStore.load_payload` adds `generated_for_date` only for a generation with `status = 'ok'`. A
-payload without that key is therefore a family that has never had a brief — never a family whose
-calendars have merely been fetched, which is the state the first tick passes through between its two
-halves. Nothing had to be added to make the question answerable.
+Failed first briefs remain due on every tick. Cloud attempts are bounded by
+`budget.FAMILY_CALLS_A_DAY`; self-hosters use their own API key without this cap.
 
-**It is a pure change, so a Pi gets it too**, and wanted it: `generate.py --tick` used to write
-nothing at all on a machine set up after dinner. No mode check, and none of the four things mode is
-allowed to gate is involved.
-
-**What it costs is a failing first brief retried around the clock** rather than from `brief_time`
-onwards. The bound is unchanged — the per-family cap of `budget.FAMILY_CALLS_A_DAY`, tripped within
-an hour by a five-minute loop (DIN-43). Charging on the attempt is what makes that true of a revoked
-key as well as a refused one.
-
-**The copy on the waiting screen changed with it**, and had to. `board.html` is byte-identical in
-both modes, and it said "Run `python generate.py` to fill this in" — a Pi's instruction on a hosted
-family's wall panel, and after this the wrong advice on the Pi as well, because the next tick writes
-it. It names no command now, and points at the settings button by name; that button says **Write it
-now** rather than "Rewrite now" when there is nothing written yet, so the two agree. It is the short
-label rather than the clearer one because `.btn` is a fixed `3rem` high and has no second line to
-wrap onto: the half-row it sits in measures **131px on a 375px phone and 103px on a 320px one**,
-against 92px for "Write it now", 95px for "Rewrite now", 118px for "Write the board" and **152px for
-"Write the first board"**. Only the first two survive the small phone.
+The shared waiting screen points to **Write it now** in settings, which becomes **Rewrite now**
+after the first brief. Keep these short labels: the button has 103px of space on a 320px phone.
 
 ### The screen
 

--- a/dinkydash/CLAUDE.md
+++ b/dinkydash/CLAUDE.md
@@ -17,8 +17,9 @@ recent_notes(config, days)   record_note(config, entry, keep)
 Both implementations exist. `FileStore(config_path)` is `config.yaml` and two JSON files in one
 directory. `PostgresStore(pool, family_id)` is the same six operations against rows, with the
 payload composed from `generations` (the brief) and `agendas` (the fetched window) and handed back
-as the same dict. The runner, the board route and the settings routes all take a store;
-`create_app(store=None)` builds one and every route reads `app.config["STORE"]`.
+as the same dict. The runner takes a store; web routes get theirs from
+`web.family.current_store()`. `create_app(store=None, *, pool=None)` accepts a store in single
+mode or a pool in cloud mode. Cloud stores are scoped to the authenticated request.
 
 Four rules keep it a seam rather than a name:
 
@@ -91,10 +92,11 @@ are load-bearing, and each is asserted in `tests/test_auth.py`:
 - **Expired, spent and never-issued are one answer.** `consume_link` returns `None` for all three,
   so there is nothing for a caller to leak by accident.
 
-The per-address rate limit lives in the same `INSERT` — at most `MOST_LIVE_LINKS` unexpired tokens
-per user — so two requests arriving together cannot both read "two live links" and both make a
-third. The per-IP half is in `web/ratelimit.py` and is in-process, because a database write on
-every unauthenticated request is itself something to flood.
+Login and signup share `_issue_link`: at most `MOST_LIVE_LINKS` unexpired tokens per subject,
+including used tokens. A transaction advisory lock serialises issuance for the user id or normalised
+signup email. Acquire it before the INSERT so READ COMMITTED sees the previous issuer's commit;
+putting the count inside an INSERT alone does not prevent concurrent requests exceeding the limit.
+The per-IP limit in `web/ratelimit.py` is in-process.
 
 **Sign-up is the same token and the same `consume_link`** (DIN-41). An address with no account gets
 a row carrying the address instead of a `user_id`; spending it creates the family, the parent and a
@@ -246,24 +248,15 @@ calendars are fetched just redraws the same thing. A parent picks "how soon does
 not a browser knob — so there is no separate setting for it and the template reads
 `view.reload_seconds` rather than deciding.
 
-Three rules hold this together:
+These rules hold this together:
 
 - **`due()` is pure and takes `now` as an aware datetime.** No clock, no I/O. That is what lets the
   same function drive a Pi's cron tick and, later, a worker loop walking every family. A brief is
   due when `generated_for_date` is not today *in the family's timezone* and the local clock has
   passed `brief_time`; a refresh is due when `calendars_fetched_at` is missing or older than
   `refresh_minutes`.
-- **The first brief is the one exception, and it is owed at once** (DIN-45). `brief_time` decides
-  when to *replace* yesterday's line, and before the first one there is nothing to replace — a
-  family with no `generated_for_date` at all has the waiting screen on the wall, which is not a
-  board at any hour. So a sign-up at 03:00 gets a board on the worker's next tick rather than at
-  06:00, and a freshly cloned Pi gets one from its first `--tick` rather than the next morning.
-  The condition is exact and needs no mode check and no new column: `save_agenda` writes only
-  `AGENDA_KEYS` and `PostgresStore.load_payload` adds `generated_for_date` only for a successful
-  generation, so the key is absent for a family that has never had a brief and present for one
-  whose calendars have merely been fetched. What it costs is that a *failing* first brief now
-  retries around the clock instead of from `brief_time`; the bound is the same one as before, which
-  is `budget.FAMILY_CALLS_A_DAY`.
+- **The first brief is due immediately** when `generated_for_date` is absent. Calendar-only
+  payloads still qualify. See [The first board](../PLAN.md#the-first-board) for retry behaviour.
 - **A refresh must not touch `headline`, `note` or `generated_for_date`**, and it now cannot: it
   writes through `store.save_agenda`, which only accepts `store.AGENDA_KEYS`. A fresh agenda under
   yesterday's brief is exactly the amber-banner state `board.build_view` already handles, and the

--- a/dinkydash/accounts.py
+++ b/dinkydash/accounts.py
@@ -1,57 +1,9 @@
-"""Users, the links that sign them in, and the families those links create.
-Cloud mode only.
+"""Cloud accounts and magic links.
 
-    normalise(email)                 -> the address as it is compared
-    user_for(pool, email)            -> (user_id, family_id), or None
-    issue_link(pool, user_id)        -> the plaintext token, or None if limited
-    issue_signup_link(pool, email)   -> the same, for an address with no account
-    consume_link(pool, token)        -> (user_id, family_id), or None
-    sweep(pool)                      -> how many dead tokens were deleted
-
-One email in, one link out, one session (PLAN.md phase 1). Signing in through
-the link *is* email verification: there is no second step, no password, and
-nothing to reset.
-
-**Sign-up is the same act, and the same token** (DIN-41). An address with no
-account gets a token carrying the address instead of a user id; spending it
-creates the family and the user and signs them in. There is one `consume_link`
-because single use is the property everything else rests on, and a second copy
-of that statement is a second thing to keep right.
-
-**The family is created when the link is clicked, never when the address is
-submitted.** A `families` row starts a 14-day trial and the worker calls
-Anthropic daily for it, so creating one on an unverified POST would let a
-script run up a real bill with no card behind it. This way an unverified
-sign-up costs one token row and one email, and the existing sweep is already
-the cleanup. It is a rate limit's worth of protection rather than a cap: the
-cap is the global spend breaker, which is PLAN.md phase 2 and still to come.
-
-**Only the hash is stored.** The plaintext exists for the length of one email
-and is never written anywhere else — not to a row, not to a log line, not into
-an exception message. Whoever reads the database gets 64 characters of SHA-256
-and no way back to a working link.
-
-**SHA-256, not a slow KDF.** A password is low-entropy and needs bcrypt or
-argon2 to make guessing expensive. This token is 32 random bytes from
-`secrets`, so there is nothing to guess and a slow hash would only make every
-login slower. What matters instead is that the lookup cannot be walked, and it
-cannot: an attacker would have to invert SHA-256 to control the value being
-matched.
-
-**Single use is one statement.** `UPDATE ... WHERE used_at IS NULL AND
-expires_at > now() RETURNING` decides and marks in the same breath, so two
-clicks on one link — or a mail scanner following it a second before the person
-does — cannot both come back with a user. A read-then-write would let both
-through, and it would look correct in every test that ran them in order.
-
-**Time comes from Postgres, never from Python.** `now()` is the transaction's
-clock, one clock for however many web instances, and it cannot drift out of
-step with the row it is being compared to.
-
-This module imports no psycopg — it is handed a pool and asks it for
-connections — so the rule that `pgstore.py` and `db.py` are the only files
-importing the driver still holds. It is not part of the engine either: nothing
-under the `generate()` boundary knows that users exist.
+Only SHA-256 hashes of random tokens are stored. Consuming a link verifies the
+mailbox; a signup creates its family in that same transaction. Unexpired
+tokens count toward the email limit even after use. See dinkydash/CLAUDE.md
+for the authentication invariants and PLAN.md for the design rationale.
 """
 
 import hashlib
@@ -64,55 +16,17 @@ from . import config as config_module
 
 log = logging.getLogger(__name__)
 
-# How long a link works. Short because a link is a bearer credential and its
-# whole defence is not being around long.
 TOKEN_TTL = timedelta(minutes=15)
-
-# 32 bytes of entropy, url-safe, which is 43 characters. Long enough that
-# enumeration is not a thing; short enough to survive a mail client wrapping
-# a line.
 TOKEN_BYTES = 32
-
-# The per-person rate limit, and it is a spend control as much as a security
-# one: every request sends an email on an account whose sender reputation is
-# shared with KeepTheScore.
-#
-# Counted as "unexpired links", which has two consequences worth stating
-# because both have been misread:
-#
-# * the sweep cannot affect it — a row it deletes is one this no longer counts;
-# * **a used link still counts.** Spending one does not free a slot. The limit
-#   is on emails sent in a window, and the email went whatever happened next.
 MOST_LIVE_LINKS = 3
-
-# Anything longer than a real token is not one, and there is no reason to hash
-# it to find that out. A URL can carry a great deal.
 LONGEST_TOKEN = 200
-
-# What `users.email` and `login_tokens.email` both allow, and the longest an
-# address can be under RFC 5321. Checked here rather than left to the column,
-# because a CHECK violation is a 500 on a route anybody can post to.
 LONGEST_EMAIL = 320
-
-# The trial, in the app rather than in Stripe (PLAN.md decisions 6 and phase 4):
-# a family that never converts never becomes a Stripe customer.
 TRIAL = timedelta(days=14)
-
-# How many times to try for an unused screen token before giving up. 12
-# characters of `config.ID_ALPHABET` is about 59 bits, so a collision is not
-# something anyone will see — but the column is UNIQUE, and an unhandled
-# violation here would spend somebody's sign-up link and hand them a 500. Three
-# tries costs nothing and turns an astronomically rare 500 into a retry.
 SCREEN_TOKEN_TRIES = 3
 
 
 def normalise(email):
-    """The address as it is compared and stored: trimmed and lower-cased.
-
-    Email local parts are case-sensitive to the letter of the RFC and to
-    nobody's mail server. A parent who types their address with a capital on
-    Tuesday has to get in on Wednesday.
-    """
+    """The address as it is compared and stored: trimmed and lower-cased."""
     return (email or "").strip().lower()
 
 
@@ -126,14 +40,7 @@ def hash_token(token):
 
 
 def user_for(pool, email):
-    """Who that address belongs to, or None.
-
-    Compared with `lower()` on both sides rather than trusting how the row was
-    written, because a user created by hand or by an import is not this
-    module's doing. `users` holds one row per family, so the scan this costs is
-    not worth a functional index yet — when it is, the index is
-    `(lower(email))` and this query is already shaped for it.
-    """
+    """Return (user_id, family_id) for an address, or None."""
     address = normalise(email)
     if not address:
         return None
@@ -146,81 +53,48 @@ def user_for(pool, email):
 
 
 def issue_link(pool, user_id, ttl=TOKEN_TTL, most=MOST_LIVE_LINKS):
-    """Mint one token for that user. Returns the plaintext, or None if limited.
-
-    The limit is inside the INSERT rather than a SELECT before it, so two
-    requests arriving together cannot both read "two live links" and both make
-    a third. The caller must answer identically either way — a request that is
-    silently dropped and one that sends an email have to look the same from
-    outside, or the rate limit becomes the account-enumeration oracle that the
-    identical wording exists to prevent.
-    """
-    token = new_token()
-    with pool.connection() as conn, conn.transaction():
-        with conn.cursor() as cur:
-            cur.execute(
-                """INSERT INTO login_tokens (user_id, token_hash, expires_at)
-                   SELECT %s, %s, now() + %s
-                   WHERE (SELECT count(*) FROM login_tokens
-                          WHERE user_id = %s AND expires_at > now()) < %s
-                   RETURNING id""",
-                (user_id, hash_token(token), ttl, user_id, most),
-            )
-            if cur.fetchone() is None:
-                # Not an error and not logged as one: asking twice is what a
-                # person does when the first email is slow.
-                return None
-    return token
+    """Mint a login token, or return None when the recipient is limited."""
+    return _issue_link(pool, user_id, None, ttl, most)
 
 
 def issue_signup_link(pool, email, ttl=TOKEN_TTL, most=MOST_LIVE_LINKS):
-    """Mint one token for an address with no account. Plaintext, or None.
-
-    The same shape as `issue_link` and deliberately so: the same TTL, the same
-    single use, and the same "at most three live at once" counted inside the
-    INSERT rather than in a SELECT before it. The only difference is what the
-    row points at — an address, because the user it will become does not exist
-    yet.
-
-    **It does not check whether the address already has an account**, and does
-    not need to: `_start_a_family` signs an existing user in rather than making
-    them a second family, so a token minted by mistake is harmless. The check
-    belongs at the call site, which needs the answer anyway to choose which
-    email to send.
-    """
+    """Mint a signup token for a valid address, or None if invalid or limited."""
     address = normalise(email)
     if not address or "@" not in address or len(address) > LONGEST_EMAIL:
         return None
+    return _issue_link(pool, None, address, ttl, most)
+
+
+def _issue_link(pool, user_id, email, ttl, most):
+    """Serialise issuance for one recipient, including when no user exists yet."""
     token = new_token()
+    subject = f"login_tokens:{user_id}:{email}"
+    digest = hashlib.sha256(subject.encode("utf-8")).digest()
+    lock_key = int.from_bytes(digest[:8], "big", signed=True)
     with pool.connection() as conn, conn.transaction():
         with conn.cursor() as cur:
+            # Acquire the lock in a separate statement so the INSERT's READ
+            # COMMITTED snapshot includes any issuer that just committed.
+            cur.execute("SELECT pg_advisory_xact_lock(%s)", (lock_key,))
             cur.execute(
-                """INSERT INTO login_tokens (email, token_hash, expires_at)
-                   SELECT %s, %s, now() + %s
+                """INSERT INTO login_tokens (user_id, email, token_hash, expires_at)
+                   SELECT %s, %s, %s, now() + %s
                    WHERE (SELECT count(*) FROM login_tokens
-                          WHERE email = %s AND expires_at > now()) < %s
+                          WHERE (user_id = %s OR email = %s)
+                            AND expires_at > now()) < %s
                    RETURNING id""",
-                (address, hash_token(token), ttl, address, most),
+                (user_id, email, hash_token(token), ttl, user_id, email, most),
             )
             if cur.fetchone() is None:
-                # Same as the sign-in half: asking twice is what somebody does
-                # when the first email is slow, so this is not an error.
                 return None
     return token
 
 
 def consume_link(pool, token):
-    """Spend a token. Returns (user_id, family_id), or None for anything wrong.
+    """Spend a token and return (user_id, family_id), or None for any invalid link.
 
-    Expired, already used, and never issued are one answer on purpose. The
-    caller shows one page for all three, so there is nothing here for a caller
-    to leak by accident.
-
-    **Two kinds of token, one statement.** The UPDATE below marks either kind
-    used; what comes back decides what happens next. A `user_id` means somebody
-    signing in. An `email` means somebody signing up, and the family is created
-    here — inside the same transaction that spent the token, so a family can
-    never exist for a link that did not work.
+    The token update and any family creation share a transaction. A failed signup
+    therefore leaves the token usable.
     """
     if not token or len(token) > LONGEST_TOKEN:
         return None
@@ -250,21 +124,10 @@ def consume_link(pool, token):
 
 
 def _start_a_family(cur, email):
-    """Create the family and the parent, and return (user_id, family_id).
+    """Create or find this address's family inside the caller's transaction.
 
-    **One transaction, and the caller's.** A `families` row with no user is
-    unreachable and a `users` row with no family violates the foreign key, so
-    there is no half-way state worth keeping — and because this runs inside the
-    same transaction that spent the token, a failure anywhere leaves the token
-    unspent and the person able to click again.
-
-    **A second link for the same new address must not make a second family.**
-    Two POSTs before either click mints two tokens, and both work. So the
-    address is looked up first, and the INSERT that follows carries
-    `ON CONFLICT DO NOTHING` for the case where the two clicks land close
-    enough together that the lookup missed. Losing that race means undoing the
-    family just created — hence the DELETE, which removes a row nothing else
-    can have seen yet.
+    Concurrent clicks can race the user insert. The loser deletes its provisional
+    family and signs in to the account the other transaction created.
     """
     address = normalise(email)
     cur.execute("SELECT id FROM users WHERE lower(email) = %s", (address,))
@@ -293,11 +156,7 @@ def _start_a_family(cur, email):
 
 
 def _new_family(cur):
-    """One `families` row, on the trial, with a screen token and a board to show.
-
-    The token is generated here and checked in the same statement rather than
-    trusted, so the UNIQUE index is the backstop and not the error path.
-    """
+    """Create a trial family with a screen token and starter config."""
     starter = json.dumps(config_module.starter_config())
     for _ in range(SCREEN_TOKEN_TRIES):
         token = config_module.new_screen_token()
@@ -318,23 +177,13 @@ def _new_family(cur):
 
 
 def _domain(address):
-    """The part of an address that is not a person, for a log line.
-
-    The same rule the login route follows: a flood from one domain is worth
-    seeing, and the list of who has an account is the thing none of this
-    publishes.
-    """
+    """Return only the recipient's domain for logging."""
     _, _, domain = normalise(address).partition("@")
     return f"@{domain}" if domain else "@?"
 
 
 def address_for(pool, user_id):
-    """The address on that account, or None. For showing somebody their own.
-
-    Deliberately a query rather than a session value: `web/session.py` puts two
-    ids in the cookie and no email, because Flask signs the cookie and does not
-    encrypt it.
-    """
+    """Read the account's address; the signed, unencrypted session stores only ids."""
     with pool.connection() as conn, conn.cursor() as cur:
         cur.execute("SELECT email FROM users WHERE id = %s", (user_id,))
         row = cur.fetchone()
@@ -342,21 +191,10 @@ def address_for(pool, user_id):
 
 
 def delete_family(pool, family_id):
-    """Delete a family and everything belonging to it. Returns True if there was one.
+    """Delete a family and its dependent rows in one transaction.
 
-    **The cascade does most of this, and there is exactly one thing it cannot
-    reach.** `families` is the root and every other table references it with
-    `ON DELETE CASCADE` — users, agendas, generations, content_history,
-    calendar_health, model_spend — and `login_tokens` follows its user. But a
-    **sign-up token has no user** (DIN-41): it carries an address instead,
-    precisely so that it can exist before the family does. Nothing cascades to
-    it, so it is deleted here by address, in the same transaction.
-
-    Left alone it would expire in fifteen minutes and be swept, so this is not a
-    security hole — it is the difference between "deleted" meaning what the
-    privacy policy says it means and meaning nearly that.
-
-    One transaction, so a half-deleted family is not a state that can exist.
+    Signup tokens have no user foreign key, so delete those by address explicitly.
+    Returns whether the family existed.
     """
     with pool.connection() as conn, conn.transaction():
         with conn.cursor() as cur:
@@ -371,21 +209,12 @@ def delete_family(pool, family_id):
                         (family_id,))
             gone = cur.fetchone() is not None
     if gone:
-        # The id, never the address. A deletion is worth a line — it is the one
-        # thing nobody can undo — and the line must not be the record of who
-        # left that the deletion was supposed to remove.
         log.info("Deleted family %s and everything belonging to it.", family_id)
     return gone
 
 
 def sweep(pool):
-    """Delete every token that has expired. Returns how many went.
-
-    A used token is deleted by the same rule, once its fifteen minutes are up:
-    there is nothing to learn from keeping it, and a table of hashes of dead
-    credentials is a table somebody has to think about in the privacy policy.
-    Walks `login_tokens_expires_idx`, which exists for this.
-    """
+    """Delete expired tokens, including used ones, and return the count."""
     with pool.connection() as conn, conn.transaction():
         with conn.cursor() as cur:
             cur.execute("DELETE FROM login_tokens WHERE expires_at < now()")

--- a/dinkydash/schedule.py
+++ b/dinkydash/schedule.py
@@ -54,27 +54,10 @@ def refresh_due(config, payload, now):
 
 
 def brief_due(config, payload, now):
-    """True when today has no brief yet and the family's clock has passed `brief_time`.
+    """Owe the first brief immediately; replace older briefs after brief_time.
 
-    **The first brief does not wait for the morning** (DIN-45). `brief_time`
-    decides when to replace yesterday's line, and there is nothing to replace
-    before the first one: a family with no brief at all has the waiting screen
-    on the wall, which is not a board at any hour. Somebody who signs up at
-    03:00 would otherwise look at it until 06:00, and that is the whole of
-    their first impression of the product.
-
-    **The signal is exact, and it is the same one in both stores.**
-    `save_agenda` writes only the agenda keys and `PostgresStore.load_payload`
-    adds `generated_for_date` only when a successful generation exists, so a
-    payload without that key is a family that has never had a brief rather
-    than one whose calendars have merely been fetched. It needs no mode check
-    and no new column: a freshly cloned Pi is in the same state, and gets the
-    same answer from its first `generate.py --tick`.
-
-    A first brief that keeps *failing* is therefore retried on every tick,
-    around the clock rather than from `brief_time` onwards. The bound is
-    unchanged and is the per-family spend cap, which a five-minute loop trips
-    within an hour (`budget.FAMILY_CALLS_A_DAY`).
+    A calendar-only payload has no generated_for_date. Failed first briefs stay
+    due on each tick; cloud callers remain subject to the spend breaker.
     """
     if not payload.get("generated_for_date"):
         return True

--- a/login_link.py
+++ b/login_link.py
@@ -1,31 +1,8 @@
 #!/usr/bin/env python3
-"""Print a working sign-in link for an account that already exists. Cloud mode only.
+"""Print a login link for an existing account without sending email.
 
-    python login_link.py you@example.com
-    python login_link.py you@example.com --base-url http://127.0.0.1:5173
-
-**Why this exists.** The settings UI is behind a magic link, and a magic link
-arrives by email. That is right for a parent and tedious for the person editing
-the page, who would otherwise wait on SendGrid to look at their own change. It
-is also what support needs on the day somebody's mail is bouncing.
-
-**There is no bypass here, and there must never be one.** It mints an ordinary
-token through `dinkydash.accounts`, subject to the same fifteen minutes, the
-same single use and the same per-address limit of three live links. The only
-thing it skips is the email.
-
-**What it prints is a credential.** Anyone holding that line can sign in as
-that person until it is spent. It grants nothing you did not already have —
-running it needs the database password — but pasting it into an issue, a chat
-or a screenshot hands it to somebody who has neither.
-
-**It does not create accounts, and no longer needs to.** Sign-up is the
-product's job and the product now does it (DIN-41): posting an address to
-`/login` sends a link, and clicking that link creates the family. This is for
-getting into an account that already exists without waiting on email — which
-is the developer's case and the support case, not a new family's.
-
-Reads `DATABASE_URL`, like the app.
+Requires database access and uses the ordinary token limits. The printed URL
+is a credential. Pass --base-url http://127.0.0.1:5173 for a local preview.
 """
 
 import argparse
@@ -35,23 +12,9 @@ import sys
 from dotenv import load_dotenv
 
 from dinkydash import accounts, db
+from web.urls import app_origin
 
 load_dotenv()
-
-
-def base_url(given):
-    """Where the link should point. Explicit, then the app's hostname, then local.
-
-    https for a real hostname because the token is a bearer credential and a
-    plain-http link puts it on the wire; http for the fallback because that is
-    what `flask run` serves on a laptop.
-    """
-    if given:
-        return given.rstrip("/")
-    host = os.environ.get("DINKYDASH_APP_HOST", "").strip()
-    if host:
-        return f"https://{host}"
-    return "http://127.0.0.1:5000"
 
 
 def main(argv=None):
@@ -68,9 +31,6 @@ def main(argv=None):
     try:
         user = accounts.user_for(pool, args.email)
         if user is None:
-            # Said plainly here, unlike the web route: this is a local tool run
-            # by somebody holding the database password, so there is nobody to
-            # enumerate accounts for.
             print(f"No account for {args.email}. To make one, post the address "
                   f"to /login and click the link it sends — that is what "
                   f"creates a family.", file=sys.stderr)
@@ -79,17 +39,15 @@ def main(argv=None):
         token = accounts.issue_link(pool, user[0])
         if token is None:
             minutes = int(accounts.TOKEN_TTL.total_seconds() // 60)
-            # **Spending one does not free a slot.** The limit counts every
-            # unexpired token, used or not, so clicking a link does not buy
-            # another. Saying otherwise sends somebody off to click a link that
-            # will not help.
             print(f"{args.email} already has {accounts.MOST_LIVE_LINKS} live links. "
                   f"They are counted until they expire, whether or not they have "
                   f"been used, so the wait is up to {minutes} minutes.",
                   file=sys.stderr)
             return 1
 
-        print(f"{base_url(args.base_url)}/login/link?t={token}")
+        origin = app_origin(os.environ.get("DINKYDASH_APP_HOST", ""),
+                            override=args.base_url)
+        print(f"{origin}/login/link?t={token}")
         print("Works once, for fifteen minutes. Do not paste it anywhere.",
               file=sys.stderr)
     finally:

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -562,6 +562,28 @@ class TestALinkThatDoesNotWork:
 # -- the two rate limits ----------------------------------------------------
 
 class TestTheLimitPerAddress:
+    @pytest.mark.parametrize("signup", [False, True], ids=["login", "signup"])
+    def test_concurrent_requests_cannot_take_the_last_slot_twice(
+            self, pg_pool, pg_user, signup):
+        from concurrent.futures import ThreadPoolExecutor, TimeoutError
+        from contextlib import nullcontext
+        from types import SimpleNamespace
+
+        issue = accounts.issue_signup_link if signup else accounts.issue_link
+        subject = "concurrent@example.com" if signup else pg_user
+        for _ in range(accounts.MOST_LIVE_LINKS - 1):
+            assert issue(pg_pool, subject) is not None
+
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            with pg_pool.connection() as conn, conn.transaction():
+                pinned_pool = SimpleNamespace(connection=lambda: nullcontext(conn))
+                assert issue(pinned_pool, subject) is not None
+                pending = executor.submit(issue, pg_pool, subject)
+                # Keep the last slot uncommitted while another request asks for it.
+                with pytest.raises(TimeoutError):
+                    pending.result(timeout=0.2)
+            assert pending.result(timeout=5) is None
+
     def test_three_live_links_is_the_most(self, client, sent, pg_user):
         for _ in range(5):
             client.post("/login", data={"email": ADDRESS})

--- a/tests/test_cloud_mode.py
+++ b/tests/test_cloud_mode.py
@@ -67,14 +67,31 @@ class TestTheSessionKey:
         with pytest.raises(RuntimeError, match="DINKYDASH_SECRET_KEY"):
             create_app()
 
-    def test_cloud_mode_starts_with_one(self, monkeypatch, tmp_path):
+    def test_cloud_mode_starts_with_one(self, monkeypatch, pg_pool):
         monkeypatch.setenv("DINKYDASH_MODE", "cloud")
         monkeypatch.setenv("DINKYDASH_SECRET_KEY", "a-real-one")
-        # A store is supplied, so nothing tries to connect.
-        from dinkydash.store import FileStore
-        (tmp_path / "config.yaml").write_text('family_name: "The Wilsons"\n')
-        app = create_app(FileStore(tmp_path / "config.yaml"))
+        app = create_app(pool=pg_pool)
         assert app.secret_key == "a-real-one"
+        assert app.config["POOL"] is pg_pool
+        assert app.config["STORE"] is None
+
+    def test_cloud_mode_rejects_a_store(self, monkeypatch, tmp_path):
+        from dinkydash.store import FileStore
+
+        monkeypatch.setenv("DINKYDASH_MODE", "cloud")
+        monkeypatch.setenv("DINKYDASH_SECRET_KEY", "a-real-one")
+        with pytest.raises(ValueError, match="Cloud mode accepts a pool"):
+            create_app(FileStore(tmp_path / "config.yaml"))
+
+    def test_single_mode_rejects_a_pool(self, monkeypatch):
+        monkeypatch.setenv("DINKYDASH_MODE", "single")
+        with pytest.raises(ValueError, match="Single mode accepts a store"):
+            create_app(pool=object())
+
+    def test_unknown_mode_cannot_silently_disable_authentication(self, monkeypatch):
+        monkeypatch.setenv("DINKYDASH_MODE", "cluod")
+        with pytest.raises(ValueError, match="DINKYDASH_MODE"):
+            create_app()
 
     def test_single_mode_still_has_its_fallback(self, monkeypatch, tmp_path):
         # A self-hoster is not made to invent a secret for a LAN-local app that

--- a/tests/test_screen.py
+++ b/tests/test_screen.py
@@ -262,6 +262,18 @@ class TestTheRateLimit:
 # -- rotation ---------------------------------------------------------------
 
 class TestRotation:
+    def test_link_and_qr_use_the_configured_https_origin(
+            self, parent, cloud, path, monkeypatch):
+        from web.routes import settings
+
+        cloud.config["APP_HOST"] = "app.dinkydash.co"
+        drawn = []
+        monkeypatch.setattr(settings, "qr_svg", lambda link: drawn.append(link))
+        page = parent.get("/settings/screen")
+        link = f"https://app.dinkydash.co{path}"
+        assert link in page.get_data(as_text=True)
+        assert drawn == [link]
+
     def test_the_settings_page_shows_the_link_and_a_qr(self, parent, path):
         page = parent.get("/settings/screen").get_data(as_text=True)
         assert path in page
@@ -321,8 +333,13 @@ class TestTheRootAndThePreview:
         assert landed.headers["Location"].endswith("/login")
 
     def test_view_board_on_the_settings_home_points_at_the_screen(
-            self, parent, path):
-        """It used to link to `/`, which is now a redirect back to that page."""
+            self, parent, path, monkeypatch):
+        from web.routes import settings
+
+        def unused_qr(link):
+            pytest.fail("The settings home should not generate a QR code")
+
+        monkeypatch.setattr(settings, "qr_svg", unused_qr)
         assert f'href="{path}"' in parent.get("/settings/").get_data(as_text=True)
 
     def test_the_preview_frames_the_board_rather_than_the_redirect(

--- a/web/CLAUDE.md
+++ b/web/CLAUDE.md
@@ -50,7 +50,10 @@ and never should be. What replaces the session is the token, resolved by `family
 what replaces the guard is that the two routes there are GETs that reach a board and nothing else.
 Registered only in cloud mode, like `auth`. **In cloud mode `/` is a redirect**, so anything that
 used to link to `url_for('board.index')` for a board — the "View board" button, `/preview`'s
-iframes — has to ask where the board actually is instead. `board.board_url` is that question.
+iframes — uses `web.urls.board_path()`. Build absolute credential URLs with
+`web.urls.absolute_url(path)`: it uses HTTPS and the configured `DINKYDASH_APP_HOST`, with the
+request host as a development fallback. The login-link CLI shares the origin policy and accepts
+an explicit local `--base-url`. QR codes are generated only on `/settings/screen`.
 
 **Every form that writes needs one hidden field.** `<input type="hidden" name="csrf_token"
 value="{{ csrf_token() }}">`, right inside the `<form>`. `csrf_token()` is a Jinja global set up by
@@ -116,14 +119,9 @@ single-column layout (an iPad in portrait) has no side column to hide behind and
 full price, around 13-18%. Everything fits at all three sizes in every case. Raising either
 constant spends more type size, so measure at `/preview` before you do.
 
-**The waiting screen may not name a command, and that is a mode rule rather than a style one.**
-`board.html` is one file rendered by both modes and `tests/test_cloud_mode.py` asserts the two are
-byte-identical, so `python generate.py` on it was a Pi's instruction sitting on a hosted family's
-wall panel — where nobody has a shell, and where the token in the address bar is the only thing
-that page is for. Since DIN-45 the first brief is owed at once, so what it says instead is true in
-both: the next tick writes it. It points at the settings button by name, and that button reads
-**Write it now** rather than "Rewrite now" while `status.state == "waiting"`, so the two
-agree; `tests/test_board.py` and `tests/test_settings.py` fail if they stop.
+**The shared waiting screen must work in both modes.** Refer to the settings button, **Write it
+now**, rather than a shell command. Keep that label in sync with `settings/home.html` and see
+[The first board](../PLAN.md#the-first-board) for scheduling behaviour.
 
 In two-column mode the body is a grid, and **the note sits under the agenda, not across the
 bottom**. The agenda is short on a quiet day while chores plus countdowns are not, so a full-width

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -1,30 +1,8 @@
-"""The Flask app: the board on one route, the settings UI on the rest.
+"""Build the Flask app for single or cloud mode.
 
-Two modes, and mode gates four things here — where the config is stored,
-whether the session key is allowed to be a fallback, whether there is a login
-at all, and whether the session cookie is `Secure`:
-
-    DINKYDASH_MODE=single   config.yaml, no accounts, no login (the default)
-    DINKYDASH_MODE=cloud    Postgres, magic links, and a real secret key or it
-                            will not start
-
-Self-hosted mode has no accounts and no login — it serves one family on a home
-network. Anyone who can reach the port can edit the config, which is the same
-trust model as the config file it writes. Cloud mode cannot inherit that: there
-the session *is* the authentication, so `web/routes/auth.py` is registered and
-both `/` and `/settings` are behind it.
-
-`Secure` on the cookie is the fourth gate and the only one that is not a
-feature: a Pi serves plain HTTP on a LAN, and a `Secure` cookie is never sent
-over it. CSRF, by contrast, is on in **both** modes — see `web/session.py`.
-
-**Where the config is stored is also *whose* config**, which is why cloud mode
-holds no store here at all: `web/family.py` builds one per request from the
-family on the session. What this module owns is the pool behind them, built
-once and shared.
-
-Everything else below `create_app` is mode-blind. The routes ask
-`family.current_store()` and never learn what they were given.
+Single mode shares one FileStore and needs no accounts. Cloud mode shares a
+database pool, resolves stores per request, and requires a real session key.
+CSRF and the no-referrer policy apply in both modes.
 """
 
 import os
@@ -33,9 +11,6 @@ from flask import Flask, redirect, url_for
 
 SINGLE, CLOUD = "single", "cloud"
 
-# Harmless with no accounts: it only ever signs flash messages on a LAN-local
-# app. A forgeable session in cloud mode is a forgeable login, which is why
-# `_secret_key` refuses to reach for this one there.
 SELF_HOSTED_KEY = "dinkydash-self-hosted"
 
 
@@ -43,41 +18,35 @@ def mode():
     return os.environ.get("DINKYDASH_MODE", SINGLE).strip().lower() or SINGLE
 
 
-def create_app(store=None, pool=None):
-    """The app. `store` and `pool` are seams for tests and for `app.py`.
+def create_app(store=None, *, pool=None):
+    """Build the app, optionally injecting its storage dependency.
 
-    In **single mode** one `FileStore` is built here and every request shares
-    it: one family, one file, no session to ask.
-
-    In **cloud mode** `STORE` stays `None` and `web/family.py` builds one per
-    request from the family on the session. An injected `store` is still used
-    for its pool, but **it is not used to serve a request** — cloud mode reads
-    the family from the session and from nowhere else, so there is no argument
-    to `create_app` that can quietly turn multi-tenancy off.
+    Single mode accepts a store; cloud mode accepts a pool and constructs a
+    family's store only after authenticating the request.
     """
     app = Flask(__name__, static_folder="static", template_folder="templates")
     app.config["MODE"] = mode()
+    if app.config["MODE"] not in (SINGLE, CLOUD):
+        raise ValueError("DINKYDASH_MODE must be 'single' or 'cloud'.")
     app.secret_key = _secret_key(app.config["MODE"])
-    # Every route reads and writes through `family.current_store()`, and none
-    # of them is told what is behind it (PLAN.md decision 10).
-    app.config["STORE"] = store if store is not None else _fixed_store(app.config["MODE"])
-    # One pool for the life of the process, shared by every request's store and
-    # by the two things that are not one family's rows: signing somebody in,
-    # and the login-token sweep. **Never one pool per request** — the cluster
-    # has 22 connections and a PgBouncer in front of them.
-    app.config["POOL"] = _pool_for(app.config["MODE"], store, pool)
 
-    # The hostname this board answers on, for the one URL that has to be built
-    # outside a browser: the sign-in link in an email. **Not `request.host`**,
-    # which is the `Host` header and is written by whoever is calling — an
-    # attacker who could set it would have a victim's link mailed to their own
-    # server. `wsgi.py` refusing to route an unknown host closes that too, but
-    # a credential should not depend on a rule in another file.
+    if app.config["MODE"] == CLOUD:
+        if store is not None:
+            raise ValueError("Cloud mode accepts a pool, not a store.")
+        if pool is None:
+            from dinkydash import db
+            pool = db.pool()
+    else:
+        if pool is not None:
+            raise ValueError("Single mode accepts a store, not a pool.")
+        if store is None:
+            from dinkydash.store import FileStore
+            store = FileStore()
+    app.config.update(STORE=store, POOL=pool)
+
     app.config["APP_HOST"] = os.environ.get("DINKYDASH_APP_HOST", "").strip()
 
-    # The templates need to know the mode too, and they cannot ask Flask's own
-    # `config` for it: the settings pages pass the *family's* config dict under
-    # that name and shadow it.
+    # Settings templates use `config` for the family's settings, not Flask's.
     app.jinja_env.globals["cloud"] = app.config["MODE"] == CLOUD
 
     from .session import configure as configure_session
@@ -90,16 +59,9 @@ def create_app(store=None, pool=None):
     app.register_blueprint(settings_bp, url_prefix="/settings")
 
     if app.config["MODE"] == CLOUD:
-        # Not registered in single mode, so `/login` is a 404 there rather than
-        # a page that exists and refuses. One family on their own network has
-        # nobody to sign in.
         from .routes.auth import bp as auth_bp
         app.register_blueprint(auth_bp)
 
-        # The board itself, at the one URL a wall panel can open without a
-        # session. Cloud only for the same reason as `auth`: a self-hosted
-        # board is at `/` and has no token, so `/s/...` is a 404 there rather
-        # than a route that exists and refuses.
         from .routes.screen import bp as screen_bp
         app.register_blueprint(screen_bp)
 
@@ -107,30 +69,14 @@ def create_app(store=None, pool=None):
 
         @app.errorhandler(NoSuchFamily)
         def family_is_gone(exc):
-            """A signed-in session naming a family that no longer exists.
-
-            A session lasts thirty days and an account can be deleted inside
-            one, so this is reachable without anything being wrong. Signing the
-            holder out and sending them to `/login` is the honest answer; a 500
-            would be a bug report about a working feature.
-            """
+            """Sign out sessions whose family has since been deleted."""
             from .session import sign_out
             sign_out()
             return redirect(url_for("auth.login"))
 
     @app.after_request
     def no_referrer(response):
-        """Never tell anybody else what URL the reader is on.
-
-        Cloud mode puts the board at `/s/<token>`, and that token is a bearer
-        credential — whoever has the URL sees the family's day. Any outbound
-        request from the page, and any link somebody follows off it, would
-        otherwise hand the whole URL to a third party in the `Referer` header.
-
-        Set here rather than in the templates so it covers every response
-        including redirects and errors, and set in single mode too: a header
-        that only exists in one mode is a header nobody tests.
-        """
+        """Keep credential-bearing URLs out of outbound Referer headers."""
         response.headers.setdefault("Referrer-Policy", "no-referrer")
         return response
 
@@ -142,48 +88,7 @@ def _secret_key(current_mode):
     if key:
         return key
     if current_mode == CLOUD:
-        # Refusing to start is the point. A hardcoded key in a multi-tenant app
-        # lets anybody mint a session cookie for any family, and the failure is
-        # silent — everything works, for everyone, including strangers.
         raise RuntimeError(
             "DINKYDASH_SECRET_KEY is not set. Cloud mode will not start without one."
         )
     return SELF_HOSTED_KEY
-
-
-def _fixed_store(current_mode):
-    """The one store a whole process shares, or `None` when each request needs its own.
-
-    Cloud mode gets `None` on purpose. There is no "the" family there, so a
-    store built at start-up could only be built from an environment variable —
-    which is what this replaced, and what served whoever the environment said
-    to whoever asked.
-    """
-    if current_mode == CLOUD:
-        return None
-    from dinkydash.store import FileStore
-    return FileStore()
-
-
-def _pool_for(current_mode, store, pool):
-    """The connection pool for this process, or `None` if it needs none.
-
-    The import is inside the branch on purpose: `dinkydash.db` pulls in
-    psycopg, which lives in `requirements-cloud.txt` and is not installed on a
-    Pi.
-
-    A supplied `pool` wins, then one hanging off a supplied `store` — both are
-    how the tests hand in a scratch database. Only a cloud app that was given
-    neither opens a connection, which is what lets a test build a cloud app
-    around a `FileStore` without one.
-    """
-    if pool is not None:
-        return pool
-    on_the_store = getattr(store, "pool", None)
-    if on_the_store is not None:
-        return on_the_store
-    if current_mode != CLOUD or store is not None:
-        return None
-
-    from dinkydash import db
-    return db.pool()

--- a/web/family.py
+++ b/web/family.py
@@ -1,46 +1,8 @@
-"""Which family a request is for, and the store that reaches only their rows.
+"""Resolve a request's family and its scoped store.
 
-    current_store()   the store this request reads and writes through
-
-One line decides the whole of multi-tenancy:
-
-    cloud    one store per request, built from the family on the session
-    single   one store per process, because there is one family and no session
-
-**In cloud mode the family comes from the session and from nowhere else** —
-with exactly one exception, which is below and is the whole of it. Not from a
-path segment, not from a query parameter, not from a form field and not from a
-header. That is a stronger promise than checking an id against the session,
-because there is no id to check: nothing a caller can send reaches a query as a
-family selector. When a route does one day need to name a *family* in its URL —
-the admin view is the likely first — the check belongs here, before the store
-is built, and **a mismatch is a 404 and never a 403**: "forbidden" confirms the
-row exists, which tells one family that another one does.
-
-**The exception is the screen, and it is not a hole in that rule.** A wall
-panel cannot sign in, so `/s/<token>` names a family with an unguessable
-credential instead of a session (DIN-42). What a caller sends is still not a
-family *id*: it is a 59-bit secret that `screens.family_for_token` either
-resolves to exactly one family or does not resolve at all, and everything read
-afterwards goes through a `PostgresStore` scoped to that family like any other.
-Both doors are here, in one file, on purpose — if a third is ever added it
-should be as obvious as these two are.
-
-The ids that *do* appear in URLs today are item ids inside one family's config
-document — `/settings/people/<item_id>`. They are already scoped by which
-family's config was loaded, so another family's id is simply not in the list
-and `find_item` 404s. `tests/test_tenancy.py` asserts that rather than assuming
-it.
-
-**One store per request must not mean one pool per request.** The pool is
-built once in `create_app` and lives for the life of the process; a
-`PostgresStore` is two attributes wrapped round it and costs nothing to build.
-Building a `ConnectionPool` per request would exhaust the cluster's 22
-connections and DigitalOcean's PgBouncer in front of them.
-
-The worker does not come through here and must not. `worker.family_ids` is the
-one deliberately unscoped read in the product, because there is no request and
-no user: walking every family is its job.
+Cloud requests use the signed session or a verified screen token. Stores are
+cached on Flask's g and share the app's pool. Single mode uses a fixed store.
+See web/CLAUDE.md for route authentication requirements.
 """
 
 import uuid
@@ -55,7 +17,6 @@ def current_store():
     from . import CLOUD
 
     if current_app.config["MODE"] != CLOUD:
-        # One family, one file, no session. A Pi builds this once at start-up.
         return current_app.config["STORE"]
     return _for_the_session()
 
@@ -66,13 +27,7 @@ def current_family_id():
 
 
 def current_budget():
-    """What this request's family may still spend on the model.
-
-    `NoBudget` in single mode — a self-hoster's key is their own bill, and the
-    board is not multi-tenant. In cloud mode a Postgres-backed breaker for the
-    family on the session, which is the same money the worker spends and so is
-    counted in the same place (DIN-43).
-    """
+    """Return this family's cloud spend breaker, or NoBudget in single mode."""
     from dinkydash import budget as budget_module
     from . import CLOUD
 
@@ -82,35 +37,14 @@ def current_budget():
 
 
 def current_screen_token():
-    """The screen token of the family on the session. Cloud mode only.
-
-    Lives here rather than in a route because it needs the same two things
-    `current_store` does — the process pool, and the family the session names —
-    and because "which family" should be answered in one file however it is
-    being asked.
-    """
+    """Return the screen token of the family on the session. Cloud mode only."""
     from dinkydash import screens
 
     return screens.token_for(_the_pool(), _family_on_the_session())
 
 
 def store_for_token(token):
-    """The store for the family that screen token belongs to, or None.
-
-    The screen's half of `current_store`, and the only place a caller's own
-    string decides which family gets read. Two things keep that safe:
-
-    * **the token is a secret, not an identifier.** A wrong one names nothing —
-      there is no neighbouring family to land on the way an off-by-one id would
-      find one — so guessing is the only attack, and 59 bits is the answer to it;
-    * **one answer for every kind of miss.** Never issued, mistyped and rotated
-      away this morning all return None here, and `web/routes/screen.py` turns
-      that into a 404 and never a 403. It answers rather than this function,
-      because a miss is also the thing the screen rate limit counts.
-
-    Cached on `g` like the session's store, so the board and its manifest are
-    one lookup rather than two, and one object rather than two.
-    """
+    """Return the request's store for a valid screen token, or None on a miss."""
     store = g.get("_store")
     if store is not None:
         return store
@@ -129,12 +63,7 @@ def store_for_token(token):
 
 
 def _for_the_session():
-    """One `PostgresStore`, cached for the length of this request.
-
-    Cached on `g` rather than rebuilt, so two calls in one view are one object
-    — and so that "one store per request" is literally true rather than
-    approximately true.
-    """
+    """Return a PostgresStore scoped to the session and cached for this request."""
     store = g.get("_store")
     if store is not None:
         return store
@@ -147,12 +76,7 @@ def _for_the_session():
 
 
 def _the_pool():
-    """The process-wide pool, or a loud failure.
-
-    **One pool per process, never one per request.** The cluster has 22
-    connections and a PgBouncer in front of them; a `PostgresStore` is two
-    attributes wrapped round this and costs nothing to build.
-    """
+    """Return the app's shared pool, or fail if cloud mode is misconfigured."""
     pool = current_app.config.get("POOL")
     if pool is None:
         raise RuntimeError(
@@ -162,19 +86,7 @@ def _the_pool():
 
 
 def _family_on_the_session():
-    """The family id on the session, checked before it can reach a query.
-
-    Flask signs the cookie, so this value is one we put there — but it is
-    parsed as a UUID anyway before it goes anywhere near SQL. Belt and braces
-    costs one function call, and "the session is signed" is the kind of
-    assumption that survives right up until somebody adds a second way to write
-    a session.
-
-    **404, not a redirect.** Every route that reaches a store in cloud mode is
-    behind `session.guard`, which sends a signed-out visitor to `/login`. So
-    getting here without a family means something is wrong rather than somebody
-    being signed out, and 404 is the answer that says nothing at all.
-    """
+    """Parse the session's family UUID; reject a missing or malformed claim with 404."""
     claimed = session.get(FAMILY_ID)
     try:
         return str(uuid.UUID(str(claimed)))

--- a/web/routes/auth.py
+++ b/web/routes/auth.py
@@ -1,52 +1,11 @@
-"""One email in, one link out, one session. Cloud mode only.
+"""Cloud signup, login and logout routes.
 
-    GET  /login          ask for an email address
-    POST /login          send a link, and always say the same thing
-    GET  /login/link     spend the token, start the session, go to the settings
-    POST /logout         throw the session away
+Login requests return the same page for known, new, limited and failed sends.
+The access-log filter removes credentials from request messages; the full
+logging and authentication requirements are in the root CLAUDE.md.
 
-**This is the sign-up form too** (DIN-41). A new address and a returning one
-submit the same field to the same route and get the same page back; which one
-happened is decided behind that answer, in `_send_a_link`, and the family is
-not created until the link is clicked. Two routes or two buttons would publish
-whether an address is already registered, which is the one thing this page
-exists to hide.
-
-Registered only when `DINKYDASH_MODE=cloud`. Self-hosted has no accounts by
-design — one family on their own network, and the same trust model as the
-config file the settings UI writes — so in single mode these routes do not
-exist rather than existing and refusing.
-
-**Answer identically whether or not the address has an account.** "No account
-with that address" is an enumeration oracle against a product whose users are
-families, and it would be one whichever way it was worded. So there is one
-message, and it is sent for an unknown address, a known one, a rate-limited one
-and a failed send alike.
-
-**A login link in a log is a login in a log**, and the app runs `gunicorn
---access-logfile -`, which writes every request line to the platform's log.
-Three things keep the token out of it, and none of them is decoration:
-
-* **the token rides in the query string, not the path.** Gunicorn's `%(U)s` is
-  the path *without* one, so the access log format in `.do/app.yaml` is built
-  from it. `tests/test_auth.py` fails if that line grows a `%(r)s` or a
-  `%(q)s` back;
-* **`NoTokens` below scrubs `?t=` out of both request logs anyway**, because
-  the development server has no format to configure and `deploy_on_push` does
-  not apply the committed spec;
-* **`Referrer-Policy: no-referrer` on every response** (`web/__init__.py`),
-  which stops a browser handing the whole URL to the next site.
-
-What none of that reaches is DigitalOcean's own edge, whose logs we do not
-format. So the token's last defence is the one it was always going to be: it
-works once, and for fifteen minutes.
-
-**Known and not closed: a mail scanner can burn a link.** A GET spends the
-token, so a corporate mail filter that follows links before the person does
-leaves them with a dead one. Single use is worth more than that is worth
-avoiding — two clicks must not both sign in — and the family mail providers
-this launches on do not do it. If it ever bites, the fix is a confirm button
-that POSTs the token, at the cost of a click for everybody.
+GET /login/link consumes the token, so mail scanners that follow links can
+invalidate them before the recipient clicks.
 """
 
 import logging
@@ -57,88 +16,38 @@ from flask import (Blueprint, current_app, redirect, render_template, request,
 
 from dinkydash import accounts, mail
 from web import ratelimit, session as user_session
+from web.urls import absolute_url
 
 log = logging.getLogger(__name__)
 
 bp = Blueprint("auth", __name__)
 
-# A `?t=` in anything being logged, and what to put there instead.
 A_TOKEN = re.compile(r"([?&]t=)[^&\s\"']+")
 REDACTED = r"\1[redacted]"
 
-# A screen token in a *path*, which is the other bearer credential this app
-# serves and the one the access log format cannot help with. `%(U)s` is the
-# path without the query string, which is exactly what keeps `?t=` out — and
-# exactly what puts `/s/<token>` in. A panel reloading every five minutes would
-# otherwise write its own credential to the platform's log for years.
-#
-# Matched on the alphabet rather than on `\S+`, so `/settings` and `/static`
-# are untouched: `config.ID_ALPHABET` has no `i`, `l`, `o` or `0`, and the
-# length bounds are the column's.
 A_SCREEN = re.compile(r"(/s/)[23456789abcdefghjkmnpqrstuvwxyz]{10,32}")
 SCREEN_REDACTED = r"\1[redacted]"
 
-# The one answer a login request ever gets. It used to begin "If that address
-# has an account", because an unknown one got nothing at all. Now that the same
-# form starts a board, a link really does go to every address that asks — so
-# the hedge is gone and the sentence is simply true. The cases that still send
-# nothing are the two rate limits and a failed send, none of which is about
-# whether an account exists.
 SAME_ANSWER = ("A link is on its way. It works once, and for fifteen minutes. "
                "If you have not got a board yet, the link starts one.")
 
-# What a token that is expired, spent or invented all get.
 DEAD_LINK = ("That link no longer works — it has either been used already or "
              "expired. Ask for a new one.")
 
-# Per client IP, per hour, in this process. Generous enough that a family
-# behind one address can all get in; small enough that a script cannot spend
-# our SendGrid quota. The per-address half of the limit is in Postgres, in
-# `accounts.issue_link`, where it holds across instances.
 MOST_PER_IP = 20
 PER_SECONDS = 3600
 
 SUBJECT = "Your DinkyDash sign-in link"
 WELCOME_SUBJECT = "Start your DinkyDash board"
 
-# Set once, by `_warn_once_if_anonymous`. Module level rather than app config
-# because it is a fact about the platform this process is running on, not about
-# any one app built inside it.
 _warned_about_anonymous = False
 
 
-# The two loggers that write a request line: Flask's development server, and
-# gunicorn's access log. Both get the filter below.
 REQUEST_LOGGERS = ("werkzeug", "gunicorn.access")
 
 
 class NoTokens(logging.Filter):
-    """Take both kinds of token out of anything a server writes about a request.
-
-    Two credentials travel in URLs here and they need different treatment. A
-    sign-in link is `?t=` in the query string, which gunicorn's `%(U)s` format
-    already leaves out; a screen URL is `/s/<token>` in the *path*, which that
-    same format writes down every time. So the access log format covers one and
-    this filter is the only thing covering the other.
-
-    Belt to the access log format's braces, and it exists because both halves
-    of that format can be missing:
-
-    * **Flask's own development server logs the whole request line**, and no
-      `--access-logformat` reaches it. A developer running cloud mode locally
-      watches sign-in links scroll past their terminal. Observed, not imagined,
-      which is how this came to be written.
-    * **`deploy_on_push` does not apply the committed app spec** — it rebuilds
-      the components that already exist (doc/operations.md). So a commit that
-      changes the format in `.do/app.yaml` and is merged without somebody
-      running `doctl apps update` leaves production on gunicorn's default
-      `%(r)s`, which is the full request line. This filter is what makes that
-      window safe rather than silent.
-
-    A filter rather than a formatter, because it has to reach the message
-    whatever handler eventually prints it, and gunicorn's message is only
-    assembled when the record is formatted.
-    """
+    """Redact magic-link and screen tokens from both server request loggers."""
 
     def filter(self, record):
         message = record.getMessage()
@@ -164,11 +73,7 @@ def _quieten(state):
 
 @bp.record_once
 def _build_the_limiter(state):
-    """One limiter per app, rather than one per process.
-
-    A module-level counter would be shared by every app built in a process,
-    which is fine in production and wrong in a test suite that builds several.
-    """
+    """Give each app its own per-caller limiter."""
     state.app.config.setdefault(
         "LOGIN_LIMITER", ratelimit.Limiter(MOST_PER_IP, PER_SECONDS))
 
@@ -189,15 +94,6 @@ def login():
 
     address = request.form.get("email", "")
     if "@" not in address or len(address.strip()) > accounts.LONGEST_EMAIL:
-        # The one thing worth saying back, and it says nothing about accounts:
-        # this is about what was typed, not about who exists.
-        #
-        # The length is checked here rather than left to the column, and it has
-        # to be checked *here* rather than only inside `issue_signup_link`: that
-        # function answers None for a refusal too, and the caller below would
-        # then log "3 live links already" about an address that has none. A line
-        # reporting a limit it did not apply is the kind of thing that misleads
-        # somebody at two in the morning.
         return render_template("auth/login.html", email=address,
                                problem="That does not look like an email address.")
 
@@ -206,39 +102,16 @@ def login():
 
 
 def _send_a_link(address):
-    """Do whatever there is to do, and tell the *caller* nothing about it.
+    """Send a login or signup link if allowed; return the same result in every case.
 
-    Every branch below returns the same None, and the page above is the same
-    page, because each of them is something an attacker would otherwise learn:
-    whether the address exists, whether it has asked recently, and whether our
-    mail provider is up.
-
-    **The log is the exception, and that is the point of having one.** The
-    limits are ours rather than an edge rule precisely so that a refusal is a
-    line somebody can read. What goes in that line is chosen, not accidental:
-
-    * **the caller's address, in full.** Without it a rate-limit warning says
-      only "something happened", which is not worth writing. One script and a
-      hundred parents look identical.
-    * **the domain of the address asked about, never the address.** A flood of
-      `@mailinator.com` is the thing you want to see at a glance, and the list
-      of who has an account is the thing this endpoint exists not to publish —
-      in a page or in a third-party log we do not control.
-
-    **Known and not closed: this takes longer when the address exists**, by
-    roughly the time SendGrid takes to answer. Somebody timing the two could
-    tell them apart. Closing it means sending off the request thread, which is
-    a background worker's job rather than a login route's, and the enumeration
-    it would buy is a list of addresses somebody already had.
+    Logs may contain the caller's IP and recipient's domain, but never the full
+    recipient address or a credential.
     """
     caller = ratelimit.client_ip(request)
     _warn_once_if_anonymous(caller)
 
     limiter = current_app.config["LOGIN_LIMITER"]
     if not limiter.allow(caller):
-        # The limiter's own numbers, not the constants above. A line that
-        # reports a limit it did not apply is the kind of thing that misleads
-        # somebody at two in the morning.
         log.warning("Sign-in requests from %s are over the limit "
                     "(%s per %s minutes, in this process).",
                     caller or "an unknown caller",
@@ -248,17 +121,11 @@ def _send_a_link(address):
     pool = _pool()
     user = accounts.user_for(pool, address)
     if user is None:
-        # No account, so this is a sign-up. **Nothing is created here.** The
-        # token carries the address, and the family is made when the link is
-        # clicked (DIN-41) — an unverified sign-up costs one row and one email
-        # rather than a trial and a daily Anthropic call.
         kind, token = "sign-up", accounts.issue_signup_link(pool, address)
     else:
         kind, token = "sign-in", accounts.issue_link(pool, user[0])
 
     if token is None:
-        # The limit that actually caps the SendGrid bill, and it used to be
-        # silent — the one refusal nobody could see.
         log.warning("No %s link minted for a %s address from %s: "
                     "%s live links already.", kind, _domain(address),
                     caller or "an unknown caller", accounts.MOST_LIVE_LINKS)
@@ -271,19 +138,8 @@ def _send_a_link(address):
                   WELCOME_SUBJECT if new_family else SUBJECT,
                   _text(link, new_family), html=_html(link, new_family))
     except mail.MailError as exc:
-        # `mail` messages carry no address, no key and no body, and this one
-        # must not add the link back. A failed send is a failed login, and the
-        # person will ask again.
         log.warning("A %s link did not go out: %s", kind, exc)
     else:
-        # So the ordinary shape of the traffic is visible too, not only the
-        # refusals. `mail` logs that *an* email went; this says what kind.
-        #
-        # **The kind is safe to write and the address is not.** Which of the
-        # two an address got is exactly what the page above refuses to say, so
-        # it goes in our own log — where the point of having one is that a
-        # refusal is a line somebody can read — with the domain and never the
-        # address, the same rule as everything else here.
         log.info("Sent a %s link to a %s address.", kind, _domain(address))
 
 
@@ -294,17 +150,7 @@ def _domain(address):
 
 
 def _warn_once_if_anonymous(caller):
-    """Say so, once per process, if callers cannot be told apart.
-
-    `client_ip` returns `""` when no header identifies the caller, and an empty
-    key is one the limiter always allows — the deliberate choice, because
-    "everybody shares one bucket" is an outage wearing a rate limit's clothes.
-    But it means the per-caller limit has quietly stopped working, and a
-    control that fails silently is worse than one that is not there.
-
-    Once per process rather than per request: this is a platform-shaped fault,
-    so the second line would say nothing the first did not.
-    """
+    """Warn once per process if requests lack a usable rate-limit address."""
     global _warned_about_anonymous
     if caller or _warned_about_anonymous:
         return
@@ -317,27 +163,8 @@ def _warn_once_if_anonymous(caller):
 
 
 def _link_for(token):
-    """The sign-in URL, built from configuration rather than from the request.
-
-    Two things here are deliberate and neither is cosmetic.
-
-    **The host is `APP_HOST`, not `request.host`.** `request.host` is the
-    `Host` header, which the caller writes. Building the link from it would let
-    somebody POST this form with a victim's address and a `Host` of their own,
-    and have a working token mailed to the victim pointing at their server.
-    `wsgi.py` already refuses to route an unknown host to this app, so the
-    attack does not land today — but a bearer credential should not rely on a
-    rule in a different file, and this app is also runnable on its own.
-
-    **The scheme is always https.** App Platform terminates TLS, so the request
-    that reaches Flask is plain HTTP and a link built from it would put the
-    credential on the wire in clear.
-
-    Falls back to `request.host` when `APP_HOST` is unset, which is local
-    development and the tests. Cloud mode sets it in `.do/app.yaml`.
-    """
-    host = current_app.config.get("APP_HOST") or request.host
-    return f"https://{host}{url_for('auth.landing', t=token)}"
+    """Build a credential URL using the shared app-origin policy."""
+    return absolute_url(url_for("auth.landing", t=token))
 
 
 @bp.route("/login/link")
@@ -401,11 +228,7 @@ https://dinkydash.co
 
 
 def _html(link, new_family=False):
-    """Deliberately plain. No images, no tracking pixel, no third-party CSS.
-
-    A login email that loads anything from anywhere else hands the fact of the
-    login, and often the URL, to whoever serves it.
-    """
+    """Render an email without remote images, tracking pixels or third-party CSS."""
     if new_family:
         return f"""\
 <p>Welcome to DinkyDash.</p>

--- a/web/routes/board.py
+++ b/web/routes/board.py
@@ -20,8 +20,9 @@ from dinkydash import board as board_view
 from dinkydash import config as config_module
 from web import CLOUD
 from web import manifest as manifest_module
-from web.family import current_screen_token, current_store
+from web.family import current_store
 from web.session import guard
+from web.urls import board_path
 
 bp = Blueprint("board", __name__)
 
@@ -116,27 +117,9 @@ def manifest():
 
 @bp.route("/preview")
 def preview():
-    """Every target screen at once, so a layout change can be checked in one go.
-
-    **What it frames is wherever the board actually is.** In cloud mode `/` is
-    a redirect, so framing it would show three iframes of the settings page —
-    the harness has to follow the board to `/s/<token>` or it stops being a
-    harness.
-    """
+    """Show the board at each target screen size."""
     return render_template("preview.html", sizes=PREVIEW_SIZES,
-                           board_url=board_url())
-
-
-def board_url():
-    """Where this family's board is served, for this mode.
-
-    The token is a column on `families`, not a key in the config dict — it is
-    the platform's business rather than a family setting, so it is asked for
-    rather than read out of what the store returned.
-    """
-    if current_app.config["MODE"] != CLOUD:
-        return url_for("board.index")
-    return url_for("screen.board", token=current_screen_token())
+                           board_url=board_path())
 
 
 @bp.route("/healthz")

--- a/web/routes/settings.py
+++ b/web/routes/settings.py
@@ -26,10 +26,10 @@ from dinkydash.runner import forget_calendar, refresh_calendars
 from dinkydash.runner import run as run_generation
 from web import CLOUD
 from web import manifest as manifest_module
-from web.family import (current_budget, current_family_id, current_screen_token,
-                        current_store)
+from web.family import current_budget, current_family_id, current_store
 from web import session as session_module
 from web.session import guard
+from web.urls import absolute_url, board_path
 
 log = logging.getLogger(__name__)
 
@@ -219,10 +219,7 @@ def home():
     payload = current_store().load_payload(config)
 
     tzinfo = config_module.tzinfo_for(config)
-    # "The next run" rather than a number of minutes: it is a worker tick in
-    # cloud mode and a cron line on a Pi, and only one of those is ours to
-    # promise. Either way the first brief is owed at once rather than at
-    # `brief_time` (DIN-45), so there is no morning to wait for.
+    # The first brief is due immediately; the next tick's timing depends on the host.
     status = {"state": "waiting",
               "detail": "No board has been generated yet. The next run writes it."}
     if payload:
@@ -253,9 +250,7 @@ def home():
         "settings/home.html", config=config, status=status, counts=counts,
         broken=broken, sections=SECTIONS, cadence=cadence_summary(config),
         first_run=looks_untouched(config),
-        # Where "View board" goes. In cloud mode `/` is a redirect back to this
-        # page, so a button pointing at it would be a button that does nothing.
-        board_link=screen_url()["screen_path"] or url_for("board.index"),
+        board_link=board_path(),
     )
 
 
@@ -501,11 +496,7 @@ def section_move(section_name, item_id):
 
 @bp.route("/screen", methods=["GET", "POST"])
 def screen():
-    """Colours, and — in cloud mode — the URL a wall panel opens.
-
-    Both live here because they are the same question from a parent's side:
-    what the screen in the kitchen shows, and how it gets there.
-    """
+    """Edit colours and, in cloud mode, show or rotate the screen URL."""
     config = current_config()
     if request.method == "POST":
         if request.form.get("action") == "rotate":
@@ -516,68 +507,20 @@ def screen():
             save(config)
             flash(f"Board set to {theme}.", "ok")
         return redirect(url_for("settings.screen"))
+    link = absolute_url(board_path()) if current_app.config["MODE"] == CLOUD else None
     return render_template("settings/screen.html", config=config,
-                           themes=config_module.THEMES, **screen_url())
-
-
-def screen_url():
-    """The board's public URL and a QR of it, or empty in single mode.
-
-    Empty rather than absent so the template can ask for it either way. A
-    self-hosted board has no token — it is at `/` on a home network, and the
-    page already says what that means.
-    """
-    nothing = {"screen_link": None, "screen_path": None, "screen_qr": None}
-    if current_app.config["MODE"] != CLOUD:
-        return nothing
-    token = current_screen_token()
-    if token is None:
-        return nothing
-    # Two forms on purpose. The absolute one is what a person copies, types
-    # into a television or scans, so it has to carry the hostname. The path is
-    # what a link on this site uses, because an absolute URL in an `href` would
-    # send somebody through DNS and TLS again to reach the page next door.
-    link = url_for("screen.board", token=token, _external=True)
-    return {"screen_link": link,
-            "screen_path": url_for("screen.board", token=token),
-            "screen_qr": qr_svg(link)}
+                           themes=config_module.THEMES, screen_link=link,
+                           screen_qr=qr_svg(link) if link else None)
 
 
 def qr_svg(link):
-    """The link as an inline SVG QR code, or None if it cannot be drawn.
-
-    **Inline, not a file and not a third-party image.** The screen URL is a
-    bearer credential, so handing it to any QR service — or writing it into a
-    filename on disk — would be publishing it. Drawn on the page, it never
-    leaves this response.
-
-    `segno` is a pure-Python encoder with no dependencies of its own, and it
-    lives in `requirements-cloud.txt` rather than `requirements.txt`: a Pi has
-    no screen token and should not install a library it can never use. Hence
-    the import here rather than at the top of the file.
-    """
+    """Draw the credential locally as inline SVG; segno is a cloud-only dependency."""
     try:
         import segno
     except ImportError:  # pragma: no cover - cloud installs it
         log.warning("segno is not installed, so the screen QR code is missing.")
         return None
-    # `xmldecl=False` because an `<svg>` inside an HTML document must not carry
-    # one, and `svgns=False` because inline SVG inherits the namespace from the
-    # page. `omitsize` lets the surrounding CSS size it. Nothing here reaches
-    # outside the response.
-    #
-    # **Black modules, and the template puts a white plate behind them** — in
-    # both themes, which is the one place in this UI that ignores the theme
-    # tokens on purpose. A QR follows the same rules a barcode does: scanners
-    # expect dark on light, and an inverted code is read by some phones and not
-    # others. Drawing it in `currentColor` looked better in dark mode and would
-    # have shipped a QR that half the phones in a kitchen could not read.
-    #
-    # `border=4` is the quiet zone the QR specification asks for. Trimming it to
-    # save space is the other classic way to make a code that scans on a desk
-    # and not across a room.
-    #
-    # A bytes buffer, because segno's SVG writer encodes before it writes.
+    # Black on the template's white background, with a four-module quiet zone.
     out = io.BytesIO()
     segno.make(link, error="m").save(
         out, kind="svg", xmldecl=False, svgns=False, omitsize=True, border=4,

--- a/web/templates/board.html
+++ b/web/templates/board.html
@@ -268,12 +268,7 @@
     <div class="family">DinkyDash</div>
     <div class="waiting-head">Writing {{ view.family_name or "your" }}{{ "'s" if view.family_name else "" }} first board&hellip;</div>
     <div class="bar"><span></span></div>
-    {# Named no command since DIN-45. This template is byte-identical in both
-       modes, so an instruction to run `python generate.py` was a Pi's
-       instruction on a hosted family's wall panel — and it is no longer the
-       thing to do in either: the first brief is owed at once, so the next
-       tick writes it. The button below is the same in both modes and is
-       there for somebody who would rather not wait for one. #}
+    {# Keep the button name in sync with settings/home.html. #}
     <div class="waiting-sub">
         The next run writes it, usually within a few minutes, and this page fills
         itself in. To have it now, open the settings page and press

--- a/web/templates/settings/home.html
+++ b/web/templates/settings/home.html
@@ -53,9 +53,6 @@
         </form>
         <div style="display:flex;gap:0.625rem;">
             <a class="btn outline" style="flex:1;" href="{{ board_link }}">{{ icons.screen() }} View board</a>
-            {# "Rewrite" is the wrong word when there is nothing written yet,
-               and the waiting screen on the board points at this button by
-               name, so the two have to agree (DIN-45). #}
             <form class="inline-form" method="post" action="{{ url_for('settings.generate_now') }}" style="flex:1;">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                 <button class="btn outline" type="submit">

--- a/web/urls.py
+++ b/web/urls.py
@@ -1,0 +1,31 @@
+"""App origins and board paths shared by routes and the login-link CLI."""
+
+from flask import current_app, request, url_for
+
+from web import CLOUD
+from web.family import current_screen_token
+
+
+def app_origin(host="", *, override=None):
+    """Use HTTPS for a configured host; allow an explicit CLI preview origin."""
+    if override:
+        return override.rstrip("/")
+    host = host.strip()
+    return f"https://{host}" if host else "http://127.0.0.1:5000"
+
+
+def absolute_url(path):
+    """Put a local path on the configured HTTPS origin, even behind a TLS proxy.
+
+    APP_HOST is set in cloud deployments. The request-host fallback supports
+    development without that configuration.
+    """
+    host = current_app.config.get("APP_HOST") or request.host
+    return app_origin(host) + path
+
+
+def board_path():
+    """Return this family's board path in the current mode."""
+    if current_app.config["MODE"] != CLOUD:
+        return url_for("board.index")
+    return url_for("screen.board", token=current_screen_token())


### PR DESCRIPTION
Login and signup now share token issuance with a transaction lock per subject, so concurrent requests cannot exceed the live-token limit.
A shared origin and board-path policy keeps cloud credential URLs on HTTPS and generates QR codes only on the screen settings page.
The app factory accepts a store only in single mode or a pool only in cloud mode, and repeated or stale explanations are consolidated while preserving first-board scheduling from #85.

Validation: 827 tests passed with PostgreSQL 16; 570 passed and 257 skipped without a database, plus CLI and self-hosted smoke checks.
