### PR TITLE
Pin calendar connections and preserve preview database overrides

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -42,10 +42,9 @@ venv/bin/python sample_board.py
 # cookie over `http://localhost`, so signing in fails and looks like a broken
 # form rather than a cookie policy. `web/CLAUDE.md` has the table.
 #
-# **This talks to the production database.** `DATABASE_URL` in `.env` is the
-# live cluster, so anything saved in /settings edits the real family. Export a
-# different DATABASE_URL before starting to point it somewhere safer — the
-# connection string is the only thing that decides.
+# Export DATABASE_URL to select a scratch database. Explicit environment values
+# take precedence over .env defaults; with no override, the file selects the
+# database, which may be production. The connection string is never printed.
 #
 # Single mode still matters and still has to work; it is just not what the
 # preview shows. To look at it:
@@ -53,18 +52,23 @@ venv/bin/python sample_board.py
 [scripts.run.dashboard]
 available_in = [ "local" ]
 command = """
-set -a; [ -f .env ] && . ./.env; set +a
-if [ -z "$DATABASE_URL" ]; then
-  echo "Cloud mode needs DATABASE_URL in .env."
-  echo "It is gitignored, so a new workspace only gets it through Files to copy."
-  exit 1
-fi
-export DINKYDASH_MODE=cloud
-echo "The board is behind a sign-in. For a link without waiting on email:"
-echo "  venv/bin/python login_link.py you@example.com --base-url http://127.0.0.1:${CONDUCTOR_PORT:-5000}"
-echo "Open it in Chrome or Firefox. Safari will not send a Secure cookie over"
-echo "http://localhost, so signing in there fails and looks like a broken form."
-FLASK_APP=app.py venv/bin/flask run --port ${CONDUCTOR_PORT:-5000} --debug
+venv/bin/python - <<'PY'
+import os
+import sys
+from dotenv import load_dotenv
+
+load_dotenv('.env', override=False)
+if not os.environ.get('DATABASE_URL'):
+    sys.exit('Cloud mode needs DATABASE_URL in the environment or .env. '
+             'Use Files to copy for this gitignored file.')
+os.environ['DINKYDASH_MODE'] = 'cloud'
+os.environ['FLASK_APP'] = 'app.py'
+port = os.environ.get('CONDUCTOR_PORT') or '5000'
+print('The board is behind a sign-in. For a link without waiting on email:')
+print(f'  venv/bin/python login_link.py you@example.com --base-url http://127.0.0.1:{port}')
+print('Use Chrome or Firefox; Safari will not send a Secure cookie over http://localhost.', flush=True)
+os.execv('venv/bin/flask', ['flask', 'run', '--port', port, '--debug'])
+PY
 """
 default = true
 icon = "cloud"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,9 +120,12 @@ Relative links like `[PLAN.md](PLAN.md)` break once a document is in Linear. Rew
   302s to `169.254.169.254` is the whole attack; and a **10 MB body cap** enforced on
   `Content-Length` *and* on the read, since a server can omit or lie in that header.
   `FeedRefused` subclasses `FeedError` on purpose, so one bad URL in a config is a failed feed
-  rather than a failed tick. **DNS rebinding is not closed by this** — between the check and the
-  socket a hostile resolver can answer differently, and closing it means connecting to the checked
-  address with an explicit `Host` header.
+  rather than a failed tick. **Connect to the checked IP**, preserving the original hostname for
+  TLS SNI, certificate verification and the `Host` header. The per-request Requests adapter uses
+  only validated numeric addresses, including IPv6/IPv4 fallback; every redirect resolves and
+  validates again. Calendar fetches use direct connections because an environment proxy could
+  resolve the hostname elsewhere. `tests/test_feed_transport.py` exercises this with changing DNS
+  answers and real TLS on an isolated local server.
 - **Calendar contents leave the machine.** They go to Anthropic to write the daily line. A fair
   trade, and it *is* said now (DIN-44): in `website/content/privacy.md`, in the sub-processor list
   on it, on `/settings/account`, and — the one that matters — in the blurb beside the field where

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,6 +1,6 @@
 # DinkyDash Hosted MVP — Plan
 
-*Updated 8 September 2026: main through PR #89, plus the DIN-46/DIN-47 implementation.*
+*Updated 8 September 2026: main through PR #92, plus the DIN-48/DIN-61 implementation and MVP triage.*
 
 This is the engineering plan for the hosted app and its shared self-hosted codebase.
 Positioning, pricing reasoning and launch strategy live in Linear on the DIN team.
@@ -14,18 +14,22 @@ management, a tokenised screen, and a worker that owes the first brief on its ne
 PR #85 delivered [DIN-45](https://linear.app/keepthescore/issue/DIN-45); PR #86 consolidated token issuance and URL construction,
 serialized the per-address token limit, and fixed hosted HTTPS screen links.
 PRs #87 and #89 added the calendar-provider and device guides ([DIN-14](https://linear.app/keepthescore/issue/DIN-14), [DIN-13](https://linear.app/keepthescore/issue/DIN-13)).
-The current batch implements privacy-safe calendar publication ([DIN-46](https://linear.app/keepthescore/issue/DIN-46))
-and removes generated text and malformed screen credentials from service logs ([DIN-47](https://linear.app/keepthescore/issue/DIN-47)).
+PR #91 implemented privacy-safe calendar publication ([DIN-46](https://linear.app/keepthescore/issue/DIN-46))
+and removed generated text and malformed screen credentials from service logs ([DIN-47](https://linear.app/keepthescore/issue/DIN-47)).
+The current batch preserves explicit preview database overrides ([DIN-48](https://linear.app/keepthescore/issue/DIN-48))
+and connects calendar fetches only to validated public addresses ([DIN-61](https://linear.app/keepthescore/issue/DIN-61)).
 
-Hosted readiness is still open. The next sequence is:
+Todo is reserved for the hosted MVP: signup and trial use, payment/cancellation,
+privacy and spending controls, basic monitoring/recovery, and real-device validation.
+Optional features, promotion and additional operational tooling are Backlog.
+Hosted readiness is still open. The remaining sequence is:
 
-1. Fix the preview database override ([DIN-48](https://linear.app/keepthescore/issue/DIN-48)) and the remaining
-   calendar-fetch DNS-rebinding gap ([DIN-61](https://linear.app/keepthescore/issue/DIN-61)).
-2. Complete spending boundaries ([DIN-49](https://linear.app/keepthescore/issue/DIN-49), [DIN-51](https://linear.app/keepthescore/issue/DIN-51)), export coverage ([DIN-50](https://linear.app/keepthescore/issue/DIN-50)), and trial
+1. Complete spending boundaries ([DIN-49](https://linear.app/keepthescore/issue/DIN-49), [DIN-51](https://linear.app/keepthescore/issue/DIN-51)), export coverage ([DIN-50](https://linear.app/keepthescore/issue/DIN-50)), and trial
    expiry/lapse ([DIN-52](https://linear.app/keepthescore/issue/DIN-52)). Complete Stripe conversion before accepting payment ([DIN-53](https://linear.app/keepthescore/issue/DIN-53)).
-3. Add error capture, liveness alerts and recovery checks ([DIN-35](https://linear.app/keepthescore/issue/DIN-35), [DIN-54](https://linear.app/keepthescore/issue/DIN-54), [DIN-55](https://linear.app/keepthescore/issue/DIN-55),
+2. Add liveness alerts and recovery checks ([DIN-54](https://linear.app/keepthescore/issue/DIN-54),
    [DIN-56](https://linear.app/keepthescore/issue/DIN-56)), and finish the trust work in Phase 5.
-4. Verify real screens and run the small private beta ([DIN-58](https://linear.app/keepthescore/issue/DIN-58)). Use observed setup
+3. Replace hosted waitlist/form links with the signup/login page ([DIN-63](https://linear.app/keepthescore/issue/DIN-63)).
+4. Verify real screens and run the small private beta ([DIN-58](https://linear.app/keepthescore/issue/DIN-58)), collecting feedback through the existing support email. Use observed setup
    problems to decide whether the existing settings flow needs a wizard.
 
 A checked box below means that capability exists; linked follow-up defects remain
@@ -138,7 +142,7 @@ self-hosted, and the board makes no third-party asset requests. QR codes are enc
 locally with lazily imported `segno`. `web/urls.py` builds hosted links from an HTTPS
 app origin; single mode retains its local HTTP URLs.
 
-The app rate-limits invalid-token attempts. Cloudflare edge hardening remains [DIN-40](https://linear.app/keepthescore/issue/DIN-40);
+The app rate-limits invalid-token attempts. Additional Cloudflare edge hardening is Backlog ([DIN-40](https://linear.app/keepthescore/issue/DIN-40));
 this document does not claim an edge rule is deployed. Access-log redaction covers
 invalid, mistyped and encoded screen-token variants ([DIN-47](https://linear.app/keepthescore/issue/DIN-47)). Offline behaviour is deferred
 under [DIN-60](https://linear.app/keepthescore/issue/DIN-60); weakening shared-cache headers is not the implementation plan.
@@ -182,7 +186,7 @@ uniqueness, not a guarantee that concurrent callers cannot make two paid model c
 Every hosted attempt must continue to pass through the budget.
 
 Keep-last-good and retries on subsequent ticks exist. Persistent failure tracking,
-backoff and parent notification remain [DIN-55](https://linear.app/keepthescore/issue/DIN-55); the worker heartbeat remains [DIN-54](https://linear.app/keepthescore/issue/DIN-54).
+backoff and parent notification are Backlog ([DIN-55](https://linear.app/keepthescore/issue/DIN-55)); the MVP worker heartbeat remains [DIN-54](https://linear.app/keepthescore/issue/DIN-54).
 Skipping rows already marked lapsed does not enforce `trial_ends_at`; [DIN-52](https://linear.app/keepthescore/issue/DIN-52) must add
 that transition and the corresponding manual-action and rendering behaviour.
 
@@ -269,8 +273,9 @@ Postgres 17 and without a configured database. The current branch rules and depl
 history are recorded in [doc/operations.md](doc/operations.md).
 
 There is no separate staging app. Tests and restores must use an explicit isolated
-database. The preview's environment-precedence defect is [DIN-48](https://linear.app/keepthescore/issue/DIN-48); a documented scratch
-URL must not be silently overwritten by `.env`.
+database. The preview loads `.env` as defaults and preserves exported values, including
+an explicit scratch `DATABASE_URL`; missing/empty database configuration fails before
+Flask starts without printing the connection string ([DIN-48](https://linear.app/keepthescore/issue/DIN-48)).
 
 #### Connection pooling
 
@@ -286,7 +291,8 @@ PR #86 uses `pg_advisory_xact_lock` for token issuance: the lock belongs to the 
 transaction. It does not introduce a session-scoped lock or require session pooling.
 
 Managed backups are documented in operations; the independent restore drill remains
-[DIN-56](https://linear.app/keepthescore/issue/DIN-56). Sentry instrumentation and worker liveness alerts remain [DIN-35](https://linear.app/keepthescore/issue/DIN-35) and [DIN-54](https://linear.app/keepthescore/issue/DIN-54).
+[DIN-56](https://linear.app/keepthescore/issue/DIN-56). Worker liveness alerts remain MVP work ([DIN-54](https://linear.app/keepthescore/issue/DIN-54));
+Sentry instrumentation is Backlog ([DIN-35](https://linear.app/keepthescore/issue/DIN-35)).
 Cloud startup validates the session key and database configuration; model/email failures
 have their own runtime handling. Stripe credentials are not required before billing exists.
 
@@ -312,15 +318,16 @@ privacy and readiness defects are tracked explicitly below.
 - [x] Schema, signup/login, session hygiene and family scoping ([DIN-31](https://linear.app/keepthescore/issue/DIN-31), [DIN-38](https://linear.app/keepthescore/issue/DIN-38), [DIN-39](https://linear.app/keepthescore/issue/DIN-39), [DIN-41](https://linear.app/keepthescore/issue/DIN-41)).
 - [x] Multi-calendar add/label/enable/remove, per-feed sharing filters and live link checks.
 - [x] Feed scheme, address, redirect and response-size checks ([DIN-33](https://linear.app/keepthescore/issue/DIN-33)).
-- [ ] Close the remaining DNS-rebinding gap ([DIN-61](https://linear.app/keepthescore/issue/DIN-61)).
+- [x] Pin calendar connections to validated public IPs, preserving HTTPS hostname verification, redirect checks and size limits ([DIN-61](https://linear.app/keepthescore/issue/DIN-61)).
 - [x] Editable family lists, timezone, family name, refresh cadence and seeded setup guidance.
 - [x] Inline Google, iCloud and Outlook help in getting-started ([DIN-2](https://linear.app/keepthescore/issue/DIN-2)).
-- [ ] Standalone provider pages and screenshots ([DIN-14](https://linear.app/keepthescore/issue/DIN-14)).
-- [ ] Enforce and hide the cloud model setting ([DIN-51](https://linear.app/keepthescore/issue/DIN-51)).
+- [x] Standalone provider pages and screenshots ([DIN-14](https://linear.app/keepthescore/issue/DIN-14)).
+- [x] Hide/reject self-hosting controls in cloud settings (PR #92).
+- [ ] Enforce platform model and token limits at every hosted generation entry point ([DIN-51](https://linear.app/keepthescore/issue/DIN-51)).
 - [ ] Assess the need for a guided wizard from observed setup friction ([DIN-58](https://linear.app/keepthescore/issue/DIN-58)).
 
 **Core completion met by [DIN-39](https://linear.app/keepthescore/issue/DIN-39):** two families can be configured independently, and
-another family's item ID returns 404. Provider-page and onboarding improvements remain open.
+another family's item ID returns 404. Onboarding validation remains open.
 
 ### Phase 2 — Generation pipeline
 
@@ -330,7 +337,7 @@ another family's item ID returns 404. Provider-page and onboarding improvements 
 - [x] Keep-last-good rendering and retry on subsequent ticks.
 - [x] Reject refresh publication after a calendar privacy/config change ([DIN-46](https://linear.app/keepthescore/issue/DIN-46)).
 - [ ] Preserve global spending across account deletion ([DIN-49](https://linear.app/keepthescore/issue/DIN-49)).
-- [ ] Failure tracking, backoff and parent notification ([DIN-55](https://linear.app/keepthescore/issue/DIN-55)).
+- [ ] Failure tracking, backoff and parent notification ([DIN-55](https://linear.app/keepthescore/issue/DIN-55); Backlog).
 - [ ] Remove the remaining implicit date fallback in feed description ([DIN-62](https://linear.app/keepthescore/issue/DIN-62); maintenance).
 
 **Done when:** families in different timezones get correct boards and calendar updates;
@@ -341,7 +348,7 @@ failed providers preserve useful last-good output; retries and paid calls obey t
 - [x] Token route, rotation, QR display, privacy headers and app miss-rate limit ([DIN-42](https://linear.app/keepthescore/issue/DIN-42)).
 - [x] Hosted HTTPS links and shared URL policy (#86).
 - [x] Real-board parity with the homepage and staleness indicator. No new person-card feature is required.
-- [ ] Cloudflare edge hardening ([DIN-40](https://linear.app/keepthescore/issue/DIN-40)).
+- [ ] Additional Cloudflare edge hardening ([DIN-40](https://linear.app/keepthescore/issue/DIN-40); Backlog).
 - [ ] Render the already-configured person colours ([DIN-8](https://linear.app/keepthescore/issue/DIN-8); feature backlog).
 - [ ] Verify TV, older iPad/tablet and Pi kiosk behaviour ([DIN-58](https://linear.app/keepthescore/issue/DIN-58)).
 - [ ] Define offline behaviour while preserving credential/cache controls ([DIN-60](https://linear.app/keepthescore/issue/DIN-60); deferred).
@@ -376,11 +383,11 @@ alone does not close the phase.
 ### Phase 6 — Ops
 
 - [x] Transactional email wired into signup/login ([DIN-36](https://linear.app/keepthescore/issue/DIN-36), [DIN-38](https://linear.app/keepthescore/issue/DIN-38)).
-- [ ] Sentry for web, worker and applicable frontend errors, with sensitive-data filtering ([DIN-35](https://linear.app/keepthescore/issue/DIN-35)).
+- [ ] Sentry for web, worker and applicable frontend errors, with sensitive-data filtering ([DIN-35](https://linear.app/keepthescore/issue/DIN-35); Backlog).
 - [ ] Worker heartbeat and external health alerts, verified by a controlled failure ([DIN-54](https://linear.app/keepthescore/issue/DIN-54)).
 - [ ] Repeatable restore into an isolated database, with a successful drill recorded ([DIN-56](https://linear.app/keepthescore/issue/DIN-56)).
-- [ ] Preserve explicit preview database overrides ([DIN-48](https://linear.app/keepthescore/issue/DIN-48)).
-- [ ] Basic administrative visibility and support workflow ([DIN-37](https://linear.app/keepthescore/issue/DIN-37)).
+- [x] Preserve explicit preview database overrides ([DIN-48](https://linear.app/keepthescore/issue/DIN-48)).
+- [ ] Dedicated admin/registration analytics dashboard ([DIN-37](https://linear.app/keepthescore/issue/DIN-37); Backlog).
 
 **Done when:** an operator can detect stopped/failed work, inspect useful metadata and
 recover the application. A healthy `/healthz` response alone is insufficient.
@@ -390,9 +397,10 @@ recover the application. A healthy `/healthz` response alone is insufficient.
 - [x] Self-hosted getting-started/provider instructions and the Pi/from-source path exist.
 - [x] Search Console and Ahrefs connection is marked Done in [DIN-3](https://linear.app/keepthescore/issue/DIN-3); ongoing account status is tracked there.
 - [ ] Real-device checks, current self-hosted smoke test and the small private beta ([DIN-58](https://linear.app/keepthescore/issue/DIN-58)).
-- [ ] Refresh launch dependencies, rewrite obsolete drafts, tag a release and execute the approved launch ([DIN-25](https://linear.app/keepthescore/issue/DIN-25)).
+- [ ] Replace hosted waitlist/form links with the actual signup/login page ([DIN-63](https://linear.app/keepthescore/issue/DIN-63)).
+- [ ] Refresh launch dependencies, rewrite obsolete drafts, tag a release and execute the approved public launch ([DIN-25](https://linear.app/keepthescore/issue/DIN-25); Backlog).
 - [x] Calendar-provider and device guides ([DIN-14](https://linear.app/keepthescore/issue/DIN-14), [DIN-13](https://linear.app/keepthescore/issue/DIN-13)).
-- [ ] Feedback collection ([DIN-34](https://linear.app/keepthescore/issue/DIN-34)).
+- [ ] Embedded feedback widget/backend ([DIN-34](https://linear.app/keepthescore/issue/DIN-34); Backlog). MVP feedback uses the existing support email.
 
 Beta invitations and public launch follow the readiness gates above. Launch copy,
 waitlist communications and rollout decisions belong in Linear. [DIN-21](https://linear.app/keepthescore/issue/DIN-21) is Canceled;
@@ -408,6 +416,11 @@ already exist and are not exclusions. Manual rewrites also already exist.
 
 Weather ([DIN-24](https://linear.app/keepthescore/issue/DIN-24)) and photo/screensaver mode ([DIN-11](https://linear.app/keepthescore/issue/DIN-11)) remain deferred scope decisions.
 Their issues must agree with the plan before either is promoted into the MVP.
+
+Additional edge rules, Sentry instrumentation, an admin analytics dashboard,
+persisted retry backoff/parent notifications, a feedback widget and public launch
+promotion are also Backlog. Existing redacted logs, bounded retries and support email
+cover those needs for the MVP alongside the remaining liveness and recovery work.
 
 ## Open questions
 

--- a/dinkydash/calendars.py
+++ b/dinkydash/calendars.py
@@ -15,11 +15,13 @@ import ipaddress
 import logging
 import re
 import socket
+from contextlib import closing, contextmanager
 from datetime import date, datetime, time, timedelta
 from urllib.parse import urljoin, urlsplit, urlunsplit
 from zoneinfo import ZoneInfo
 
 import requests
+from requests.adapters import HTTPAdapter
 from icalendar import Calendar
 from recurring_ical_events import of as recurring_events_of
 
@@ -212,36 +214,66 @@ def normalise_url(url):
     return urlunsplit(parts)
 
 
-def _check_address(hostname):
-    """Refuse a host that resolves anywhere it has no business being.
+def _check_address(hostname, port=443):
+    """Resolve once and return only checked public addresses, in resolver order.
 
-    The board fetches URLs a person typed. On a Pi that person owns the
-    network. Hosted it is our infrastructure dialling whatever a stranger
-    pasted, and the interesting targets are all *inside*: the cloud metadata
-    endpoint on 169.254.169.254, a database on 127.0.0.1, anything on the
-    platform's own private range.
-
-    Every resolved address has to pass, not just the first, because a host with
-    one public and one private address is otherwise a way through.
-
-    **This does not close DNS rebinding.** Between this check and the socket,
-    a hostile resolver can answer differently. Closing that means connecting to
-    the checked address with an explicit Host header, which is a bigger change
-    than this and is written down rather than implied.
+    Every answer must pass before any connection is attempted. The transport
+    connects to these numeric addresses, so later DNS answers cannot redirect it.
     """
     try:
-        infos = socket.getaddrinfo(hostname, 443, proto=socket.IPPROTO_TCP)
+        infos = socket.getaddrinfo(hostname, port, proto=socket.IPPROTO_TCP)
     except socket.gaierror as exc:
         raise FeedRefused("that server name does not resolve") from exc
 
+    checked = []
     for info in infos:
         address = ipaddress.ip_address(info[4][0])
-        if (address.is_private or address.is_loopback or address.is_link_local
-                or address.is_reserved or address.is_multicast
-                or address.is_unspecified):
+        if not address.is_global or address.is_reserved or address.is_multicast:
             # Deliberately does not say which address. The answer would
             # otherwise be a way to map the inside of the network from outside.
             raise FeedRefused("that link points inside a private network")
+        if str(address) not in checked:
+            checked.append(str(address))
+    if not checked:
+        raise FeedRefused("that server name does not resolve")
+    return checked
+
+
+class _PinnedHTTPSAdapter(HTTPAdapter):
+    """Connect to a checked IP; authenticate and address the original hostname."""
+
+    def __init__(self, address):
+        self.address = address
+        super().__init__()
+
+    def build_connection_pool_key_attributes(self, request, verify, cert=None):
+        host, tls = super().build_connection_pool_key_attributes(request, verify, cert)
+        tls.update(server_hostname=host['host'], assert_hostname=host['host'])
+        host['host'] = self.address
+        request.headers['Host'] = urlsplit(request.url).netloc.rsplit('@', 1)[-1]
+        return host, tls
+
+
+@contextmanager
+def _open_public(url, timeout):
+    # Prepare first so resolution, TLS and Host agree on IDNA/escaped hostnames.
+    request = requests.Request('GET', url, headers=requests.utils.default_headers()).prepare()
+    parts = urlsplit(request.url)
+    addresses = _check_address(parts.hostname, parts.port or 443)
+    for index, address in enumerate(addresses):
+        with closing(_PinnedHTTPSAdapter(address)) as adapter:
+            try:
+                # Send directly: environment proxies could resolve the hostname
+                # elsewhere, and Session would read a redirect body to build its
+                # automatic next request even with allow_redirects=False.
+                response = adapter.send(request, timeout=timeout, stream=True, verify=True)
+            except requests.ConnectionError:
+                if index == len(addresses) - 1:
+                    raise
+                continue  # Preserve IPv6/IPv4 fallback using only the checked answers.
+            with closing(response):
+                yield response
+            return
 
 
 def fetch_feed(url, start, end, tzinfo, label=None, timeout=DEFAULT_TIMEOUT,
@@ -265,32 +297,21 @@ def fetch_text(url, timeout=DEFAULT_TIMEOUT):
     """
     target = normalise_url(url)
 
-    for _hop in range(MAX_REDIRECTS + 1):
-        parts = urlsplit(target)
-        _check_address(parts.hostname)
-        try:
-            response = requests.get(target, timeout=timeout, stream=True,
-                                    allow_redirects=False)
-        except Exception as exc:
-            raise FeedError(f"could not fetch the calendar: {_why(exc)}") from exc
-
-        if response.is_redirect or response.is_permanent_redirect:
-            location = response.headers.get("Location", "")
-            response.close()
-            if not location:
-                raise FeedError("could not fetch the calendar: a redirect with nowhere to go")
-            # urljoin covers all three legal shapes of a Location: absolute,
-            # root-relative and relative. normalise_url then re-applies the
-            # scheme rule, so a 302 to http:// or file:// is refused here too.
-            target = normalise_url(urljoin(target, location))
-            continue
-
-        try:
-            response.raise_for_status()
-        except Exception as exc:
-            response.close()
-            raise FeedError(f"could not fetch the calendar: {_why(exc)}") from exc
-        return _read_capped(response)
+    try:
+        for _hop in range(MAX_REDIRECTS + 1):
+            with _open_public(target, timeout) as response:
+                if response.is_redirect or response.is_permanent_redirect:
+                    location = response.headers.get("Location", "")
+                    if not location:
+                        raise FeedError("could not fetch the calendar: a redirect with nowhere to go")
+                    target = normalise_url(urljoin(target, location))
+                    continue
+                response.raise_for_status()
+                return _read_capped(response)
+    except FeedError:
+        raise
+    except Exception as exc:
+        raise FeedError(f"could not fetch the calendar: {_why(exc)}") from exc
 
     raise FeedError("could not fetch the calendar: too many redirects")
 
@@ -304,18 +325,14 @@ def _read_capped(response):
     """
     declared = response.headers.get("Content-Length")
     if declared and declared.isdigit() and int(declared) > MAX_FEED_BYTES:
-        response.close()
         raise FeedError("could not fetch the calendar: it is too big to be a calendar")
 
     chunks, total = [], 0
-    try:
-        for chunk in response.iter_content(chunk_size=64 * 1024):
-            total += len(chunk)
-            if total > MAX_FEED_BYTES:
-                raise FeedError("could not fetch the calendar: it is too big to be a calendar")
-            chunks.append(chunk)
-    finally:
-        response.close()
+    for chunk in response.iter_content(chunk_size=64 * 1024):
+        total += len(chunk)
+        if total > MAX_FEED_BYTES:
+            raise FeedError("could not fetch the calendar: it is too big to be a calendar")
+        chunks.append(chunk)
     return b"".join(chunks).decode(response.encoding or "utf-8", errors="replace")
 
 

--- a/tests/test_conductor.py
+++ b/tests/test_conductor.py
@@ -1,0 +1,60 @@
+"""Run the configured preview command with invented environment values."""
+
+import json
+import os
+from pathlib import Path
+import shlex
+import subprocess
+import sys
+import tomllib
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+FILE_URL = 'postgresql:///invented_file_database'
+SCRATCH_URL = 'postgresql:///invented_scratch_database'
+
+
+@pytest.mark.parametrize('exported,file_value,expected', [
+    (SCRATCH_URL, FILE_URL, SCRATCH_URL),
+    (None, FILE_URL, FILE_URL),
+    (SCRATCH_URL, None, SCRATCH_URL),
+    (None, None, None),
+    ('', FILE_URL, None),
+])
+def test_preview_preserves_explicit_environment_and_never_prints_the_database(
+        tmp_path, exported, file_value, expected):
+    if file_value is not None:
+        (tmp_path / '.env').write_text(f'DATABASE_URL="{file_value}"\nDINKYDASH_MODE=single\n')
+    executables = tmp_path / 'venv/bin'
+    executables.mkdir(parents=True)
+    python = executables / 'python'
+    python.write_text(f'#!/bin/sh\nexec {shlex.quote(sys.executable)} "$@"\n')
+    python.chmod(0o755)
+    flask = executables / 'flask'
+    flask.write_text(f'#!{sys.executable}\n' + '''import json, os, pathlib, sys
+pathlib.Path('captured.json').write_text(json.dumps({
+    'database': os.environ['DATABASE_URL'], 'mode': os.environ['DINKYDASH_MODE'],
+    'app': os.environ['FLASK_APP'], 'args': sys.argv[1:]}))
+''')
+    flask.chmod(0o755)
+    env = {key: value for key, value in os.environ.items()
+           if key not in {'DATABASE_URL', 'DATABASE_URL_DIRECT', 'DINKYDASH_MODE'}}
+    env['CONDUCTOR_PORT'] = '5123'
+    if exported is not None:
+        env['DATABASE_URL'] = exported
+    settings = tomllib.loads((ROOT / '.conductor/settings.toml').read_text())
+    command = settings['scripts']['run']['dashboard']['command']
+    result = subprocess.run(['sh', '-c', command], cwd=tmp_path, env=env,
+                            text=True, capture_output=True, timeout=10)
+    assert FILE_URL not in result.stdout + result.stderr
+    assert SCRATCH_URL not in result.stdout + result.stderr
+    if expected is None:
+        assert result.returncode != 0
+        assert 'Cloud mode needs DATABASE_URL' in result.stderr
+        assert not (tmp_path / 'captured.json').exists()
+    else:
+        assert result.returncode == 0, result.stderr
+        assert json.loads((tmp_path / 'captured.json').read_text()) == {
+            'database': expected, 'mode': 'cloud', 'app': 'app.py',
+            'args': ['run', '--port', '5123', '--debug']}

--- a/tests/test_feed_safety.py
+++ b/tests/test_feed_safety.py
@@ -76,17 +76,17 @@ def serves(monkeypatch, *responses):
     asked = []
     queue = list(responses)
 
-    def fake_get(url, **kwargs):
-        asked.append(url)
+    def fake_send(adapter, request, **kwargs):
+        asked.append(request.url)
         return queue.pop(0) if queue else FakeResponse(body=ICS.encode())
-    monkeypatch.setattr(calendars.requests, "get", fake_get)
+    monkeypatch.setattr(calendars.HTTPAdapter, "send", fake_send)
     return asked
 
 
 def never_called(monkeypatch):
-    def fake_get(url, **kwargs):
-        raise AssertionError(f"a request was made to {url}")
-    monkeypatch.setattr(calendars.requests, "get", fake_get)
+    def fake_send(adapter, request, **kwargs):
+        raise AssertionError("a refused feed reached the HTTP transport")
+    monkeypatch.setattr(calendars.HTTPAdapter, "send", fake_send)
 
 
 class TestTheSchemeRule:
@@ -130,6 +130,11 @@ class TestWhereItWillNotGo:
         ("172.16.5.4", "private"),
         ("0.0.0.0", "unspecified"),
         ("224.0.0.1", "multicast"),
+        ("100.64.0.1", "shared address space"),
+        ("192.0.2.1", "reserved documentation address"),
+        ("::1", "IPv6 loopback"),
+        ("fc00::1", "IPv6 private"),
+        ("fe80::1", "IPv6 link-local"),
     ])
     def test_it_refuses_and_does_not_even_ask(self, monkeypatch, address, what):
         resolves_to(monkeypatch, address)
@@ -162,6 +167,12 @@ class TestWhereItWillNotGo:
         def boom(*args, **kwargs):
             raise socket.gaierror("nope")
         monkeypatch.setattr(calendars.socket, "getaddrinfo", boom)
+        never_called(monkeypatch)
+        with pytest.raises(FeedRefused, match="does not resolve"):
+            fetch_feed(SECRET, START, END, zone("UTC"))
+
+    def test_an_empty_resolution_is_refused(self, monkeypatch):
+        resolves_to(monkeypatch)
         never_called(monkeypatch)
         with pytest.raises(FeedRefused, match="does not resolve"):
             fetch_feed(SECRET, START, END, zone("UTC"))

--- a/tests/test_feed_transport.py
+++ b/tests/test_feed_transport.py
@@ -1,0 +1,174 @@
+"""Exercise DNS pinning and real TLS against an isolated, invented calendar."""
+
+from collections import Counter
+from datetime import date
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+import ipaddress
+import shutil
+import socket
+import ssl
+import subprocess
+from threading import Thread
+
+import pytest
+import requests.adapters
+import urllib3.util.connection
+
+from dinkydash import calendars
+from dinkydash.calendars import FeedError, FeedRefused
+from test_feed_safety import ICS
+
+PUBLIC = '1.1.1.1'
+PUBLIC_V6 = '2606:4700:4700::1111'
+
+
+@pytest.fixture(scope='module')
+def certificate(tmp_path_factory):
+    openssl = shutil.which('openssl')
+    if not openssl:
+        pytest.skip('openssl is needed to generate a temporary TLS test certificate')
+    directory = tmp_path_factory.mktemp('calendar-tls')
+    cert, key = directory / 'cert.pem', directory / 'key.pem'
+    subprocess.run([openssl, 'req', '-x509', '-newkey', 'rsa:2048', '-nodes',
+                    '-keyout', str(key), '-out', str(cert), '-days', '1',
+                    '-subj', '/CN=calendar.example', '-addext',
+                    'subjectAltName=DNS:calendar.example,DNS:next.example'],
+                   check=True, capture_output=True)
+    return cert, key
+
+
+@pytest.fixture
+def transport(certificate, monkeypatch):
+    cert, key = certificate
+    seen = {'dns': Counter(), 'connections': [], 'sni': [], 'requests': []}
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            seen['requests'].append((self.headers['Host'], self.path))
+            if self.path.startswith('/redirect'):
+                host = 'next.example' if self.path == '/redirect-host' else 'calendar.example'
+                self.send_response(302)
+                self.send_header('Location', f'https://{host}:{self.server.server_port}/calendar.ics')
+                # Following a redirect must not first download its unbounded body.
+                self.send_header('Content-Length', '100000000')
+                self.end_headers()
+                return
+            self.send_response(200)
+            self.send_header('Content-Type', 'text/calendar; charset=utf-8')
+            self.send_header('Content-Length', str(len(ICS.encode())))
+            self.end_headers()
+            self.wfile.write(ICS.encode())
+
+        def log_message(self, *args):
+            pass
+
+    server = ThreadingHTTPServer(('127.0.0.1', 0), Handler)
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    context.load_cert_chain(cert, key)
+    context.set_servername_callback(lambda sock, name, ctx: seen['sni'].append(name))
+    server.socket = context.wrap_socket(server.socket, server_side=True)
+    thread = Thread(target=server.serve_forever, kwargs={'poll_interval': .01}, daemon=True)
+    thread.start()
+    real_resolve = socket.getaddrinfo
+    real_connect = urllib3.util.connection.create_connection
+    answers, unreachable = {}, set()
+
+    def resolve(host, port, *args, **kwargs):
+        if host.endswith('.example'):
+            seen['dns'][host] += 1
+            batches = answers.get(host, [[PUBLIC], ['127.0.0.1']])
+            addresses = batches[min(seen['dns'][host] - 1, len(batches) - 1)]
+            return [(socket.AF_INET6 if ':' in address else socket.AF_INET,
+                     socket.SOCK_STREAM, 6, '',
+                     (address, port, 0, 0) if ':' in address else (address, port))
+                    for address in addresses]
+        ipaddress.ip_address(host)  # An unexpected external hostname must not escape this test.
+        return real_resolve(host, port, *args, **kwargs)
+
+    def connect(address, *args, **kwargs):
+        seen['connections'].append(address)
+        host, port = address
+        assert host in {PUBLIC, PUBLIC_V6}, 'the transport re-resolved an unchecked hostname'
+        assert port == server.server_port
+        if host in unreachable:
+            raise OSError('Invented unreachable address')
+        # Only the test transport maps these public addresses to its local server.
+        return real_connect(('127.0.0.1', server.server_port), *args, **kwargs)
+
+    monkeypatch.setattr(socket, 'getaddrinfo', resolve)
+    monkeypatch.setattr(urllib3.util.connection, 'create_connection', connect)
+    monkeypatch.setattr(requests.adapters, 'DEFAULT_CA_BUNDLE_PATH', str(cert))
+    for name in ('http_proxy', 'https_proxy', 'all_proxy', 'HTTP_PROXY', 'HTTPS_PROXY', 'ALL_PROXY'):
+        monkeypatch.delenv(name, raising=False)
+    try:
+        yield f'https://calendar.example:{server.server_port}', seen, answers, unreachable
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+@pytest.mark.parametrize('mode', ['single', 'cloud'])
+@pytest.mark.parametrize('address', [PUBLIC, PUBLIC_V6])
+def test_rebinding_cannot_change_the_socket_destination_and_tls_keeps_the_hostname(
+        transport, monkeypatch, mode, address):
+    origin, seen, answers, _ = transport
+    answers['calendar.example'] = [[address], ['127.0.0.1']]
+    monkeypatch.setenv('DINKYDASH_MODE', mode)
+    events = calendars.fetch_feed(origin + '/calendar.ics', date(2026, 9, 7),
+                                  date(2026, 9, 21), calendars.zone('UTC'))
+    assert [event['title'] for event in events] == ['Swimming']
+    assert seen['dns']['calendar.example'] == 1
+    assert [target[0] for target in seen['connections']] == [address]
+    assert seen['sni'] == ['calendar.example']
+    assert seen['requests'] == [(origin.removeprefix('https://'), '/calendar.ics')]
+
+
+def test_a_same_host_redirect_rechecks_dns_before_another_connection(transport):
+    origin, seen, _, _ = transport
+    with pytest.raises(FeedRefused, match='private network'):
+        calendars.fetch_text(origin + '/redirect')
+    assert seen['dns']['calendar.example'] == 2
+    assert len(seen['connections']) == 1
+
+
+def test_a_public_redirect_uses_its_own_hostname_and_does_not_read_the_redirect_body(transport):
+    origin, seen, _, _ = transport
+    assert calendars.fetch_text(origin + '/redirect-host') == ICS
+    assert seen['sni'] == ['calendar.example', 'next.example']
+    assert seen['requests'][1][0] == origin.replace('https://calendar', 'next')
+
+
+def test_environment_proxies_cannot_resolve_the_calendar_elsewhere(transport, monkeypatch):
+    origin, seen, _, _ = transport
+    monkeypatch.setenv('HTTPS_PROXY', 'http://proxy.example:8123')
+    monkeypatch.setenv('ALL_PROXY', 'http://proxy.example:8123')
+    monkeypatch.setenv('NO_PROXY', '')
+    assert calendars.fetch_text(origin + '/calendar.ics') == ICS
+    assert seen['dns']['proxy.example'] == 0
+
+
+def test_a_failed_public_address_can_fall_back_to_another_validated_address(transport):
+    origin, seen, answers, unreachable = transport
+    answers['calendar.example'] = [[PUBLIC_V6, PUBLIC]]
+    unreachable.add(PUBLIC_V6)
+    assert calendars.fetch_text(origin + '/calendar.ics') == ICS
+    assert [target[0] for target in seen['connections']] == [PUBLIC_V6, PUBLIC]
+    assert seen['dns']['calendar.example'] == 1
+
+
+def test_a_certificate_for_another_hostname_is_rejected(transport):
+    origin, seen, _, _ = transport
+    with pytest.raises(FeedError):
+        calendars.fetch_text(origin.replace('calendar.example', 'wrong.example') + '/calendar.ics')
+    assert seen['sni'] == ['wrong.example']
+    assert seen['requests'] == []
+
+
+def test_an_untrusted_certificate_is_rejected(transport, monkeypatch):
+    origin, seen, _, _ = transport
+    monkeypatch.setattr(requests.adapters, 'DEFAULT_CA_BUNDLE_PATH', requests.certs.where())
+    with pytest.raises(FeedError):
+        calendars.fetch_text(origin + '/calendar.ics')
+    assert seen['sni'] == ['calendar.example']
+    assert seen['requests'] == []

--- a/tests/test_secrets_and_headers.py
+++ b/tests/test_secrets_and_headers.py
@@ -16,6 +16,7 @@ import requests
 
 from dinkydash.calendars import FeedError, fetch_feed, zone
 from dinkydash.store import FileStore
+from test_feed_safety import resolves_to
 from tests.conftest import client_for
 from web import create_app
 
@@ -41,8 +42,8 @@ def client(tmp_path):
 
 
 def _raising(exc):
-    """A `requests.get` stand-in that fails the way the real one does."""
-    def _get(url, timeout=None, **kwargs):
+    """An HTTP transport stand-in that fails the way Requests does."""
+    def _get(adapter, request, timeout=None, **kwargs):
         raise exc
     return _get
 
@@ -58,7 +59,8 @@ def _http_error(status, reason):
 
 
 def _fetch(monkeypatch, exc):
-    monkeypatch.setattr(requests, "get", _raising(exc))
+    resolves_to(monkeypatch, "1.1.1.1")
+    monkeypatch.setattr(requests.adapters.HTTPAdapter, "send", _raising(exc))
     with pytest.raises(FeedError) as caught:
         fetch_feed(SECRET, date(2026, 9, 3), date(2026, 9, 17), zone("UTC"),
                    label="Dad's", timeout=1)
@@ -108,7 +110,8 @@ class TestTheCalendarUrlNeverEscapes:
         # fetch_events puts the message into `calendar_statuses`, which the
         # settings page renders.
         from dinkydash import calendars
-        monkeypatch.setattr(requests, "get", _raising(_http_error(403, "Forbidden")))
+        resolves_to(monkeypatch, "1.1.1.1")
+        monkeypatch.setattr(requests.adapters.HTTPAdapter, "send", _raising(_http_error(403, "Forbidden")))
         _events, statuses = calendars.fetch_events(
             [{"label": "Dad's", "url": SECRET, "enabled": True}],
             date(2026, 9, 3), zone("UTC"), timeout=1)


### PR DESCRIPTION
Calendar fetches could resolve a different address after validation, and the Conductor preview could replace an exported scratch database with the `.env` value.

Fixes [DIN-48](https://linear.app/keepthescore/issue/DIN-48) and [DIN-61](https://linear.app/keepthescore/issue/DIN-61): preview defaults preserve exports, while calendar connections use only checked public IPs with HTTPS hostname verification, redirect checks, bounded bodies and IPv4/IPv6 fallback through direct connections that bypass environment proxies.

Updates the engineering plan to reflect MVP-only Todo work, completed main changes, and the new signup-link issue [DIN-63](https://linear.app/keepthescore/issue/DIN-63).

Validation: 930 tests passed with PostgreSQL and 653 without a database (277 expected skips), including real TLS/DNS-rebinding regressions and execution of the configured preview command with invented environment values.
