### PR TITLE
Hide self-hosting settings in cloud mode, and drop the model in the route

### DIFF
--- a/tests/test_cloud_mode.py
+++ b/tests/test_cloud_mode.py
@@ -110,32 +110,38 @@ class TestTheSessionKey:
         assert create_app(FileStore(tmp_path / "config.yaml")).secret_key == "mine"
 
 
+@pytest.fixture
+def client(pg_pool, pg_family, monkeypatch):
+    """A signed-in cloud app with one family's board already written.
+
+    Module level rather than nested, because more than one class below needs
+    the same thing: a real cloud app, over a real pool, with a session on it.
+    """
+    from dinkydash.pgstore import PostgresStore
+
+    store = PostgresStore(pg_pool, pg_family)
+    store.save_config(dict(CONFIG))
+    today = payload_for_today()
+    store.save_agenda(store.load_config(), today)
+    store.save_brief(store.load_config(), today)
+
+    monkeypatch.setenv("DINKYDASH_MODE", "cloud")
+    monkeypatch.setenv("DINKYDASH_SECRET_KEY", "a-real-one")
+    # The pool, not the store. Cloud mode builds a `PostgresStore` per
+    # request from the family on the session, so handing one in would
+    # test a path production does not have.
+    client = client_for(create_app(pool=pg_pool))
+    # These tests are about the rows, not the login. Signing in by hand is
+    # what keeps them that way; `tests/test_auth.py` is where the gate
+    # itself is tested, and `tests/test_tenancy.py` the scoping.
+    with client.session_transaction() as stored:
+        stored["user_id"] = 1
+        stored["family_id"] = str(pg_family)
+    return client
+
+
 class TestABoardOutOfPostgres:
     """DIN-31's "done when": a board renders in cloud mode, from rows."""
-
-    @pytest.fixture
-    def client(self, pg_pool, pg_family, monkeypatch):
-        from dinkydash.pgstore import PostgresStore
-
-        store = PostgresStore(pg_pool, pg_family)
-        store.save_config(dict(CONFIG))
-        today = payload_for_today()
-        store.save_agenda(store.load_config(), today)
-        store.save_brief(store.load_config(), today)
-
-        monkeypatch.setenv("DINKYDASH_MODE", "cloud")
-        monkeypatch.setenv("DINKYDASH_SECRET_KEY", "a-real-one")
-        # The pool, not the store. Cloud mode builds a `PostgresStore` per
-        # request from the family on the session, so handing one in would
-        # test a path production does not have.
-        client = client_for(create_app(pool=pg_pool))
-        # These tests are about the rows, not the login. Signing in by hand is
-        # what keeps them that way; `tests/test_auth.py` is where the gate
-        # itself is tested, and `tests/test_tenancy.py` the scoping.
-        with client.session_transaction() as stored:
-            stored["user_id"] = 1
-            stored["family_id"] = str(pg_family)
-        return client
 
     def test_the_board_renders_the_stored_brief(self, client, pg_pool, pg_family):
         page = client.get(board_path(pg_pool, pg_family)).get_data(as_text=True)
@@ -206,3 +212,84 @@ class TestABoardOutOfPostgres:
         manifest = re.compile(r'<link rel="manifest" href="[^"]+">')
         assert manifest.search(from_file) and manifest.search(from_rows)
         assert manifest.sub("[manifest]", from_rows) == manifest.sub("[manifest]", from_file)
+
+
+class TestWhichModelRunsIsNotAHostedSetting:
+    """The model box is self-hosted only, and the route is what enforces it.
+
+    Self-hosted, the API key is the family's own: the model is their choice and
+    the price beside the field is theirs to read. Hosted, the key is ours, so a
+    free text box naming a model is a way to move an account onto an expensive
+    one at our expense — and `budget.py` counts *calls*, deliberately, so it
+    would not see it. Hiding the input is the courtesy; ignoring the field is
+    the control, which is why both are asserted here.
+    """
+
+    def test_the_field_is_not_offered(self, client):
+        page = client.get("/settings/system").get_data(as_text=True)
+        assert 'name="claude_model"' not in page
+        assert "claude-sonnet-5" not in page
+
+    def test_nor_is_a_key_a_hosted_family_does_not_have(self, client):
+        page = client.get("/settings/system").get_data(as_text=True)
+        assert "ANTHROPIC_API_KEY" not in page
+
+    def test_and_a_posted_one_is_ignored(self, client, pg_pool, pg_family):
+        client.post("/settings/system",
+                    data={"family_name": "The Wilsons", "timezone": "Europe/Berlin",
+                          "claude_model": "claude-opus-5"})
+        with pg_pool.connection() as conn, conn.cursor() as cur:
+            cur.execute("SELECT config ->> 'claude_model' FROM families WHERE id = %s",
+                        (pg_family,))
+            assert cur.fetchone()[0] == "claude-haiku-4-5"
+        # The rest of the form still saved, so this is a dropped field rather
+        # than a rejected request.
+        assert "The Wilsons" in client.get("/settings/system").get_data(as_text=True)
+
+    def test_but_a_self_hoster_still_chooses(self, tmp_path, monkeypatch):
+        """The same page on a Pi keeps the field, the price and the key note."""
+        import yaml
+
+        from dinkydash.store import FileStore
+
+        monkeypatch.delenv("DINKYDASH_MODE", raising=False)
+        (tmp_path / "config.yaml").write_text(yaml.safe_dump(CONFIG, allow_unicode=True))
+        app = create_app(FileStore(tmp_path / "config.yaml"))
+        page = app.test_client().get("/settings/system").get_data(as_text=True)
+        assert 'name="claude_model"' in page
+        assert "ANTHROPIC_API_KEY" in page
+
+        client_for(app).post("/settings/system",
+                             data={"family_name": "The Wilsons",
+                                   "timezone": "Europe/Berlin",
+                                   "claude_model": "claude-sonnet-5"})
+        saved = yaml.safe_load((tmp_path / "config.yaml").read_text())
+        assert saved["claude_model"] == "claude-sonnet-5"
+
+
+class TestSelfHostingInstructionsStayThere:
+    """Copy that tells a self-hoster what to do is not shown to a hosted one.
+
+    The crontab note on /settings/refresh is the case that matters: what drives
+    the scheduler is one of the four things mode gates, so hosted there is no
+    crontab — and the note does not say "ignore this", it says nothing on the
+    page has any effect. Wrong, and alarming, to somebody paying for it.
+    """
+
+    def test_the_crontab_note_is_not_shown_to_a_hosted_family(self, client):
+        page = client.get("/settings/refresh").get_data(as_text=True)
+        assert "crontab" not in page
+        # The settings themselves are still there — this is one note box, not
+        # the page.
+        assert 'name="brief_time"' in page
+
+    def test_but_a_self_hoster_is_still_told(self, tmp_path, monkeypatch):
+        import yaml
+
+        from dinkydash.store import FileStore
+
+        monkeypatch.delenv("DINKYDASH_MODE", raising=False)
+        (tmp_path / "config.yaml").write_text(yaml.safe_dump(CONFIG, allow_unicode=True))
+        app = create_app(FileStore(tmp_path / "config.yaml"))
+        page = app.test_client().get("/settings/refresh").get_data(as_text=True)
+        assert "crontab" in page

--- a/web/routes/settings.py
+++ b/web/routes/settings.py
@@ -115,7 +115,12 @@ SECTIONS = {
                  "sent to Anthropic each morning so Claude can write the day's line; an event "
                  "kept off the board by a guest list is never stored and never sent.",
         "fields": [
-            ("label", "Call it", "text", True, ""),
+            # "Name", like People and Pets, rather than an instruction. The
+            # heading above already says what is being named, and this string
+            # never reaches the board — it is how the settings list and the
+            # feed status refer to this calendar, so the hint says so.
+            ("label", "Name", "text", True,
+             "Only you see this — try “Family” or “School”."),
             ("url", "iCal link", "url", True,
              "Google → Settings and sharing → Integrate calendar → Secret address in iCal format. "
              "iCloud → share the calendar → Public Calendar → Copy Link (a webcal:// link is "
@@ -769,6 +774,17 @@ def delete_account():
 
 @bp.route("/system", methods=["GET", "POST"])
 def system():
+    """The family's name, clock and whereabouts — and, self-hosted, the model.
+
+    **Which model runs is not a hosted family's setting**, because it is not
+    their API key. Self-hosted, the key is theirs and so is the bill, so the
+    model is a free text box with its price beside it. Hosted, the box would
+    let anybody move the whole account onto an expensive model on our key, and
+    `budget.py` would not notice: it counts *calls*, deliberately, because a
+    price table goes stale silently. So cloud mode drops the field from the
+    form and ignores it here — the template is the courtesy, this is the
+    control.
+    """
     config = current_config()
     if request.method == "POST":
         config["family_name"] = request.form.get("family_name", "").strip()
@@ -777,7 +793,7 @@ def system():
         if timezone:
             config["timezone"] = timezone
         model = request.form.get("claude_model", "").strip()
-        if model:
+        if model and current_app.config["MODE"] != CLOUD:
             config["claude_model"] = model
         save(config)
         flash("Saved.", "ok")

--- a/web/templates/settings/edit.html
+++ b/web/templates/settings/edit.html
@@ -108,8 +108,6 @@
     {% if section_name == 'calendars' %}
     <button class="btn outline" type="submit" name="action" value="check">Check this link</button>
     {% endif %}
-
-    <button class="btn" type="submit" name="action" value="save">Save</button>
 </form>
 
 {% if not is_new %}

--- a/web/templates/settings/refresh.html
+++ b/web/templates/settings/refresh.html
@@ -38,8 +38,6 @@
             <strong>Rewrite now</strong> if you want a fresh one sooner.
         </div>
     </div>
-
-    <button class="btn" type="submit">Save</button>
 </form>
 
 <div class="note-box">
@@ -47,9 +45,15 @@
     The daily line is the part that costs money: one call to Claude, once a day.
 </div>
 
+{# Self-hosted only, and not merely irrelevant hosted — false. What drives the
+   scheduler is one of the four things mode gates, so a hosted family has no
+   crontab to be wrong, and telling them this page has no effect unless they fix
+   one is alarming and untrue. #}
+{% if not cloud %}
 <div class="note-box">
     Both need <strong>generate.py --tick</strong> in your crontab, every five minutes. If yours
     still says <strong>0 6 * * *</strong> without <strong>--tick</strong> — the line older setup
     guides gave — nothing on this page has any effect, and the board updates once at 6am as before.
 </div>
+{% endif %}
 {% endblock %}

--- a/web/templates/settings/system.html
+++ b/web/templates/settings/system.html
@@ -35,6 +35,14 @@
         <div class="hint">Gives the daily line some local flavour. Optional.</div>
     </div>
 
+    {# Self-hosted only, and it is the bill that decides that. On a Pi the key is
+       the family's own, so the model is their choice and the price is theirs to
+       read. Hosted, the key is ours: the cost line is about a bill they do not
+       pay, and a text box naming a model is a way to spend our money that
+       budget.py cannot see — it counts calls, not what a call cost. The route
+       ignores the field in cloud mode as well; hiding an input is not a
+       control. #}
+    {% if not cloud %}
     <div class="field">
         <label for="claude_model">Model</label>
         <input type="text" id="claude_model" name="claude_model" value="{{ config.claude_model or '' }}">
@@ -43,12 +51,14 @@
             <strong>claude-sonnet-5</strong> writes better for about three times that.
         </div>
     </div>
-
-    <button class="btn" type="submit">Save</button>
+    {% endif %}
 </form>
 
+{# Nothing to say to a hosted family: there is no .env of theirs to put a key in. #}
+{% if not cloud %}
 <div class="note-box">
     The API key is read from <strong>ANTHROPIC_API_KEY</strong> in your <strong>.env</strong> file,
     not from here — a key does not belong in a config file that gets committed.
 </div>
+{% endif %}
 {% endblock %}


### PR DESCRIPTION
Three settings written for somebody holding their own API key were being shown to hosted families: the model text box with its per-month price, the `ANTHROPIC_API_KEY` note, and the crontab warning on **How often it updates** — the last not merely irrelevant hosted but false, since what drives the scheduler is one of the four things mode gates, so it told a paying family that nothing on the page has any effect until they fix a crontab they do not have. Hiding the model box was only half of it: `POST /settings/system` took `claude_model` from anybody, so a hosted family could move their account onto an expensive model on our key, and `budget.py` would not have noticed because it counts calls rather than money — the route now ignores the field unless the app is self-hosted, and `tests/test_cloud_mode.py` asserts both halves plus the self-hosted path that still saves.

Two smaller things visible in the same screenshots: **Save appeared twice** on the system page, the refresh page and every item-edit page — once in the sticky app bar and again at the foot of the card — so the in-form copy goes, matching `design/settings-ui/`; implicit submission is unchanged, because the app bar renders first and its button was always the form's default. And **"Call it" is now "Name"**, matching People and Pets rather than reading as an instruction, with a hint saying where the string is used — it never reaches the board.

Tested both ways: 836 pass with a scratch Postgres, 575 pass and 261 skip without one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)