### PR TITLE
Prevent stale calendar publication and private service logs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,6 +132,10 @@ Relative links like `[PLAN.md](PLAN.md)` break once a document is in Linear. Rew
   commit.
 - **Log the label, not the URL.** `fetch_events` logs `entry["label"]` on purpose. The exception
   text does not follow that rule by itself — see the gotcha below.
+- **Service ticks log metadata, never generated family text.** `runner.write_brief` logs the
+  date and token usage. Headline/note output belongs to an explicit CLI run, outside `--tick`.
+  Access-log redaction covers malformed and encoded screen URLs as well as valid credentials;
+  the route's token alphabet must not limit the log filter (`tests/test_private_logs.py`).
 
 ### Hosted mode raises the stakes
 
@@ -288,7 +292,7 @@ dinkydash/
 ├── config.py          config.yaml load/save (ruamel round-trip), item ids
 ├── history.py         what the recent notes say, and how they trim (pure)
 ├── schedule.py        due(config, payload, now) -> what a tick owes (pure)
-├── store.py           the six storage operations; FileStore, the single-mode one
+├── store.py           the seven storage operations; FileStore, the single-mode one
 ├── pgstore.py         PostgresStore, the cloud one. Imports psycopg; single mode never does
 ├── db.py              the connection pool and the migration runner (cloud only)
 ├── mail.py            one transactional email, over SendGrid (cloud only)
@@ -312,7 +316,7 @@ web/
 
 ### The storage seam
 
-Six operations, on one object, and nothing above them knows what is behind it — `FileStore`
+Seven operations, on one object, and nothing above them knows what is behind it — `FileStore`
 for a Pi, `PostgresStore` for cloud mode, and `tests/test_store_contract.py` asserting the two
 behave identically. Two invariants hold anywhere in the repo:
 
@@ -324,7 +328,7 @@ behave identically. Two invariants hold anywhere in the repo:
   unscoped write in that file, and there must never be one. An id arriving in a URL is a claim, not
   a fact, and the place to check it is before it reaches a store.
 
-The six operations, how the halves are written, the migration runner and the connection pool are
+The seven operations, how the halves are written, the migration runner and the connection pool are
 in [`dinkydash/CLAUDE.md`](dinkydash/CLAUDE.md), along with what the payload may hold and how the
 two cadences of a tick are decided.
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,6 +1,6 @@
 # DinkyDash Hosted MVP — Plan
 
-*Updated 8 September 2026 against main through PR #86.*
+*Updated 8 September 2026: main through PR #89, plus the DIN-46/DIN-47 implementation.*
 
 This is the engineering plan for the hosted app and its shared self-hosted codebase.
 Positioning, pricing reasoning and launch strategy live in Linear on the DIN team.
@@ -13,11 +13,14 @@ The multi-tenant core is built: email signup/login, family-scoped settings, cale
 management, a tokenised screen, and a worker that owes the first brief on its next tick.
 PR #85 delivered [DIN-45](https://linear.app/keepthescore/issue/DIN-45); PR #86 consolidated token issuance and URL construction,
 serialized the per-address token limit, and fixed hosted HTTPS screen links.
+PRs #87 and #89 added the calendar-provider and device guides ([DIN-14](https://linear.app/keepthescore/issue/DIN-14), [DIN-13](https://linear.app/keepthescore/issue/DIN-13)).
+The current batch implements privacy-safe calendar publication ([DIN-46](https://linear.app/keepthescore/issue/DIN-46))
+and removes generated text and malformed screen credentials from service logs ([DIN-47](https://linear.app/keepthescore/issue/DIN-47)).
 
 Hosted readiness is still open. The next sequence is:
 
-1. Fix privacy publication and logging ([DIN-46](https://linear.app/keepthescore/issue/DIN-46), [DIN-47](https://linear.app/keepthescore/issue/DIN-47)), the preview database override
-   ([DIN-48](https://linear.app/keepthescore/issue/DIN-48)), and the remaining calendar-fetch DNS-rebinding gap ([DIN-61](https://linear.app/keepthescore/issue/DIN-61)).
+1. Fix the preview database override ([DIN-48](https://linear.app/keepthescore/issue/DIN-48)) and the remaining
+   calendar-fetch DNS-rebinding gap ([DIN-61](https://linear.app/keepthescore/issue/DIN-61)).
 2. Complete spending boundaries ([DIN-49](https://linear.app/keepthescore/issue/DIN-49), [DIN-51](https://linear.app/keepthescore/issue/DIN-51)), export coverage ([DIN-50](https://linear.app/keepthescore/issue/DIN-50)), and trial
    expiry/lapse ([DIN-52](https://linear.app/keepthescore/issue/DIN-52)). Complete Stripe conversion before accepting payment ([DIN-53](https://linear.app/keepthescore/issue/DIN-53)).
 3. Add error capture, liveness alerts and recovery checks ([DIN-35](https://linear.app/keepthescore/issue/DIN-35), [DIN-54](https://linear.app/keepthescore/issue/DIN-54), [DIN-55](https://linear.app/keepthescore/issue/DIN-55),
@@ -92,9 +95,9 @@ recent_notes / record_note
 
 The runner, settings and renderer use that interface. A cloud payload combines the
 latest brief in `generations` with the current calendar window in `agendas`. Agenda
-and brief writes own separate fields. This prevents one operation from overwriting
-the other's output; rejecting a refresh that used obsolete privacy settings is a
-separate, outstanding requirement ([DIN-46](https://linear.app/keepthescore/issue/DIN-46)).
+and brief writes own separate fields. Config saves clear affected calendars and
+coordinate with refresh publication using a short storage lock. A refresh made with
+obsolete calendar settings is rejected before that tick can call the model ([DIN-46](https://linear.app/keepthescore/issue/DIN-46)).
 
 ### Sign-up
 
@@ -136,8 +139,8 @@ locally with lazily imported `segno`. `web/urls.py` builds hosted links from an 
 app origin; single mode retains its local HTTP URLs.
 
 The app rate-limits invalid-token attempts. Cloudflare edge hardening remains [DIN-40](https://linear.app/keepthescore/issue/DIN-40);
-this document does not claim an edge rule is deployed. Access-log redaction exists,
-but invalid/mistyped token variants still need [DIN-47](https://linear.app/keepthescore/issue/DIN-47). Offline behaviour is deferred
+this document does not claim an edge rule is deployed. Access-log redaction covers
+invalid, mistyped and encoded screen-token variants ([DIN-47](https://linear.app/keepthescore/issue/DIN-47)). Offline behaviour is deferred
 under [DIN-60](https://linear.app/keepthescore/issue/DIN-60); weakening shared-cache headers is not the implementation plan.
 
 ### The spend breaker
@@ -325,7 +328,7 @@ another family's item ID returns 404. Provider-page and onboarding improvements 
 - [x] Separate agenda/brief persistence, one daily generation row, and reported token usage.
 - [x] Per-family and approximate global call caps, including manual rewrites ([DIN-43](https://linear.app/keepthescore/issue/DIN-43)).
 - [x] Keep-last-good rendering and retry on subsequent ticks.
-- [ ] Reject refresh publication after a calendar privacy/config change ([DIN-46](https://linear.app/keepthescore/issue/DIN-46)).
+- [x] Reject refresh publication after a calendar privacy/config change ([DIN-46](https://linear.app/keepthescore/issue/DIN-46)).
 - [ ] Preserve global spending across account deletion ([DIN-49](https://linear.app/keepthescore/issue/DIN-49)).
 - [ ] Failure tracking, backoff and parent notification ([DIN-55](https://linear.app/keepthescore/issue/DIN-55)).
 - [ ] Remove the remaining implicit date fallback in feed description ([DIN-62](https://linear.app/keepthescore/issue/DIN-62); maintenance).
@@ -344,7 +347,8 @@ failed providers preserve useful last-good output; retries and paid calls obey t
 - [ ] Define offline behaviour while preserving credential/cache controls ([DIN-60](https://linear.app/keepthescore/issue/DIN-60); deferred).
 
 **Done when:** the shared board works on the actual target devices, including the
-agreed failure behaviour. Device-specific marketing pages remain [DIN-13](https://linear.app/keepthescore/issue/DIN-13).
+agreed failure behaviour. Device-specific guides are published ([DIN-13](https://linear.app/keepthescore/issue/DIN-13));
+the real-device checks remain [DIN-58](https://linear.app/keepthescore/issue/DIN-58).
 
 ### Phase 4 — Money
 
@@ -361,7 +365,7 @@ trial date and excluding already-lapsed rows do not meet this requirement on the
 - [x] Published privacy policy, terms, processor list and relevant disclosures beside calendar setup ([DIN-44](https://linear.app/keepthescore/issue/DIN-44)).
 - [x] Account export/download and hard-delete actions, scoped to the signed-in family ([DIN-44](https://linear.app/keepthescore/issue/DIN-44)).
 - [ ] Include every retained historical generation in the export ([DIN-50](https://linear.app/keepthescore/issue/DIN-50)).
-- [ ] Keep generated family text and bearer credentials out of service logs ([DIN-47](https://linear.app/keepthescore/issue/DIN-47)).
+- [x] Keep generated family text and bearer credentials out of service logs ([DIN-47](https://linear.app/keepthescore/issue/DIN-47)).
 - [ ] Verify DigitalOcean/Cloudflare agreement status and record private evidence ([DIN-59](https://linear.app/keepthescore/issue/DIN-59)).
 - [ ] Implement and then disclose old-brief and lapsed-family retention sweeps ([DIN-57](https://linear.app/keepthescore/issue/DIN-57)).
 
@@ -387,7 +391,8 @@ recover the application. A healthy `/healthz` response alone is insufficient.
 - [x] Search Console and Ahrefs connection is marked Done in [DIN-3](https://linear.app/keepthescore/issue/DIN-3); ongoing account status is tracked there.
 - [ ] Real-device checks, current self-hosted smoke test and the small private beta ([DIN-58](https://linear.app/keepthescore/issue/DIN-58)).
 - [ ] Refresh launch dependencies, rewrite obsolete drafts, tag a release and execute the approved launch ([DIN-25](https://linear.app/keepthescore/issue/DIN-25)).
-- [ ] Feedback collection ([DIN-34](https://linear.app/keepthescore/issue/DIN-34)); provider and device content remain [DIN-14](https://linear.app/keepthescore/issue/DIN-14) and [DIN-13](https://linear.app/keepthescore/issue/DIN-13).
+- [x] Calendar-provider and device guides ([DIN-14](https://linear.app/keepthescore/issue/DIN-14), [DIN-13](https://linear.app/keepthescore/issue/DIN-13)).
+- [ ] Feedback collection ([DIN-34](https://linear.app/keepthescore/issue/DIN-34)).
 
 Beta invitations and public launch follow the readiness gates above. Launch copy,
 waitlist communications and rollout decisions belong in Linear. [DIN-21](https://linear.app/keepthescore/issue/DIN-21) is Canceled;

--- a/dinkydash/CLAUDE.md
+++ b/dinkydash/CLAUDE.md
@@ -5,23 +5,23 @@ to every change; this file holds the ones that only bite here.
 
 ## The storage seam
 
-Six operations, on one object, and nothing above them knows what is behind it:
+Seven operations, on one object, and nothing above them knows what is behind it:
 
 ```python
-load_config()                save_config(config)
+load_config()                save_config(config, invalidate_calendars=())
 load_payload(config)         save_agenda(config, agenda)
                              save_brief(config, brief)
 recent_notes(config, days)   record_note(config, entry, keep)
 ```
 
 Both implementations exist. `FileStore(config_path)` is `config.yaml` and two JSON files in one
-directory. `PostgresStore(pool, family_id)` is the same six operations against rows, with the
+directory. `PostgresStore(pool, family_id)` is the same seven operations against rows, with the
 payload composed from `generations` (the brief) and `agendas` (the fetched window) and handed back
 as the same dict. The runner takes a store; web routes get theirs from
 `web.family.current_store()`. `create_app(store=None, *, pool=None)` accepts a store in single
 mode or a pool in cloud mode. Cloud stores are scoped to the authenticated request.
 
-Four rules keep it a seam rather than a name:
+These rules keep the storage contract consistent:
 
 - **`store.py` and `config.py` are the only files under `dinkydash/` that open a file**, and
   `pgstore.py` and `db.py` are the only ones that import psycopg. `grep -rn "open(" dinkydash web`
@@ -39,11 +39,18 @@ Four rules keep it a seam rather than a name:
   its hand is stale by then (DIN-28). Each half is **replaced, not merged into**: a key the caller
   stops sending disappears, because that is what whole-row writes do in Postgres, and a stale value
   surviving on a Pi but not in the cloud is exactly the divergence the seam exists to prevent.
-  `FileStore` takes a short `flock` **on the containing directory** for its read-modify-write — a
+  `FileStore` takes a short `flock` **on the config directory** for settings and payload writes — a
   lock file beside the data would have to be kept out of `deploy_to_pi.sh`'s `rsync --delete`, and a
   deploy landing mid-write would otherwise unlink the inode a running tick still held, leaving the
-  next writer to lock a fresh file and serialise against nobody. Cloud mode needs no lock at all:
-  there the halves are separate rows and each write is one statement.
+  next writer to lock a fresh file and serialise against nobody. This also covers a `data_file`
+  in another directory. Cloud mode stores the two halves in separate rows.
+- **Settings saves invalidate affected calendars before another refresh can publish.** Both
+  stores compare the fetch's calendar settings with the saved config inside the write lock;
+  `save_agenda` returns `False` if they differ. `save_config` clears changed labels and the fetch
+  stamp under that same lock, with an optional `invalidate_calendars` for an explicit Save of
+  unchanged values. Postgres uses a family-row lock and one transaction; FileStore clears the
+  agenda before replacing the config. No network call holds either lock. Item ID backfills and
+  unrelated settings preserve the agenda; changing the timezone or fetched window clears it.
 - **`tests/test_store_contract.py` runs every one of its assertions against both**, parametrised over
   the two backends with no branching. That parity is most of the value of having named the seam: a
   suite that only ran against files would not notice the day the two drifted. The Postgres half
@@ -290,8 +297,7 @@ instead: whatever is owed is still owed five minutes later. It is deliberately o
 
 A calendar entry's `shared_with` is a list of email addresses, and `parse_feed` keeps only the
 events with one of them on the guest list or as the organiser. A personal calendar full of work
-and private appointments then contributes the family things and nothing else. Four things about
-it are deliberate:
+and private appointments then contributes the family things and nothing else:
 
 - **It is per feed, not global.** The school calendar has no guests, and the global
   `calendar_filter_emails` this replaced emptied it — which is why that key was dropped.
@@ -305,14 +311,11 @@ it are deliberate:
 - **`describe_feed` counts before and after**, so **Check this link** can say a working link has
   24 events and none of them match. A list that matches nobody looks exactly like an empty
   calendar from the board, and that silent zero was the old filter's failure mode.
-- **Saving or removing a calendar forgets what it last said** (`runner.forget_calendar`, called
-  from the settings routes). The stored events under that label go, and the fetch stamp with
-  them, so the next tick owes a refresh and a calendar that is still on is back within one.
-  Without this, a guest list added after a fetch left the unfiltered events on the board and in
-  the next brief until a refresh happened to succeed — and because `_with_last_known` keeps a
-  failing feed's previous events, a feed that then went down kept them for as long as it was
-  down. Forgetting first means there is nothing old left to keep. The stored events cannot be
-  re-filtered instead: they carry no addresses, by design.
+- **Saving or removing a calendar forgets what it last said**, through the store's config save.
+  Its events, statuses and the fetch stamp go, so the next tick owes a refresh. Publication checks
+  also reject a fetch still using the previous settings, including failed-fetch fallback data.
+  A rejected refresh stops the tick before the model call; the next tick loads the new config.
+  The stored events cannot be re-filtered instead: they carry no addresses, by design.
 
 `addresses()` is the one normaliser — list or comma-separated string in, lowercase list out, with
 `mailto:` stripped — and both the form and the engine go through it, so a hand-written

--- a/dinkydash/pgstore.py
+++ b/dinkydash/pgstore.py
@@ -1,14 +1,13 @@
 """The cloud half of the storage seam: one family's rows in Postgres.
 
-Same six operations as `FileStore`, same dicts in and out, so the runner, the
+Same seven operations as `FileStore`, same dicts in and out, so the runner, the
 board route and the settings routes cannot tell which one they were handed
 (PLAN.md decision 10, and the seam named in DIN-19).
 
 Kept in its own module rather than beside `FileStore` for one reason: single
 mode must never import psycopg. A Raspberry Pi has no database and should not
 install a driver for one, so `psycopg` lives in `requirements-cloud.txt` and
-`dinkydash/store.py` stays importable with nothing but the standard library and
-ruamel.
+`dinkydash/store.py` stays importable with the single-mode dependencies.
 
 **Every query is scoped to `self.family_id`.** There is no unscoped read and no
 unscoped write in this file, and there must never be one — an id arriving in a
@@ -25,8 +24,10 @@ Where the payload lives:
 `save_agenda` and `save_brief` each write one table and never the other. That
 is why the two are separate operations rather than one `save_payload`: a brief
 whose write is separated from its read by a slow model call would otherwise
-overwrite an agenda that landed in between (DIN-28). Here each write is a
-single statement, so no lock is involved at all.
+overwrite an agenda that landed in between (DIN-28). Config saves and agenda
+publication also lock the family's config row: invalidation and settings commit
+together, and a fetch made with obsolete calendar settings is rejected (DIN-46).
+Network requests run outside these transactions.
 """
 
 import logging
@@ -35,7 +36,7 @@ from datetime import date, datetime, timezone
 from psycopg.types.json import Jsonb
 
 from . import config as config_module
-from .store import AGENDA_KEYS
+from .store import AGENDA_KEYS, calendar_config, invalidated_agenda
 
 log = logging.getLogger(__name__)
 
@@ -76,24 +77,33 @@ class PostgresStore:
             raise NoSuchFamily(f"No family {self.family_id}")
         return config_module.with_defaults(dict(row[0] or {}))
 
-    def save_config(self, config):
+    def save_config(self, config, *, invalidate_calendars=()):
         with self.pool.connection() as conn, conn.transaction():
             with conn.cursor() as cur:
+                previous = self._locked_config(cur)
+                agenda = invalidated_agenda(previous, config, self._load_agenda(cur),
+                                            invalidate_calendars)
                 cur.execute(
                     "UPDATE families SET config = %s, updated_at = now() WHERE id = %s",
                     (Jsonb(_plain(config)), self.family_id),
                 )
+                if agenda is not None:
+                    self._save_agenda(cur, agenda)
+
+    def _locked_config(self, cur):
+        """Serialize settings edits and agenda publication, never the fetch itself."""
+        cur.execute("SELECT config FROM families WHERE id = %s FOR UPDATE", (self.family_id,))
+        row = cur.fetchone()
+        if row is None:
+            raise NoSuchFamily(f"No family {self.family_id}")
+        return config_module.with_defaults(dict(row[0] or {}))
 
     # -- the board ----------------------------------------------------------
 
     def load_payload(self, config=None):
         """The stored board, or None when this family has never had one."""
         with self.pool.connection() as conn, conn.cursor() as cur:
-            cur.execute(
-                "SELECT events, statuses, fetched_at FROM agendas WHERE family_id = %s",
-                (self.family_id,),
-            )
-            agenda = cur.fetchone()
+            agenda = self._load_agenda(cur)
             cur.execute(
                 """SELECT brief, generated_for_date, generated_at, model,
                           input_tokens, output_tokens
@@ -118,28 +128,40 @@ class PostgresStore:
             payload["input_tokens"] = tokens_in
             payload["output_tokens"] = tokens_out
         if agenda is not None:
-            events, statuses, fetched_at = agenda
-            payload["events"] = events or []
-            payload["calendar_statuses"] = statuses or []
-            payload["calendars_fetched_at"] = _iso(fetched_at)
+            payload.update(agenda)
         return payload
 
+    def _load_agenda(self, cur):
+        cur.execute("SELECT events, statuses, fetched_at FROM agendas WHERE family_id = %s",
+                    (self.family_id,))
+        row = cur.fetchone()
+        if row is None:
+            return None
+        events, statuses, fetched_at = row
+        return {"events": events or [], "calendar_statuses": statuses or [],
+                "calendars_fetched_at": _iso(fetched_at)}
+
     def save_agenda(self, config, agenda):
-        """Replace this family's `agendas` row. One statement, nothing else touched."""
+        """Publish only if the saved calendar settings still match the fetch."""
         with self.pool.connection() as conn, conn.transaction():
             with conn.cursor() as cur:
-                cur.execute(
-                    """INSERT INTO agendas (family_id, events, statuses, fetched_at)
-                       VALUES (%s, %s, %s, %s)
-                       ON CONFLICT (family_id) DO UPDATE
-                       SET events = EXCLUDED.events,
-                           statuses = EXCLUDED.statuses,
-                           fetched_at = EXCLUDED.fetched_at""",
-                    (self.family_id,
-                     Jsonb(agenda.get("events") or []),
-                     Jsonb(agenda.get("calendar_statuses") or []),
-                     _stamp(agenda.get("calendars_fetched_at"))),
-                )
+                if calendar_config(self._locked_config(cur)) != calendar_config(config):
+                    return False
+                self._save_agenda(cur, agenda)
+                return True
+
+    def _save_agenda(self, cur, agenda):
+        cur.execute(
+            """INSERT INTO agendas (family_id, events, statuses, fetched_at)
+               VALUES (%s, %s, %s, %s)
+               ON CONFLICT (family_id) DO UPDATE
+               SET events = EXCLUDED.events,
+                   statuses = EXCLUDED.statuses,
+                   fetched_at = EXCLUDED.fetched_at""",
+            (self.family_id, Jsonb(agenda.get("events") or []),
+             Jsonb(agenda.get("calendar_statuses") or []),
+             _stamp(agenda.get("calendars_fetched_at"))),
+        )
 
     def save_brief(self, config, brief):
         """Replace today's `generations` row. Never writes `agendas`.

--- a/dinkydash/runner.py
+++ b/dinkydash/runner.py
@@ -71,7 +71,8 @@ def refresh_calendars(config, store, now=None, today=None):
         "calendar_statuses": statuses,
         "calendars_fetched_at": now.astimezone(timezone.utc).isoformat(),
     }
-    store.save_agenda(config, agenda)
+    if not store.save_agenda(config, agenda):
+        raise GenerationError("Calendar settings changed during the refresh. Please refresh again.")
     log.info("Calendars refreshed: %d events stored", len(events))
     return agenda
 
@@ -104,34 +105,6 @@ def _with_last_known(fresh, previous, failed_labels, start, end):
     if kept:
         log.info("Kept %d event(s) from the feeds that did not answer", len(kept))
     return sorted(fresh + kept, key=sort_key)
-
-
-def forget_calendar(config, store, labels):
-    """Drop what a calendar last said, and make the next tick fetch again.
-
-    The settings UI calls this when a calendar is saved or removed. Events
-    fetched under the old entry cannot be trusted under the new one — a
-    changed URL is a different calendar, and a guest list added after the
-    fetch was never applied to it, nor can it be now, because the events
-    carry no addresses. So they go, rather than sit on the board and in the
-    next brief until a refresh happens to succeed. Only that calendar's go:
-    the rest of the agenda is still exactly what its feeds said.
-
-    The fetch stamp goes with them, which is what makes the next tick owe a
-    refresh (`schedule.refresh_due`), so a calendar that is still on is back
-    within a tick — and what stops `_with_last_known` bringing the old events
-    back if that first fetch fails: there is nothing left to keep. Written
-    through `save_agenda`, so the brief cannot be touched from here.
-    """
-    labels = set(labels)
-    payload = store.load_payload(config)
-    if not payload:
-        return
-    events = [e for e in payload.get("events") or [] if e.get("calendar") not in labels]
-    statuses = [s for s in payload.get("calendar_statuses") or []
-                if s.get("label") not in labels]
-    store.save_agenda(config, {"events": events, "calendar_statuses": statuses})
-    log.info("Forgot the stored events of %s; a refresh is due", ", ".join(sorted(labels)))
 
 
 def write_brief(config, store, today=None, client=None, budget=None):

--- a/dinkydash/store.py
+++ b/dinkydash/store.py
@@ -1,19 +1,15 @@
 """The storage seam: where a family's config, board and history are kept.
 
-The engine takes a config dict and hands back a payload dict. Something has to
-keep those somewhere, and today that is three files beside `config.yaml`. In
-cloud mode it is rows in Postgres, keyed on a family (PLAN.md decision 10).
+FileStore keeps config.yaml and two JSON files; PostgresStore keeps rows keyed
+on a family (PLAN.md decision 10). Both expose seven operations:
 
-So the six operations get a name now, while there is still one implementation:
-
-    load_config()                save_config(config)
+    load_config()                save_config(config, invalidate_calendars=())
     load_payload(config)         save_agenda(config, agenda)
                                  save_brief(config, brief)
     recent_notes(config, days)   record_note(config, entry, keep)
 
 The runner, the board route and the settings routes take a store and never
-learn which one they were given. `PostgresStore` is then a second class rather
-than a fork of every caller.
+learn which one they were given.
 
 **The board is read whole and written in halves**, and that is the shape rather
 than an accident. A refresh owns the agenda; the daily brief owns the words.
@@ -24,13 +20,17 @@ triggered it said it had worked (DIN-28). Two operations that each write only
 what they own makes that impossible rather than merely unlikely; in Postgres
 they are already two tables, so it is also the more honest mapping.
 
+Settings saves clear affected calendars under the same lock as agenda writes.
+`save_agenda` returns False if the saved calendar settings no longer match the
+fetch; the runner then stops before generating a brief from obsolete results.
+
 The payload and history calls are handed the config because `FileStore` needs
 two keys out of it — `data_file` and `content_history_file` — to know where to
 write. Those are storage-layer keys: they mean nothing in cloud mode, and this
 is the only module that reads them.
 
 This module and `config.py` are the only places under `dinkydash/` that touch
-a file. Everything else stays pure.
+a file.
 """
 
 import json
@@ -47,6 +47,7 @@ except ImportError:  # pragma: no cover - Windows has no flock
 
 from . import config as config_module
 from . import history as history_module
+from .calendars import feed_label
 
 log = logging.getLogger(__name__)
 
@@ -75,11 +76,23 @@ class FileStore:
 
     def load_config(self):
         """The config as a plain dict, defaults filled in and old shapes migrated."""
-        return config_module.load_config(self.config_path)
+        with _locked(self.base):
+            return config_module.load_config(self.config_path)
 
-    def save_config(self, config):
-        """Write it back, comments and key order intact."""
-        config_module.save_config(config, self.config_path)
+    def save_config(self, config, *, invalidate_calendars=()):
+        """Save settings and invalidate changed calendars under the same lock."""
+        with _locked(self.base):
+            try:
+                previous = config_module.load_config(self.config_path)
+            except FileNotFoundError:
+                previous = {}
+            agenda = invalidated_agenda(previous, config, self.load_payload(previous),
+                                        invalidate_calendars)
+            if agenda is not None:
+                # Clear first: even a failed config write must not leave a new
+                # privacy setting visible beside events fetched before it.
+                self._replace(previous, _is_agenda_key, agenda)
+            config_module.save_config(config, self.config_path)
 
     # -- the board ----------------------------------------------------------
 
@@ -89,9 +102,14 @@ class FileStore:
         return payload if isinstance(payload, dict) else None
 
     def save_agenda(self, config, agenda):
-        """Replace the fetched window, leaving the brief exactly as it was."""
-        self._replace(config, _is_agenda_key,
-                      {k: agenda[k] for k in AGENDA_KEYS if k in agenda})
+        """Publish only if the saved calendar settings still match the fetch."""
+        with _locked(self.base):
+            current = config_module.load_config(self.config_path)
+            if calendar_config(current) != calendar_config(config):
+                return False
+            self._replace(config, _is_agenda_key,
+                          {k: agenda[k] for k in AGENDA_KEYS if k in agenda})
+            return True
 
     def save_brief(self, config, brief):
         """Replace the model's words, leaving the fetched window alone.
@@ -99,33 +117,19 @@ class FileStore:
         Agenda keys are dropped rather than trusted, so a caller handing over a
         whole payload cannot resurrect a stale agenda through this door.
         """
-        self._replace(config, lambda key: not _is_agenda_key(key),
-                      {k: v for k, v in brief.items() if not _is_agenda_key(k)})
+        with _locked(self.base):
+            self._replace(config, lambda key: not _is_agenda_key(key),
+                          {k: v for k, v in brief.items() if not _is_agenda_key(k)})
 
     def _replace(self, config, owns, updates):
-        """Swap out everything this half owns, inside one lock.
-
-        **Replace, not merge.** A key the caller has stopped sending has to
-        disappear, because that is what `PostgresStore` does — it writes whole
-        rows, so an omitted `model` or token count comes back as None. Merging
-        instead would leave a stale value behind on a Pi and not in the cloud,
-        which is exactly the sort of quiet divergence the storage seam exists to
-        prevent.
-
-        The lock covers a read and a write a microsecond apart, never a model
-        call, so nothing waits on it in practice. Without it two processes on
-        one Pi could still interleave — the same bug the split removes, only
-        very much narrower. Cloud mode needs no equivalent: there each half is
-        a row and each write is one statement.
-        """
+        """Replace this half's fields. The caller holds the config-directory lock."""
         path = self._data_path(config)
-        with _locked(path.parent):
-            stored = _read_json(path, "the stored board")
-            if not isinstance(stored, dict):
-                stored = {}
-            payload = {k: v for k, v in stored.items() if not owns(k)}
-            payload.update(updates)
-            _write_json(path, payload)
+        stored = _read_json(path, "the stored board")
+        if not isinstance(stored, dict):
+            stored = {}
+        payload = {k: v for k, v in stored.items() if not owns(k)}
+        payload.update(updates)
+        _write_json(path, payload)
 
     # -- what was written recently ------------------------------------------
 
@@ -172,6 +176,33 @@ def _is_agenda_key(key):
     return key in AGENDA_KEYS
 
 
+def calendar_config(config):
+    """Fetch inputs, grouped by the label carried by stored events.
+
+    Ignore item IDs so backfilling them does not invalidate a working agenda.
+    Keep duplicate labels together: changing either source invalidates that label.
+    """
+    feeds = {}
+    for entry in config.get("calendars") or []:
+        if isinstance(entry, dict):
+            feeds.setdefault(feed_label(entry), []).append(
+                {key: value for key, value in entry.items() if key != "id"})
+    return (config.get("timezone") or config_module.DEFAULTS["timezone"],
+            int(config.get("calendar_days_ahead") or 14), feeds)
+
+
+def invalidated_agenda(previous, current, payload, labels=()):
+    """Drop affected events and the fetch stamp, or return None for no change."""
+    before, after = calendar_config(previous), calendar_config(current)
+    if payload is None or (before == after and not labels):
+        return None
+    changed = set(labels) | {label for label in before[2].keys() | after[2].keys()
+                            if before[2].get(label) != after[2].get(label)}
+    return {key: [entry for entry in payload.get(key) or []
+                  if before[:2] == after[:2] and entry.get(label_key) not in changed]
+            for key, label_key in (("events", "calendar"), ("calendar_statuses", "label"))}
+
+
 @contextmanager
 def _locked(directory):
     """An exclusive lock on the directory, for one read and one write.
@@ -184,10 +215,9 @@ def _locked(directory):
     nobody — silently. A directory's inode survives all of that, and there is no
     file to remember to exclude.
 
-    `flock` is per-machine, which is all single mode needs: the web process and
-    the tick are on the same Pi. It is deliberately not the answer for cloud
-    mode, where `web` and `worker` are separate containers — there the split
-    into two rows is what makes concurrent writes safe.
+    Lock the config directory for settings and payload writes, including when
+    `data_file` points elsewhere. No network call runs under this lock. Cloud
+    mode coordinates config and agenda writes with a family-row lock instead.
     """
     if fcntl is None:  # Windows; the board runs on Linux and macOS
         yield

--- a/generate.py
+++ b/generate.py
@@ -130,23 +130,20 @@ def tick(config, store, budget=None):
         log.debug("Nothing due")
         return 0
 
-    if owed["refresh"]:
-        # Outside the budget on purpose: a fetch costs requests, not money, and
-        # a family who cannot afford a new headline today should still have an
-        # accurate agenda under yesterday's.
-        refresh_calendars(config, store, now=now)
-
-    if owed["brief"]:
-        today = now.astimezone(config_module.tzinfo_for(config)).date()
-        try:
-            report(write_brief(config, store, today=today, budget=budget))
-        except GenerationError as exc:
-            # Not fatal: the brief is simply due again on the next tick. That
-            # covers a refused call too — the next tick asks again, gets the
-            # same refusal until the day turns over, and writes nothing.
-            log.error("%s", exc)
-            log.error("Keeping the previous board; the next tick will try again.")
-            return 1
+    try:
+        if owed["refresh"]:
+            # A stale refresh also stops this tick's brief; the next pass loads
+            # the new config before fetching or making a model call.
+            refresh_calendars(config, store, now=now)
+        if owed["brief"]:
+            today = now.astimezone(config_module.tzinfo_for(config)).date()
+            # runner logs date and usage. Reporting family text is reserved for
+            # the explicit CLI run above, never the shared worker or cron tick.
+            write_brief(config, store, today=today, budget=budget)
+    except GenerationError as exc:
+        log.error("%s", exc)
+        log.error("Keeping the previous board; the next tick will try again.")
+        return 1
     return 0
 
 

--- a/tests/test_calendar_publication.py
+++ b/tests/test_calendar_publication.py
@@ -1,0 +1,191 @@
+"""A settings edit must invalidate both stored and in-flight calendar results."""
+
+from concurrent.futures import ThreadPoolExecutor
+from copy import copy, deepcopy
+from datetime import datetime, timezone
+from threading import Event
+
+import pytest
+
+import generate as cli
+from dinkydash import board, runner
+from dinkydash.claude_client import GenerationError
+from dinkydash.schedule import due
+from test_generate import FakeClient
+from test_store_contract import store  # noqa: F401 - run against both backends
+
+NOW = datetime(2026, 9, 3, 8, tzinfo=timezone.utc)
+PRIVATE = "Private appointment marker"
+FAMILY = {"id": "family", "label": "Family", "url": "https://example.com/family.ics",
+          "enabled": True}
+SCHOOL = {"id": "school", "label": "School", "url": "https://example.com/school.ics",
+          "enabled": True}
+
+
+def event(title, label):
+    return {"title": title, "calendar": label, "date": "2026-09-03",
+            "time": "15:45", "all_day": False, "start": "2026-09-03T15:45:00+02:00",
+            "location": None}
+
+
+@pytest.fixture
+def seeded(store, tmp_path):
+    config = store.load_config()
+    # File mode must coordinate settings and agenda even in different directories.
+    (tmp_path / "payload").mkdir()
+    config["data_file"] = "payload/data.json"
+    config["calendars"] = deepcopy([FAMILY, SCHOOL])
+    store.save_config(config)
+    agenda = {"events": [event(PRIVATE, "Family"), event("Sports day", "School")],
+              "calendar_statuses": [{"label": name, "ok": True, "count": 1}
+                                    for name in ("Family", "School")],
+              "calendars_fetched_at": NOW.isoformat()}
+    store.save_agenda(config, agenda)
+    store.save_brief(config, {"generated_for_date": "2026-09-02",
+                             "headline": "Previous headline", "note": "Previous note"})
+    return config, agenda
+
+
+def change(config, kind):
+    updated = deepcopy(config)
+    if kind == "remove":
+        updated["calendars"].pop(0)
+    else:
+        field, value = {
+            "filter": ("shared_with", ["parent@example.com"]),
+            "pause": ("enabled", False),
+            "rename": ("label", "Renamed family"),
+            "url": ("url", "https://example.com/replacement.ics"),
+        }[kind]
+        updated["calendars"][0][field] = value
+    return updated
+
+
+@pytest.mark.parametrize("kind", ["filter", "remove", "pause", "rename", "url"])
+@pytest.mark.parametrize("failed", [False, True], ids=["in-flight-fetch", "cached-fallback"])
+def test_an_old_refresh_cannot_restore_events_after_a_calendar_edit(
+        store, seeded, kind, failed, monkeypatch):
+    config, agenda = seeded
+    paused, resume = Event(), Event()
+    load_payload = store.load_payload
+    editor = copy(store)
+
+    def fetch(*args, **kwargs):
+        if failed:
+            return [], [{"label": "Family", "ok": False},
+                        {"label": "School", "ok": False}]
+        paused.set()
+        assert resume.wait(5), "settings did not finish while the fetch was paused"
+        return deepcopy(agenda["events"]), deepcopy(agenda["calendar_statuses"])
+
+    def read_previous(config):
+        previous = load_payload(config)
+        if failed:
+            # The failure fallback already has the private events in hand.
+            paused.set()
+            assert resume.wait(5), "settings did not finish while fallback was paused"
+        return previous
+
+    monkeypatch.setattr(runner, "fetch_events", fetch)
+    monkeypatch.setattr(store, "load_payload", read_previous)
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        pending = pool.submit(runner.refresh_calendars, config, store, now=NOW)
+        try:
+            assert paused.wait(5)
+            updated = change(config, kind)
+            # Use a second store object, as a concurrent web request does.
+            editor.save_config(updated)
+            after_edit = load_payload(updated)
+        finally:
+            resume.set()
+        with pytest.raises(GenerationError, match="Calendar settings changed"):
+            pending.result(timeout=5)
+
+    monkeypatch.setattr(store, "load_payload", load_payload)
+    assert after_edit["events"] == [event("Sports day", "School")]
+    assert not after_edit.get("calendars_fetched_at")
+    payload = store.load_payload(updated)
+    assert payload["events"] == after_edit["events"]
+    assert payload["headline"] == "Previous headline"
+    assert due(updated, payload, NOW)["refresh"]
+    assert PRIVATE not in str(board.build_view(updated, payload, NOW.date()))
+
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-not-a-real-key")
+    client = FakeClient()
+    runner.write_brief(updated, store, today=NOW.date(), client=client)
+    assert PRIVATE not in client.messages.calls[0]["messages"][0]["content"]
+
+
+def test_a_failed_fetch_under_the_new_filter_cannot_reuse_old_events(
+        store, seeded, monkeypatch):
+    config, _ = seeded
+    updated = change(config, "filter")
+    store.save_config(updated)
+    monkeypatch.setattr(runner, "fetch_events", lambda *a, **k: (
+        [], [{"label": "Family", "ok": False}, {"label": "School", "ok": False}]))
+    runner.refresh_calendars(updated, store, now=NOW)
+    assert store.load_payload(updated)["events"] == [event("Sports day", "School")]
+
+
+def test_a_stale_tick_skips_the_model_and_retries_with_current_settings(
+        store, seeded, monkeypatch):
+    config, agenda = seeded
+    store.save_agenda(config, dict(agenda, calendars_fetched_at="2026-09-03T06:00:00+00:00"))
+    updated = change(config, "filter")
+    client = FakeClient()
+    calls = []
+
+    class Clock:
+        @staticmethod
+        def now(tz):
+            return NOW
+
+    def fetch(feeds, *args, **kwargs):
+        calls.append(feeds)
+        if len(calls) == 1:
+            store.save_config(updated)
+            return agenda["events"], agenda["calendar_statuses"]
+        return [event("Sports day", "School")], agenda["calendar_statuses"]
+
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-not-a-real-key")
+    monkeypatch.setattr(cli, "datetime", Clock)
+    monkeypatch.setattr(runner, "fetch_events", fetch)
+    monkeypatch.setattr(cli, "write_brief", lambda *args, **kwargs:
+                        runner.write_brief(*args, client=client, **kwargs))
+
+    assert cli.tick(config, store) == 1
+    assert client.messages.calls == []
+    assert store.load_payload(updated)["headline"] == "Previous headline"
+    assert cli.tick(store.load_config(), store) == 0
+    assert calls[1] == updated["calendars"]
+    assert len(client.messages.calls) == 1
+    assert PRIVATE not in client.messages.calls[0]["messages"][0]["content"]
+
+
+def test_unrelated_edits_and_id_backfilling_keep_the_agenda(store, seeded):
+    config, agenda = seeded
+    updated = deepcopy(config)
+    updated["theme"] = "dark"
+    updated["calendars"][0]["id"] = "backfilled-id"
+    store.save_config(updated)
+    assert store.load_payload(updated)["events"] == agenda["events"]
+    # An in-flight refresh is still usable when only unrelated settings changed.
+    assert store.save_agenda(config, agenda) is True
+
+
+def test_explicitly_saving_a_calendar_still_clears_its_cache(store, seeded):
+    config, _ = seeded
+    store.save_config(config, invalidate_calendars=("Family",))
+    payload = store.load_payload(config)
+    assert payload["events"] == [event("Sports day", "School")]
+    assert not payload.get("calendars_fetched_at")
+
+
+@pytest.mark.parametrize("field,value", [("timezone", "Pacific/Auckland"),
+                                         ("calendar_days_ahead", 7)])
+def test_a_changed_calendar_window_invalidates_the_old_results(store, seeded, field, value):
+    config, agenda = seeded
+    updated = dict(config, **{field: value})
+    store.save_config(updated)
+    assert store.load_payload(updated)["events"] == []
+    assert store.save_agenda(config, agenda) is False

--- a/tests/test_private_logs.py
+++ b/tests/test_private_logs.py
@@ -1,0 +1,128 @@
+"""Exercise the service entry points with invented family text and credentials."""
+
+import logging
+from datetime import timedelta
+from types import SimpleNamespace
+from urllib.parse import unquote
+
+import pytest
+
+import generate as cli
+from dinkydash import runner
+from dinkydash.claude_client import GenerationError
+from dinkydash.store import FileStore
+from test_worker import FakeBudget, FakePool
+from web.routes.auth import quieten_the_request_log
+from worker import tick_all
+
+
+@pytest.mark.parametrize("logger_name", ["werkzeug", "gunicorn.access"])
+@pytest.mark.parametrize("path", [
+    "/s/abcdEfghjkmn",
+    "/s/abcd%45fghjkmn",
+    "/s/abcdEfghjkmn/manifest.webmanifest",
+    "/s/short",
+    "/s/abcd!fghjkmn",
+    "/s/abcd💛fghjkmn",
+    "/%73/abcdEfghjkmn",
+    "%2Fs%2FabcdEfghjkmn",
+    "/s%2FabcdEfghjkmn",
+    "/S/abcdEfghjkmn",
+    "/s/abcd/efghjkmn",
+    "/s/abcd?efghjkmn",
+    "/s/abcd'fghjkmn",
+    '/s/abcd"fghjkmn',
+])
+def test_request_loggers_redact_the_whole_credential_even_when_invalid(
+        logger_name, path, caplog):
+    quieten_the_request_log()
+    with caplog.at_level(logging.INFO, logger=logger_name):
+        logging.getLogger(logger_name).info('GET %s HTTP/1.1 %d', path, 404)
+    message = caplog.records[-1].getMessage()
+    assert "[redacted]" in message
+    assert "abcd" not in message and "fghjkmn" not in message and "short" not in message
+    assert "HTTP/1.1 404" in message
+
+
+@pytest.mark.parametrize("logger_name", ["werkzeug", "gunicorn.access"])
+def test_request_loggers_preserve_ordinary_request_fields(logger_name, caplog):
+    quieten_the_request_log()
+    with caplog.at_level(logging.INFO, logger=logger_name):
+        logging.getLogger(logger_name).info("GET %s HTTP/1.1 %d", "/settings/people", 200)
+    assert caplog.records[-1].getMessage() == "GET /settings/people HTTP/1.1 200"
+
+
+@pytest.mark.parametrize("encoded", ["%20", "%09", "%0A", "%C2%A0", "%27", "%22"])
+@pytest.mark.parametrize("server", ["gunicorn", "werkzeug"])
+def test_server_formatting_cannot_expose_the_tail_of_a_decoded_token(encoded, server, caplog):
+    path = f"/s/abcd{encoded}fghjkmn"
+    quieten_the_request_log()
+    with caplog.at_level(logging.INFO):
+        if server == "gunicorn":
+            glogging = pytest.importorskip("gunicorn.glogging")
+            # Use the real atoms and escaping, without changing global handlers.
+            logger = object.__new__(glogging.Logger)
+            logger.cfg = SimpleNamespace(accesslog="-", access_log_format=
+                                         '"%(m)s %(U)s %(H)s" %(s)s')
+            logger.access_log = logging.getLogger("gunicorn.access")
+            environ = {"REQUEST_METHOD": "GET", "RAW_URI": path,
+                       "PATH_INFO": unquote(path), "SERVER_PROTOCOL": "HTTP/1.1"}
+            response = SimpleNamespace(status="404 NOT FOUND", headers=[], sent=0)
+            logger.access(response, {}, environ, timedelta())
+        else:
+            from werkzeug.serving import WSGIRequestHandler
+
+            handler = object.__new__(WSGIRequestHandler)
+            handler.path, handler.command, handler.request_version = path, "GET", "HTTP/1.1"
+            handler.client_address = ("127.0.0.1", 1234)
+            handler.log_request(404)
+
+    assert "abcd" not in caplog.text and "fghjkmn" not in caplog.text
+    assert "[redacted]" in caplog.text
+    assert "HTTP/1.1" in caplog.text and "404" in caplog.text
+
+
+@pytest.fixture
+def generated_store(tmp_path, monkeypatch):
+    path = tmp_path / "config.yaml"
+    path.write_text('family_name: "Invented family"\ncalendars: []\n')
+    store = FileStore(path)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-not-a-real-key")
+
+    def generated(config, today, events, **kwargs):
+        return {"generated_for_date": today.isoformat(),
+                "headline": "Private headline marker", "note": "Private note marker",
+                "note_kind": "fact", "input_tokens": 123, "output_tokens": 45}
+
+    monkeypatch.setattr(runner, "generate", generated)
+    return store
+
+
+def test_real_worker_tick_logs_metadata_without_generated_text(generated_store, caplog):
+    with caplog.at_level(logging.INFO):
+        assert tick_all(FakePool(["family"]), store_factory=lambda _: generated_store,
+                        budget_factory=FakeBudget) == 1
+    assert "Board written for" in caplog.text
+    assert "123 tokens in, 45 out" in caplog.text
+    assert "Private headline marker" not in caplog.text
+    assert "Private note marker" not in caplog.text
+    assert generated_store.load_payload(generated_store.load_config())["headline"] == "Private headline marker"
+
+
+def test_an_explicit_cli_run_still_reports_its_result(generated_store, caplog):
+    with caplog.at_level(logging.INFO):
+        assert cli.main(["--config", str(generated_store.config_path)]) == 0
+    assert "Private headline marker" in caplog.text
+    assert "Private note marker" in caplog.text
+
+
+def test_a_failed_worker_generation_still_reports_the_failure(generated_store, caplog, monkeypatch):
+    def failed(*args, **kwargs):
+        raise GenerationError("Provider unavailable")
+
+    monkeypatch.setattr(runner, "generate", failed)
+    with caplog.at_level(logging.INFO):
+        tick_all(FakePool(["family"]), store_factory=lambda _: generated_store,
+                 budget_factory=FakeBudget)
+    assert "Provider unavailable" in caplog.text
+    assert "the next tick will try again" in caplog.text

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -93,48 +93,6 @@ def fake_fetch(events, statuses, seen=None):
     return _fetch
 
 
-class TestForgetCalendar:
-    """Saving a calendar in the settings UI forgets what it last said."""
-
-    BOTH = EVENTS + SCHOOL
-    BOTH_STATUS = [{"label": "Family", "ok": True, "detail": "", "count": 1},
-                   {"label": "School", "ok": True, "detail": "", "count": 1}]
-
-    def test_drops_only_that_calendars_events_and_the_stamp(self, home, store, config):
-        write_stored(home, {
-            "generated_for_date": "2026-09-03", "headline": "Hi", "note": "There",
-            "events": self.BOTH, "calendar_statuses": self.BOTH_STATUS,
-            "calendars_fetched_at": "2026-09-03T08:00:00+00:00",
-        })
-        runner.forget_calendar(config, store, {"Family"})
-        payload = stored(home)
-        assert payload["events"] == SCHOOL
-        assert payload["calendar_statuses"] == self.BOTH_STATUS[1:]
-        assert "calendars_fetched_at" not in payload
-        assert payload["headline"] == "Hi"  # the brief is not this half's to touch
-
-    def test_a_forgotten_calendar_is_due_at_the_next_tick(self, home, store, config):
-        write_stored(home, {"events": self.BOTH, "calendars_fetched_at": NOW.isoformat()})
-        assert due(config, stored(home), NOW)["refresh"] is False
-        runner.forget_calendar(config, store, {"Family"})
-        assert due(config, stored(home), NOW)["refresh"] is True
-
-    def test_the_last_known_fallback_cannot_bring_them_back(self, home, store, config,
-                                                            monkeypatch):
-        # The privacy case: a guest list added after the fetch. If the first
-        # fetch under the new entry fails, the old unfiltered events must not
-        # come back as "last known" — there has to be nothing left to keep.
-        write_stored(home, {"events": self.BOTH, "calendars_fetched_at": NOW.isoformat()})
-        runner.forget_calendar(config, store, {"Family"})
-        monkeypatch.setattr(runner, "fetch_events", fake_fetch(SCHOOL, MIXED_STATUS))
-        runner.refresh_calendars(config, store, now=NOW)
-        assert stored(home)["events"] == SCHOOL
-
-    def test_nothing_stored_is_nothing_to_do(self, home, store, config):
-        runner.forget_calendar(config, store, {"Family"})
-        assert not (home / "dashboard_data.json").exists()
-
-
 class TestRefreshCalendars:
     def test_stores_the_events_and_stamps_the_fetch(self, home, store, config, monkeypatch):
         monkeypatch.setattr(runner, "fetch_events", fake_fetch(EVENTS, OK_STATUS))

--- a/tests/test_screen.py
+++ b/tests/test_screen.py
@@ -162,8 +162,7 @@ class TestItIsTreatedAsACredential:
         assert "/s/[redacted]" in record.getMessage()
 
     def test_and_leaves_ordinary_paths_alone(self):
-        """`config.ID_ALPHABET` has no `i`, `l`, `o` or `0`, which is what lets
-        the pattern be this narrow — `/settings` and `/static` must survive."""
+        """The /s/ route prefix distinguishes credentials from ordinary paths."""
         for line in ('GET /settings/people HTTP/1.1', 'GET /static/fonts.css'):
             record = logging.LogRecord("gunicorn.access", logging.INFO, "", 0,
                                        line, None, None)

--- a/web/routes/auth.py
+++ b/web/routes/auth.py
@@ -25,7 +25,11 @@ bp = Blueprint("auth", __name__)
 A_TOKEN = re.compile(r"([?&]t=)[^&\s\"']+")
 REDACTED = r"\1[redacted]"
 
-A_SCREEN = re.compile(r"(/s/)[23456789abcdefghjkmnpqrstuvwxyz]{10,32}")
+# Validation belongs to the route. A typo still reveals a recoverable credential;
+# encoded separators/letters can also reach these paths through a server's decoder.
+SCREEN_PREFIX = r"((?:/|%2f)(?:s|%73|%53)(?:/|%2f))"
+A_SCREEN = re.compile(SCREEN_PREFIX + r"\S*", re.IGNORECASE)
+A_SCREEN_TARGET = re.compile(SCREEN_PREFIX + r".*", re.IGNORECASE | re.DOTALL)
 SCREEN_REDACTED = r"\1[redacted]"
 
 SAME_ANSWER = ("A link is on its way. It works once, and for fifteen minutes. "
@@ -50,10 +54,25 @@ class NoTokens(logging.Filter):
     """Redact magic-link and screen tokens from both server request loggers."""
 
     def filter(self, record):
+        # Redact while the server still gives us the target separately: decoded
+        # spaces and quotes inside a credential are not log-field separators.
+        if record.name == "gunicorn.access" and isinstance(record.args, dict):
+            path = record.args.get("U")
+            if isinstance(path, str):
+                record.args["U"] = A_SCREEN_TARGET.sub(SCREEN_REDACTED, path)
+        elif (record.name == "werkzeug" and isinstance(record.args, tuple)
+              and record.args and isinstance(record.args[0], str)):
+            request_line = record.args[0]
+            target, separator, protocol = request_line.rpartition(" HTTP/")
+            if not separator:
+                target, protocol = request_line, ""
+            redacted = A_SCREEN_TARGET.sub(SCREEN_REDACTED, target)
+            record.args = (redacted + separator + protocol, *record.args[1:])
+
         message = record.getMessage()
-        if "t=" in message or "/s/" in message:
-            record.msg = A_SCREEN.sub(SCREEN_REDACTED,
-                                      A_TOKEN.sub(REDACTED, message))
+        redacted = A_SCREEN.sub(SCREEN_REDACTED, A_TOKEN.sub(REDACTED, message))
+        if redacted != message:
+            record.msg = redacted
             record.args = ()
         return True
 

--- a/web/routes/settings.py
+++ b/web/routes/settings.py
@@ -22,7 +22,7 @@ from dinkydash import schedule, screens
 from dinkydash.calendars import FeedError, addresses, describe_feed, feed_label
 from dinkydash.claude_client import GenerationError
 from dinkydash.context import compute_birthday_info, upcoming_for
-from dinkydash.runner import forget_calendar, refresh_calendars
+from dinkydash.runner import refresh_calendars
 from dinkydash.runner import run as run_generation
 from web import CLOUD
 from web import manifest as manifest_module
@@ -157,8 +157,8 @@ def current_config():
     return config
 
 
-def save(config):
-    current_store().save_config(config)
+def save(config, *, invalidate_calendars=()):
+    current_store().save_config(config, invalidate_calendars=invalidate_calendars)
 
 
 def section_or_404(name):
@@ -392,14 +392,12 @@ def section_edit(section_name, item_id):
                 else:
                     submitted["id"] = item_id
                     items[index] = submitted
-                save(config)
+                # Pressing Save explicitly refreshes this calendar even when
+                # the values are unchanged. The store also detects changed or
+                # removed sources and clears them in the same operation.
+                save(config, invalidate_calendars=(feed_label(submitted),)
+                     if section_name == "calendars" else ())
                 if section_name == "calendars":
-                    # What this calendar last said was fetched under the old
-                    # entry — before a guest list, say — so it goes, and the
-                    # next tick fetches afresh. Under the old name as well as
-                    # the new, in case this was a rename.
-                    stale = {feed_label(submitted)} | ({feed_label(item)} if not is_new else set())
-                    forget_calendar(config, current_store(), stale)
                     flash(f"Saved {feed_label(submitted)}. The board picks up the change at "
                           f"the next refresh — press Refresh calendars if you don't want to wait.",
                           "ok")
@@ -472,8 +470,6 @@ def section_delete(section_name, item_id):
         abort(404)
     items.pop(index)
     save(config)
-    if section_name == "calendars":
-        forget_calendar(config, current_store(), {feed_label(removed)})
     flash(f"Removed {removed.get('name') or removed.get('title') or removed.get('label') or 'it'}.", "ok")
     return redirect(url_for("settings.section_list", section_name=section_name))
 


### PR DESCRIPTION
Calendar edits could be undone by an in-flight refresh, and routine worker/access logs could retain family text or recoverable screen credentials.

Fixes [DIN-46](https://linear.app/keepthescore/issue/DIN-46) and [DIN-47](https://linear.app/keepthescore/issue/DIN-47) by coordinating config invalidation with agenda publication in both stores, stopping stale ticks before model calls, logging worker metadata only, and redacting malformed or decoded screen targets before server formatting.

Updates the plan and storage/logging guidance, including the provider and device guides now on main.

Validation: 903 tests passed with PostgreSQL; 630 passed without a database (273 expected skips), including interleaving, failed-fetch fallback, retry, and real Gunicorn/Werkzeug logging regressions.
