### PR TITLE
Name the link in the sign-in mail, because "it" grabbed the board

### DIFF
--- a/web/routes/auth.py
+++ b/web/routes/auth.py
@@ -204,7 +204,7 @@ already filled in with an invented family for you to replace:
 
 {link}
 
-It works once, and for fifteen minutes.
+The link works once, and for fifteen minutes.
 
 If you did not ask for this, you can ignore it. Nothing has been created, and
 the link stops working on its own.
@@ -217,7 +217,7 @@ Here is your link to sign in to DinkyDash:
 
 {link}
 
-It works once, and for fifteen minutes.
+The link works once, and for fifteen minutes.
 
 If you did not ask for this, you can ignore it. Nobody can sign in without
 the link, and it stops working on its own.
@@ -235,7 +235,7 @@ def _html(link, new_family=False):
 <p>Open this link and your board is ready — people, chores and countdowns are
 already filled in with an invented family for you to replace:</p>
 <p><a href="{link}">Start my board</a></p>
-<p>It works once, and for fifteen minutes.</p>
+<p>The link works once, and for fifteen minutes.</p>
 <p>If you did not ask for this, you can ignore it. Nothing has been created,
 and the link stops working on its own.</p>
 <p>— DinkyDash</p>
@@ -243,7 +243,7 @@ and the link stops working on its own.</p>
     return f"""\
 <p>Here is your link to sign in to DinkyDash:</p>
 <p><a href="{link}">Sign in to DinkyDash</a></p>
-<p>It works once, and for fifteen minutes.</p>
+<p>The link works once, and for fifteen minutes.</p>
 <p>If you did not ask for this, you can ignore it. Nobody can sign in without
 the link, and it stops working on its own.</p>
 <p>— DinkyDash</p>


### PR DESCRIPTION
The sign-in and welcome emails said "It works once, and for fifteen minutes." In the HTML version that sentence sits directly under an anchor reading "Start my board", so the pronoun attaches to the nearest noun and reads as a claim about the dashboard rather than the credential. Naming the subject costs one word, in all four bodies — plain text and HTML, welcome and returning.

The on-screen message in `SAME_ANSWER` keeps its "It": there the pronoun follows "A link is on its way" immediately, so nothing else can claim it, and that paragraph already says "link" twice more. Copy only — 572 tests pass, and `tests/test_auth.py` still asserts the mail carries "fifteen minutes".

🤖 Generated with [Claude Code](https://claude.com/claude-code)