### PR TITLE
Close MVP spending, export and trial-expiry gaps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,6 +197,8 @@ mode is a different product on the same code.
   caller's existing keep-last-good path handles it and no second such path gets written; and
   **anything new that calls Anthropic takes a budget**, the way it takes a store. "Rewrite now" was
   the one path with no limit on it at all, and it is charged now too.
+  The budget also applies the platform's model and output-token ceiling before hosted generation.
+  Its global daily aggregate has no family identifiers and survives account deletion (DIN-49/51).
 
 ### The safety net, and what it does not cover
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,6 +1,6 @@
 # DinkyDash Hosted MVP — Plan
 
-*Updated 8 September 2026: main through PR #92, plus the DIN-48/DIN-61 implementation and MVP triage.*
+*Updated 9 September 2026: main through PR #93, plus the DIN-49/DIN-51 spending controls.*
 
 This is the engineering plan for the hosted app and its shared self-hosted codebase.
 Positioning, pricing reasoning and launch strategy live in Linear on the DIN team.
@@ -16,15 +16,17 @@ serialized the per-address token limit, and fixed hosted HTTPS screen links.
 PRs #87 and #89 added the calendar-provider and device guides ([DIN-14](https://linear.app/keepthescore/issue/DIN-14), [DIN-13](https://linear.app/keepthescore/issue/DIN-13)).
 PR #91 implemented privacy-safe calendar publication ([DIN-46](https://linear.app/keepthescore/issue/DIN-46))
 and removed generated text and malformed screen credentials from service logs ([DIN-47](https://linear.app/keepthescore/issue/DIN-47)).
-The current batch preserves explicit preview database overrides ([DIN-48](https://linear.app/keepthescore/issue/DIN-48))
+PR #93 preserves explicit preview database overrides ([DIN-48](https://linear.app/keepthescore/issue/DIN-48))
 and connects calendar fetches only to validated public addresses ([DIN-61](https://linear.app/keepthescore/issue/DIN-61)).
+The current batch preserves charged global usage after account deletion ([DIN-49](https://linear.app/keepthescore/issue/DIN-49))
+and enforces the platform's model and token ceiling for hosted generation ([DIN-51](https://linear.app/keepthescore/issue/DIN-51)).
 
 Todo is reserved for the hosted MVP: signup and trial use, payment/cancellation,
 privacy and spending controls, basic monitoring/recovery, and real-device validation.
 Optional features, promotion and additional operational tooling are Backlog.
 Hosted readiness is still open. The remaining sequence is:
 
-1. Complete spending boundaries ([DIN-49](https://linear.app/keepthescore/issue/DIN-49), [DIN-51](https://linear.app/keepthescore/issue/DIN-51)), export coverage ([DIN-50](https://linear.app/keepthescore/issue/DIN-50)), and trial
+1. Complete export coverage ([DIN-50](https://linear.app/keepthescore/issue/DIN-50)) and trial
    expiry/lapse ([DIN-52](https://linear.app/keepthescore/issue/DIN-52)). Complete Stripe conversion before accepting payment ([DIN-53](https://linear.app/keepthescore/issue/DIN-53)).
 2. Add liveness alerts and recovery checks ([DIN-54](https://linear.app/keepthescore/issue/DIN-54),
    [DIN-56](https://linear.app/keepthescore/issue/DIN-56)), and finish the trust work in Phase 5.
@@ -69,7 +71,7 @@ work for a self-hoster without Postgres, email or billing services.
 | Settings access | Local network, no authentication | Magic-link session |
 | Board | `/` | `/s/<token>` |
 | Scheduler | `generate.py --tick` from cron | `worker/`, one pass every five minutes |
-| Model configuration | User's model, token limit and API key | Platform key; enforcing platform model/token policy remains [DIN-51](https://linear.app/keepthescore/issue/DIN-51) |
+| Model configuration | User's model, token limit and API key | Platform key, model and output-token ceiling ([DIN-51](https://linear.app/keepthescore/issue/DIN-51)) |
 | Billing | None | Planned; [DIN-52](https://linear.app/keepthescore/issue/DIN-52) and [DIN-53](https://linear.app/keepthescore/issue/DIN-53) |
 
 `create_app(store=None, *, pool=None)` accepts a store only in single mode and a
@@ -151,15 +153,17 @@ under [DIN-60](https://linear.app/keepthescore/issue/DIN-60); weakening shared-c
 
 Built in [DIN-43](https://linear.app/keepthescore/issue/DIN-43). Hosted worker ticks and manual rewrites share a budget charged before
 the model call. `model_spend` records calls and reported tokens per family per UTC day.
-The per-family cap uses an atomic upsert; the global sum is approximate under concurrent
-calls and scales with the number of non-lapsed families. Zero caps refuse generation.
+The per-family cap uses an atomic upsert; the global cap is approximate under concurrent
+calls and scales with the number of non-lapsed families. `global_model_spend` holds a
+daily call total with no family identifiers; a database trigger adds every charged
+attempt, including writes from older instances during deployment. Account deletion
+removes the family's usage rows without refunding this total ([DIN-49](https://linear.app/keepthescore/issue/DIN-49)). Zero caps refuse generation.
 Single mode uses the self-hoster's own key without this hosted budget.
 
-Two boundaries are still missing: deleting a family erases its contribution to the
-current global total ([DIN-49](https://linear.app/keepthescore/issue/DIN-49)), and family config still controls the hosted model and
-output-token limit ([DIN-51](https://linear.app/keepthescore/issue/DIN-51)). Call counts alone therefore do not establish the intended
-hosted cost ceiling. Budget refusal preserves the previous brief; calendar refreshes
-are not charged to the model budget.
+The same budget applies the platform's `claude-haiku-4-5` model and 1,024-token output
+ceiling before generation, ignoring legacy or crafted family overrides ([DIN-51](https://linear.app/keepthescore/issue/DIN-51)).
+Budget refusal preserves the previous brief; calendar refreshes are not charged to
+the model budget. Call counts and an output ceiling are not a currency-denominated cap.
 
 ### Three clocks, one setting
 
@@ -246,6 +250,7 @@ The SQL files in [migrations/](migrations/) are authoritative. The current table
 | `generations` | Per-day brief plus generation metadata and reported token usage |
 | `content_history` | Recent generated copy, trimmed to 30 entries |
 | `model_spend` | Daily per-family calls and reported tokens |
+| `global_model_spend` | Daily call totals without family identifiers; survives deletion |
 | `calendar_health` | Schema exists; recurring-failure tracking is not yet wired up |
 | `schema_migrations` | Applied migration versions |
 
@@ -323,7 +328,7 @@ privacy and readiness defects are tracked explicitly below.
 - [x] Inline Google, iCloud and Outlook help in getting-started ([DIN-2](https://linear.app/keepthescore/issue/DIN-2)).
 - [x] Standalone provider pages and screenshots ([DIN-14](https://linear.app/keepthescore/issue/DIN-14)).
 - [x] Hide/reject self-hosting controls in cloud settings (PR #92).
-- [ ] Enforce platform model and token limits at every hosted generation entry point ([DIN-51](https://linear.app/keepthescore/issue/DIN-51)).
+- [x] Enforce platform model and token limits at every hosted generation entry point ([DIN-51](https://linear.app/keepthescore/issue/DIN-51)).
 - [ ] Assess the need for a guided wizard from observed setup friction ([DIN-58](https://linear.app/keepthescore/issue/DIN-58)).
 
 **Core completion met by [DIN-39](https://linear.app/keepthescore/issue/DIN-39):** two families can be configured independently, and
@@ -336,7 +341,7 @@ another family's item ID returns 404. Onboarding validation remains open.
 - [x] Per-family and approximate global call caps, including manual rewrites ([DIN-43](https://linear.app/keepthescore/issue/DIN-43)).
 - [x] Keep-last-good rendering and retry on subsequent ticks.
 - [x] Reject refresh publication after a calendar privacy/config change ([DIN-46](https://linear.app/keepthescore/issue/DIN-46)).
-- [ ] Preserve global spending across account deletion ([DIN-49](https://linear.app/keepthescore/issue/DIN-49)).
+- [x] Preserve global spending across account deletion ([DIN-49](https://linear.app/keepthescore/issue/DIN-49)).
 - [ ] Failure tracking, backoff and parent notification ([DIN-55](https://linear.app/keepthescore/issue/DIN-55); Backlog).
 - [ ] Remove the remaining implicit date fallback in feed description ([DIN-62](https://linear.app/keepthescore/issue/DIN-62); maintenance).
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,6 +1,6 @@
 # DinkyDash Hosted MVP — Plan
 
-*Updated 9 September 2026: main through PR #93, plus the DIN-49/DIN-51 spending controls.*
+*Updated 9 September 2026: main through PR #93, plus spending, export and trial-expiry fixes (DIN-49–52).*
 
 This is the engineering plan for the hosted app and its shared self-hosted codebase.
 Positioning, pricing reasoning and launch strategy live in Linear on the DIN team.
@@ -20,14 +20,15 @@ PR #93 preserves explicit preview database overrides ([DIN-48](https://linear.ap
 and connects calendar fetches only to validated public addresses ([DIN-61](https://linear.app/keepthescore/issue/DIN-61)).
 The current batch preserves charged global usage after account deletion ([DIN-49](https://linear.app/keepthescore/issue/DIN-49))
 and enforces the platform's model and token ceiling for hosted generation ([DIN-51](https://linear.app/keepthescore/issue/DIN-51)).
+It also exports retained daily generations ([DIN-50](https://linear.app/keepthescore/issue/DIN-50)) and enforces trial expiry,
+manual-action restrictions and the 30-day lapsed display period ([DIN-52](https://linear.app/keepthescore/issue/DIN-52)).
 
 Todo is reserved for the hosted MVP: signup and trial use, payment/cancellation,
 privacy and spending controls, basic monitoring/recovery, and real-device validation.
 Optional features, promotion and additional operational tooling are Backlog.
 Hosted readiness is still open. The remaining sequence is:
 
-1. Complete export coverage ([DIN-50](https://linear.app/keepthescore/issue/DIN-50)) and trial
-   expiry/lapse ([DIN-52](https://linear.app/keepthescore/issue/DIN-52)). Complete Stripe conversion before accepting payment ([DIN-53](https://linear.app/keepthescore/issue/DIN-53)).
+1. Complete Stripe conversion, subscription changes and cancellation before accepting payment ([DIN-53](https://linear.app/keepthescore/issue/DIN-53)).
 2. Add liveness alerts and recovery checks ([DIN-54](https://linear.app/keepthescore/issue/DIN-54),
    [DIN-56](https://linear.app/keepthescore/issue/DIN-56)), and finish the trust work in Phase 5.
 3. Replace hosted waitlist/form links with the signup/login page ([DIN-63](https://linear.app/keepthescore/issue/DIN-63)).
@@ -180,7 +181,7 @@ run still performs a refresh and brief for compatibility with older self-hosted 
 
 ### Scheduling (cloud mode)
 
-The worker reads non-lapsed family IDs, visits them sequentially, and passes each
+The worker reads family IDs with current access, visits them sequentially, and passes each
 config and payload through the scheduling calculation. It does not currently select
 due families through timezone expression indexes or fan calendar fetches into a thread pool.
 One family's failure does not stop the pass; shutdown finishes the family in hand.
@@ -191,8 +192,17 @@ Every hosted attempt must continue to pass through the budget.
 
 Keep-last-good and retries on subsequent ticks exist. Persistent failure tracking,
 backoff and parent notification are Backlog ([DIN-55](https://linear.app/keepthescore/issue/DIN-55)); the MVP worker heartbeat remains [DIN-54](https://linear.app/keepthescore/issue/DIN-54).
-Skipping rows already marked lapsed does not enforce `trial_ends_at`; [DIN-52](https://linear.app/keepthescore/issue/DIN-52) must add
-that transition and the corresponding manual-action and rendering behaviour.
+Trial access ends at `trial_ends_at`, using the database's timezone-aware clock ([DIN-52](https://linear.app/keepthescore/issue/DIN-52)).
+The worker persists expired trials as lapsed; selection, manual feed checks, calendar refreshes
+and model calls also enforce the deadline independently of that sweep. Legacy trials with no
+deadline get one 14 days after account creation. Active paid accounts ignore their old trial dates.
+
+For 30 days after access ends, the screen renders the last successful brief using its saved date,
+so dates, chore rotations and countdowns stop advancing. Explicit settings edits and calendar
+privacy invalidation still apply; no extra copy of family content is stored. At 30 days, or if no
+successful brief exists, only the ended-access message is rendered. Settings, export and deletion
+remain available. Reactivation clears the lapse timestamp and the screen resumes on reload.
+This display cutoff does not delete stored content; retention sweeps remain DIN-57.
 
 ### The engine boundary
 
@@ -243,20 +253,21 @@ The SQL files in [migrations/](migrations/) are authoritative. The current table
 
 | Table | Stored data / current use |
 |---|---|
-| `families` | Config, screen token, account status and trial/subscription fields |
+| `families` | Config, screen token, account status, trial deadline and lapse timestamp |
 | `users` | Family membership and login address |
 | `login_tokens` | Hashed single-use token, expiry, and either user or signup email |
 | `agendas` | One overwritten calendar window and fetch status per family |
 | `generations` | Per-day brief plus generation metadata and reported token usage |
-| `content_history` | Recent generated copy, trimmed to 30 entries |
+| `content_history` | Recent generated copy, trimmed to the configured history length (at least 30) |
 | `model_spend` | Daily per-family calls and reported tokens |
 | `global_model_spend` | Daily call totals without family identifiers; survives deletion |
 | `calendar_health` | Schema exists; recurring-failure tracking is not yet wired up |
 | `schema_migrations` | Applied migration versions |
 
 Model-written text can contain calendar details and currently remains in older
-`generations.brief` rows until account deletion. Export completeness ([DIN-50](https://linear.app/keepthescore/issue/DIN-50)) and
-retention sweeps ([DIN-57](https://linear.app/keepthescore/issue/DIN-57)) are separate requirements. A config change normally uses
+`generations.brief` rows until account deletion. Exports include all retained generations and the
+separate recent rewrite history ([DIN-50](https://linear.app/keepthescore/issue/DIN-50)); retention sweeps remain
+[DIN-57](https://linear.app/keepthescore/issue/DIN-57). A config change normally uses
 `with_defaults`; platform schema changes use migrations.
 
 ### Hosting and deployment
@@ -365,18 +376,18 @@ the real-device checks remain [DIN-58](https://linear.app/keepthescore/issue/DIN
 ### Phase 4 — Money
 
 - [x] Store the trial deadline when a verified signup creates a family ([DIN-41](https://linear.app/keepthescore/issue/DIN-41)).
-- [ ] Enforce expiry, restrict manual actions, and render the agreed lapsed state ([DIN-52](https://linear.app/keepthescore/issue/DIN-52)).
+- [x] Enforce expiry, restrict manual actions, and render the agreed lapsed state ([DIN-52](https://linear.app/keepthescore/issue/DIN-52)).
 - [ ] Checkout, Customer Portal, verified/idempotent webhooks, pricing and lifecycle notifications ([DIN-53](https://linear.app/keepthescore/issue/DIN-53)).
 - [ ] Apply the agreed price/tax configuration and update processor disclosures when enabling Stripe ([DIN-53](https://linear.app/keepthescore/issue/DIN-53)).
 
-**Done when:** signup → trial → paid → cancel passes in Stripe test mode. Storing a
-trial date and excluding already-lapsed rows do not meet this requirement on their own.
+**Done when:** signup → trial → paid → cancel passes in Stripe test mode. Trial
+expiry is implemented; checkout, payment and cancellation still need that verification.
 
 ### Phase 5 — Legal & trust
 
 - [x] Published privacy policy, terms, processor list and relevant disclosures beside calendar setup ([DIN-44](https://linear.app/keepthescore/issue/DIN-44)).
 - [x] Account export/download and hard-delete actions, scoped to the signed-in family ([DIN-44](https://linear.app/keepthescore/issue/DIN-44)).
-- [ ] Include every retained historical generation in the export ([DIN-50](https://linear.app/keepthescore/issue/DIN-50)).
+- [x] Include every retained historical generation in the export ([DIN-50](https://linear.app/keepthescore/issue/DIN-50)).
 - [x] Keep generated family text and bearer credentials out of service logs ([DIN-47](https://linear.app/keepthescore/issue/DIN-47)).
 - [ ] Verify DigitalOcean/Cloudflare agreement status and record private evidence ([DIN-59](https://linear.app/keepthescore/issue/DIN-59)).
 - [ ] Implement and then disclose old-brief and lapsed-family retention sweeps ([DIN-57](https://linear.app/keepthescore/issue/DIN-57)).
@@ -431,7 +442,6 @@ cover those needs for the MVP alongside the remaining liveness and recovery work
 
 | Decision / verification | Tracking |
 |---|---|
-| Exact lapse presentation and transition boundaries; proposal: stop refresh/briefs, preserve the last board, then message-only after 30 days | [DIN-52](https://linear.app/keepthescore/issue/DIN-52) |
 | Implement the proposed 90-day brief-content and lapsed-family deletion periods before promising them | [DIN-57](https://linear.app/keepthescore/issue/DIN-57) |
 | Account-specific Stripe price/tax setup before the first charge | [DIN-53](https://linear.app/keepthescore/issue/DIN-53) |
 | Whether observed setup failures justify a multi-step wizard | [DIN-58](https://linear.app/keepthescore/issue/DIN-58) |

--- a/dinkydash/CLAUDE.md
+++ b/dinkydash/CLAUDE.md
@@ -118,7 +118,7 @@ starter config in the transaction that spent it. Five things about that are deli
   and that statement is the thing the whole design rests on — written twice, one copy drifts.
 - **A sign-up token is outside every cascade.** It has no `user_id`, so deleting a family does not
   reach it; the sweep does, fifteen minutes later. That is fine in production and it bit the test
-  suite, where the scratch database is reused between runs — `tests/conftest.forget_ownerless_tokens`
+  suite, where the scratch database is reused between runs — `tests/conftest.forget_unowned_rows`
   is what stops three abandoned sign-ups silently exhausting `MOST_LIVE_LINKS` on the next run.
 - **Two links for one new address must not make two families.** `_start_a_family` looks the address
   up first and the INSERT that follows carries `ON CONFLICT DO NOTHING`; losing that race means
@@ -147,8 +147,9 @@ Five things in it are load-bearing, and `tests/test_budget.py` asserts each:
   no row to conflict with. Written with only the first, a cap of `0` let every family through once
   daily, so the brake that exists to stop all spending was the one setting that could not.
 - **The global cap is approximate and says so**, by at most the number of simultaneous callers.
-  Making it exact means serialising every family's tick behind one row, which is not worth it for a
-  ceiling set well above legitimate use.
+  Its check reads a daily aggregate before the charge. A trigger atomically adds successful
+  charges to `global_model_spend`, which has only a date and count and survives family deletion.
+  Keep the trigger: older instances still write `model_spend` during pre-deploy migrations.
 - **A refusal is an `OverBudget`, a subclass of `GenerationError`.** That is what lets every caller
   keep the board on the wall with no new branch — "a failure is not handled, it is simply due again"
   already covers it. A second kind of failure would mean a second keep-last-good path.
@@ -156,6 +157,12 @@ Five things in it are load-bearing, and `tests/test_budget.py` asserts each:
 The **calendar refresh is outside the budget**. A fetch costs HTTP requests to somebody else's
 server, not money, and a family who cannot afford a new headline today should still have an
 accurate agenda under yesterday's.
+
+The budget also supplies `generation_config(config)` at the shared `write_brief` boundary
+(DIN-51). `NoBudget` preserves the self-hoster's settings; `PostgresBudget` returns a copy with
+the platform's `DEFAULT_MODEL` and `DEFAULT_MAX_TOKENS`. Do not read the mode from the environment
+inside the engine or trust saved family model overrides. Both hosted entry points must continue
+to pass the same budget; API-stub tests cover worker ticks and manual rewrites.
 
 ## Cloud mode: schema, migrations, connections
 

--- a/dinkydash/CLAUDE.md
+++ b/dinkydash/CLAUDE.md
@@ -154,15 +154,23 @@ Five things in it are load-bearing, and `tests/test_budget.py` asserts each:
   keep the board on the wall with no new branch — "a failure is not handled, it is simply due again"
   already covers it. A second kind of failure would mean a second keep-last-good path.
 
-The **calendar refresh is outside the budget**. A fetch costs HTTP requests to somebody else's
+The **calendar refresh is outside the call cap**. A fetch costs HTTP requests to somebody else's
 server, not money, and a family who cannot afford a new headline today should still have an
-accurate agenda under yesterday's.
+accurate agenda under yesterday's. It still takes the budget to check hosted account access;
+an expired or lapsed account cannot start a fetch, a feed check or a model call (DIN-52).
 
 The budget also supplies `generation_config(config)` at the shared `write_brief` boundary
 (DIN-51). `NoBudget` preserves the self-hoster's settings; `PostgresBudget` returns a copy with
 the platform's `DEFAULT_MODEL` and `DEFAULT_MAX_TOKENS`. Do not read the mode from the environment
 inside the engine or trust saved family model overrides. Both hosted entry points must continue
 to pass the same budget; API-stub tests cover worker ticks and manual rewrites.
+
+`lifecycle.py` evaluates hosted access against Postgres `now()`, including expired trials that
+the worker has not swept yet. The sweep writes `lapsed_at = trial_ends_at`, so a late sweep
+cannot extend the display period. Migration 005 fills missing trial deadlines from creation;
+its trigger requires a lapse timestamp on lapsed status and clears it on reactivation.
+The wall keeps the last brief's date for 30 days, then shows only an ended-access message.
+This is a rendering cutoff, not a retention sweep; settings and account data remain available.
 
 ## Cloud mode: schema, migrations, connections
 

--- a/dinkydash/board.py
+++ b/dinkydash/board.py
@@ -7,7 +7,7 @@ generation fails, the times and turns on the wall are still today's — only the
 written line is yesterday's, and it says so.
 """
 
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
 
 from .calendars import events_on
 from .context import build_countdowns, compute_chore_assignments
@@ -111,3 +111,24 @@ def build_view(config, payload, today):
             view["stale_days"] = None
 
     return view
+
+
+def build_lapsed_view(config, payload, show_last_board):
+    """Hold the last brief's date and computed turns, then show only a message.
+
+    Read existing data rather than retaining another copy of calendar details.
+    Explicit settings edits and calendar privacy invalidation still take effect.
+    """
+    if show_last_board:
+        try:
+            saved_day = date.fromisoformat((payload or {}).get("generated_for_date", ""))
+        except (TypeError, ValueError):
+            pass  # No successful brief: there is no board to preserve.
+        else:
+            view = build_view(config, payload, saved_day)
+            view["state"] = "frozen"
+            return view
+    return {
+        "state": "ended", "family_name": "", "reload_seconds": MAX_RELOAD_SECONDS,
+        "theme": "dark" if config.get("theme") == "dark" else "light",
+    }

--- a/dinkydash/budget.py
+++ b/dinkydash/budget.py
@@ -7,6 +7,7 @@
     budget.allow()                    charge one call, or raise OverBudget
     budget.record(input, output)      what that call actually used
     budget.generation_config(config)  apply the payer's model/token policy
+    budget.check_access()             refuse updates after hosted access ends
 
 Nothing bounded the Anthropic bill before this (DIN-43). The worker walks every
 non-lapsed family and calls Claude, "Rewrite now" calls it from a web request,
@@ -104,6 +105,9 @@ class NoBudget:
     def generation_config(self, config):
         return config
 
+    def check_access(self):
+        return None
+
 
 class PostgresBudget:
     """The breaker, for one family, over the shared pool."""
@@ -119,6 +123,10 @@ class PostgresBudget:
     def generation_config(self, config):
         """The platform pays, so stored family overrides cannot choose the cost."""
         return dict(config, claude_model=DEFAULT_MODEL, max_tokens=DEFAULT_MAX_TOKENS)
+
+    def check_access(self):
+        from .lifecycle import access_for
+        access_for(self.pool, self.family_id).require_live()
 
     def allow(self):
         """Charge one call, or raise `OverBudget`. Returns how many are now used.
@@ -138,6 +146,7 @@ class PostgresBudget:
         call a day: the brake that exists to stop all spending was the one
         setting that could not. Caught by a test, not by reading it.
         """
+        self.check_access()
         day = _today()
         with self.pool.connection() as conn, conn.transaction():
             with conn.cursor() as cur:

--- a/dinkydash/budget.py
+++ b/dinkydash/budget.py
@@ -6,6 +6,7 @@
 
     budget.allow()                    charge one call, or raise OverBudget
     budget.record(input, output)      what that call actually used
+    budget.generation_config(config)  apply the payer's model/token policy
 
 Nothing bounded the Anthropic bill before this (DIN-43). The worker walks every
 non-lapsed family and calls Claude, "Rewrite now" calls it from a web request,
@@ -32,10 +33,13 @@ difference is written down rather than glossed:
 * **the per-family cap is exact.** It is enforced in the `ON CONFLICT ... DO
   UPDATE ... WHERE`, which Postgres evaluates against the locked, current row;
 * **the global cap is approximate**, by at most the number of callers arriving
-  in the same instant. It is a sum read before the write, and making it exact
-  would mean serialising every family's tick behind one row. For a ceiling set
-  well above what anybody legitimately uses, an overshoot of a handful of calls
-  is not worth that.
+  in the same instant. Its daily total is read before the write; concurrent
+  callers can pass the check together. The trigger adds every successful charge
+  to `global_model_spend` atomically, without retaining family identifiers or
+  refunding calls when an account is deleted.
+
+Cloud generation uses the platform's model and output-token ceiling. Family
+config cannot change either; single mode keeps the self-hoster's settings.
 
 **The global cap scales with the number of families**, and that is deliberate: a
 fixed number is a control that silently starts starving real boards on the day
@@ -51,7 +55,7 @@ import logging
 import os
 from datetime import datetime, timezone
 
-from .claude_client import GenerationError
+from .claude_client import DEFAULT_MAX_TOKENS, DEFAULT_MODEL, GenerationError
 
 log = logging.getLogger(__name__)
 
@@ -97,6 +101,9 @@ class NoBudget:
     def record(self, input_tokens, output_tokens):
         return None
 
+    def generation_config(self, config):
+        return config
+
 
 class PostgresBudget:
     """The breaker, for one family, over the shared pool."""
@@ -108,6 +115,10 @@ class PostgresBudget:
         self.family_a_day = family_a_day
         self.global_floor = global_floor
         self.global_per_family = global_per_family
+
+    def generation_config(self, config):
+        """The platform pays, so stored family overrides cannot choose the cost."""
+        return dict(config, claude_model=DEFAULT_MODEL, max_tokens=DEFAULT_MAX_TOKENS)
 
     def allow(self):
         """Charge one call, or raise `OverBudget`. Returns how many are now used.
@@ -133,8 +144,8 @@ class PostgresBudget:
                 cur.execute(
                     """INSERT INTO model_spend (day, family_id, calls)
                        SELECT %(day)s, %(family)s, 1
-                       WHERE (SELECT coalesce(sum(calls), 0) FROM model_spend
-                              WHERE day = %(day)s)
+                       WHERE coalesce((SELECT calls FROM global_model_spend
+                                       WHERE day = %(day)s), 0)
                              < (SELECT %(floor)s + %(per)s * count(*)
                                 FROM families WHERE status <> 'lapsed')
                          -- The insert path: no row yet, so this family has made
@@ -196,10 +207,11 @@ class PostgresBudget:
         day = _today()
         with self.pool.connection() as conn, conn.cursor() as cur:
             cur.execute(
-                """SELECT coalesce(max(calls) FILTER (WHERE family_id = %s), 0),
-                          coalesce(sum(calls), 0)
-                   FROM model_spend WHERE day = %s""",
-                (self.family_id, day),
+                """SELECT coalesce((SELECT calls FROM model_spend
+                                    WHERE family_id = %s AND day = %s), 0),
+                          coalesce((SELECT calls FROM global_model_spend
+                                    WHERE day = %s), 0)""",
+                (self.family_id, day, day),
             )
             return cur.fetchone()
 

--- a/dinkydash/lifecycle.py
+++ b/dinkydash/lifecycle.py
@@ -1,0 +1,61 @@
+"""Hosted access boundaries. All decisions use the database's aware clock."""
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+
+from .claude_client import GenerationError
+
+FROZEN_BOARD_PERIOD = timedelta(days=30)
+ENDED_MESSAGE = "Your trial or subscription has ended. Board updates are paused."
+
+
+@dataclass(frozen=True)
+class Access:
+    lapsed_at: datetime | None
+    now: datetime
+
+    @property
+    def ended(self):
+        return self.lapsed_at is not None
+
+    @property
+    def show_last_board(self):
+        return self.ended and self.now < self.lapsed_at + FROZEN_BOARD_PERIOD
+
+    def require_live(self):
+        if self.ended:
+            raise GenerationError(ENDED_MESSAGE)
+
+
+def access_for(pool, family_id):
+    """Check the deadline even if the worker has not swept this family yet.
+
+    An active paid account ignores its old trial deadline. The migration fills
+    missing trial deadlines from account creation and requires one thereafter.
+    """
+    with pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            """SELECT CASE
+                          WHEN status = 'lapsed' THEN lapsed_at
+                          WHEN status = 'trialing' AND trial_ends_at <= now()
+                              THEN trial_ends_at
+                      END, now()
+               FROM families WHERE id = %s""", (family_id,),
+        )
+        row = cur.fetchone()
+    if row is None:
+        from .pgstore import NoSuchFamily
+        raise NoSuchFamily(f"No family {family_id}")
+    return Access(*row)
+
+
+def expire_trials(pool):
+    """Persist ended trials once; a delayed or repeated sweep keeps the deadline."""
+    with pool.connection() as conn, conn.transaction(), conn.cursor() as cur:
+        cur.execute(
+            """UPDATE families
+               SET status = 'lapsed', lapsed_at = trial_ends_at, updated_at = now()
+               WHERE status = 'trialing' AND trial_ends_at <= now()
+               RETURNING id""",
+        )
+        return len(cur.fetchall())

--- a/dinkydash/runner.py
+++ b/dinkydash/runner.py
@@ -136,7 +136,8 @@ def write_brief(config, store, today=None, client=None, budget=None):
     budget.allow()
 
     payload = generate(
-        config, today, stored.get("events") or [], recent_notes=recent, client=client
+        budget.generation_config(config), today, stored.get("events") or [],
+        recent_notes=recent, client=client,
     )
     budget.record(payload.get("input_tokens"), payload.get("output_tokens"))
     # Only the brief. `stored` was read before a model call that takes seconds,

--- a/dinkydash/runner.py
+++ b/dinkydash/runner.py
@@ -39,14 +39,16 @@ from .generate import generate
 log = logging.getLogger(__name__)
 
 
-def refresh_calendars(config, store, now=None, today=None):
+def refresh_calendars(config, store, now=None, today=None, budget=None):
     """Re-fetch every enabled feed and store the merged agenda. No model call.
 
     `now` is when this is happening and becomes the `calendars_fetched_at`
     stamp. `today` is the day the fourteen-day window starts on, and defaults
     to today on the family's clock — they are the same thing except under
     `generate.py --date`, where the window is moved but the stamp is not.
+    The budget checks account access here without charging a model call.
     """
+    (budget or NoBudget()).check_access()
     now = now or datetime.now(timezone.utc)
     tzinfo = config_module.tzinfo_for(config)
     today = today or now.astimezone(tzinfo).date()
@@ -171,7 +173,7 @@ def run(config, store, today=None, client=None, budget=None):
     yesterday's headline.
     """
     require_api_key()  # before the fetch, so a missing key fails in a second
-    refresh_calendars(config, store, today=today)
+    refresh_calendars(config, store, today=today, budget=budget)
     return write_brief(config, store, today=today, client=client, budget=budget)
 
 

--- a/doc/operations.md
+++ b/doc/operations.md
@@ -309,21 +309,35 @@ dashboard-only change.
 doctl apps logs <id> worker --type run | grep "over the daily budget"
 ```
 
-and the running total is one query:
+and the running total, including calls made by deleted accounts, is one query:
 
 ```sql
-SELECT day, sum(calls) AS calls, sum(input_tokens) AS tok_in, sum(output_tokens) AS tok_out
-FROM model_spend GROUP BY day ORDER BY day DESC LIMIT 14;
+SELECT day, calls FROM global_model_spend ORDER BY day DESC LIMIT 14;
 ```
 
-**Two things it does not do.** It does not know about money, so a model change (Haiku to Sonnet is
-three times the cost) moves the real spend without moving the ceiling — the table above is what has
-to be corrected then. And the global half is approximate by the number of simultaneous callers,
-which with one worker and two web processes is a handful of calls, not a category of problem.
+Per-family usage and reported tokens remain in `model_spend` until account deletion.
+The breaker counts calls rather than currency; provider pricing or input size can change the bill
+without changing the count. The global cap remains approximate by the number of simultaneous
+callers, because its check reads the total before the charge.
 
 **Applied by the pre-deploy job**, like every migration, so this needs no separate step. The app
 spec *did* change — three new environment variables — so it joins the applies already outstanding
 below.
+
+### Spending controls, 9 September 2026 (DIN-49/DIN-51)
+
+Migration `004_global_model_spend.sql` backfills existing call counts and installs a trigger
+under a write lock in one transaction. Old web/worker instances continue contributing during
+deployment. The aggregate holds only a UTC date and call count, with no family foreign key;
+deleting an account still removes its personal data and per-family usage. Counts already erased
+by deletions before this migration cannot be reconstructed.
+
+The shared generation budget now fixes hosted calls to the platform's `DEFAULT_MODEL`
+(`claude-haiku-4-5`) and `DEFAULT_MAX_TOKENS` (1,024). Stored family overrides cannot select a
+different model or token ceiling. Self-hosted configuration still works as before.
+No new environment variable or app-spec change is needed; the normal pre-deploy job applies
+the migration. Deployment checks cover existing-row backfill, writes from old callers,
+transaction rollback, deletion/re-signup, and the real worker and manual paths against an API stub.
 
 ## Legal and trust, 8 September 2026 (DIN-44)
 

--- a/doc/operations.md
+++ b/doc/operations.md
@@ -379,6 +379,28 @@ transaction.
 **No spec change and no `doctl apps update` for this one** — no new environment variable, no
 migration. `deploy_on_push` is enough.
 
+### Export and trial expiry, 9 September 2026 (DIN-50/DIN-52)
+
+The account export now includes a dated `generations` array with every retained brief and its
+metadata, alongside `written_lines` for recent rewrites. Both queries use the signed-in family;
+download headers remain `no-store`. The privacy page now distinguishes retained daily briefs
+from the trimmed recent history.
+
+Migration `005_family_lapse.sql` adds `lapsed_at`, backfills existing lapsed rows from their
+last update, and fills missing trial deadlines with creation time plus 14 days. Its trigger
+stamps transitions to lapsed and clears the stamp when an account becomes active again.
+The worker marks expired trials once per pass, preserving the original deadline as `lapsed_at`.
+Worker selection and every hosted fetch/model entry point also check the database clock, so a
+late or failed sweep does not extend access. Active paid accounts ignore old trial deadlines.
+
+The screen holds the saved brief's date for 30 days after access ends, then renders only an
+ended-access message. Settings edits and calendar privacy invalidation still apply during that
+period. No extra snapshot is stored or retained. Export and deletion stay available, and the
+normal reload timer picks up reactivation. The display cutoff does not delete database content;
+the retention sweeps are still DIN-57. Stripe integration remains DIN-53.
+
+The usual pre-deploy job applies the migration; no new environment variables or app-spec changes.
+
 ## GitHub Pages, switched off 8 September 2026
 
 **Pages was still enabled, still set to build `main:/docs`, and still serving.** DIN-27 deleted that

--- a/generate.py
+++ b/generate.py
@@ -134,7 +134,7 @@ def tick(config, store, budget=None):
         if owed["refresh"]:
             # A stale refresh also stops this tick's brief; the next pass loads
             # the new config before fetching or making a model call.
-            refresh_calendars(config, store, now=now)
+            refresh_calendars(config, store, now=now, budget=budget)
         if owed["brief"]:
             today = now.astimezone(config_module.tzinfo_for(config)).date()
             # runner logs date and usage. Reporting family text is reserved for

--- a/migrations/004_global_model_spend.sql
+++ b/migrations/004_global_model_spend.sql
@@ -1,0 +1,37 @@
+-- Keep charged calls after a family's personal data is deleted (DIN-49).
+-- Only a UTC date and a total survive; there is no link back to an account.
+CREATE TABLE global_model_spend (
+    day   DATE PRIMARY KEY,
+    calls BIGINT NOT NULL DEFAULT 0 CHECK (calls >= 0)
+);
+
+-- The pre-deploy job runs while the old worker/web code may still be writing.
+-- Block writes during the backfill and install a trigger in the same transaction
+-- so those callers also contribute until the new code takes over.
+LOCK TABLE model_spend IN SHARE ROW EXCLUSIVE MODE;
+
+INSERT INTO global_model_spend (day, calls)
+SELECT day, sum(calls) FROM model_spend GROUP BY day;
+
+CREATE FUNCTION count_global_model_calls() RETURNS trigger
+LANGUAGE plpgsql AS $$
+DECLARE
+    charged BIGINT := NEW.calls;
+BEGIN
+    IF TG_OP = 'UPDATE' THEN
+        charged := NEW.calls - OLD.calls;
+    END IF;
+    IF charged > 0 THEN
+        INSERT INTO global_model_spend (day, calls) VALUES (NEW.day, charged)
+        ON CONFLICT (day) DO UPDATE
+            SET calls = global_model_spend.calls + EXCLUDED.calls;
+    END IF;
+    RETURN NULL;
+END;
+$$;
+
+-- Refused upserts and token bookkeeping charge nothing. Deletion never refunds
+-- an attempt; a rolled-back write rolls back its contribution too.
+CREATE TRIGGER count_global_model_calls
+AFTER INSERT OR UPDATE OF calls ON model_spend
+FOR EACH ROW EXECUTE FUNCTION count_global_model_calls();

--- a/migrations/005_family_lapse.sql
+++ b/migrations/005_family_lapse.sql
@@ -1,0 +1,29 @@
+-- The display grace period starts when access ends, not when a worker next runs.
+ALTER TABLE families ADD COLUMN lapsed_at TIMESTAMPTZ;
+UPDATE families SET lapsed_at = updated_at WHERE status = 'lapsed';
+UPDATE families SET trial_ends_at = created_at + interval '14 days'
+WHERE status = 'trialing' AND trial_ends_at IS NULL;
+ALTER TABLE families ADD CONSTRAINT families_lapse_matches_status
+    CHECK ((status = 'lapsed') = (lapsed_at IS NOT NULL));
+ALTER TABLE families ADD CONSTRAINT families_trial_has_deadline
+    CHECK (status <> 'trialing' OR trial_ends_at IS NOT NULL);
+
+-- Keep direct status changes consistent too, including later payment webhooks.
+CREATE FUNCTION stamp_family_lapse() RETURNS trigger
+LANGUAGE plpgsql AS $$
+BEGIN
+    IF NEW.status = 'trialing' AND NEW.trial_ends_at IS NULL THEN
+        NEW.trial_ends_at := NEW.created_at + interval '14 days';
+    END IF;
+    IF NEW.status = 'lapsed' THEN
+        NEW.lapsed_at := coalesce(NEW.lapsed_at, now());
+    ELSE
+        NEW.lapsed_at := NULL;
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER stamp_family_lapse
+BEFORE INSERT OR UPDATE OF status, trial_ends_at ON families
+FOR EACH ROW EXECUTE FUNCTION stamp_family_lapse();

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,13 +45,13 @@ def pg_pool():
 
     pool = db.pool(url, min_size=1, max_size=2)
     pool.wait(timeout=10)
-    forget_ownerless_tokens(pool)
+    forget_unowned_rows(pool)
     yield pool
     pool.close()
 
 
-def forget_ownerless_tokens(pool):
-    """Delete every sign-up token, which nothing else will.
+def forget_unowned_rows(pool):
+    """Reset scratch rows that deliberately survive account deletion.
 
     A sign-up token has no `user_id` — that is the whole point of it (DIN-41),
     and it is why `login_tokens.user_id` became nullable. The consequence is
@@ -63,19 +63,22 @@ def forget_ownerless_tokens(pool):
     database is reused between runs, so three abandoned sign-ups for one address
     silently exhaust `MOST_LIVE_LINKS` and the next run fails somewhere else
     entirely. Once when the pool is built, and again after every family.
+
+    The global model-call aggregate also has no family foreign key. Clear it
+    explicitly here so one test's calls cannot exhaust another test's budget.
     """
     with pool.connection() as conn, conn.transaction():
         with conn.cursor() as cur:
             cur.execute("DELETE FROM login_tokens WHERE user_id IS NULL")
+            cur.execute("DELETE FROM global_model_spend")
 
 
 @pytest.fixture
 def pg_family(pg_pool):
     """One empty family, and everything belonging to it removed afterwards.
 
-    Returns its id. Truncating `families` cascades to every other table, which
-    is also a live check that the foreign keys really do cascade — Phase 5's
-    hard delete depends on exactly that.
+    Returns its id. Deleting the family cascades to its dependent rows, which
+    is also a live check of the foreign keys used by the hard delete.
     """
     from dinkydash import config as config_module
 
@@ -99,7 +102,7 @@ def pg_family(pg_pool):
         with conn.cursor() as cur:
             cur.execute("DELETE FROM families WHERE id = %s", (family_id,))
     # Not part of that cascade, and not reachable from it — see above.
-    forget_ownerless_tokens(pg_pool)
+    forget_unowned_rows(pg_pool)
 
 
 # -- a test client that behaves like a browser ------------------------------

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -19,6 +19,7 @@ Skips without `DINKYDASH_TEST_DATABASE_URL`.
 """
 
 import json
+from datetime import date, timedelta
 
 import pytest
 import yaml
@@ -98,6 +99,49 @@ def rows(pg_pool, sql, args=()):
 # -- export -----------------------------------------------------------------
 
 class TestExport:
+    def test_older_daily_briefs_and_recent_rewrites_are_exported_only_for_this_family(
+            self, parent, pg_pool, family):
+        from dinkydash import config as config_module
+        from dinkydash.pgstore import PostgresStore
+
+        store = PostgresStore(pg_pool, family[0])
+        config = store.load_config()
+        for offset in range(31):
+            day = (date(2026, 9, 8) + timedelta(days=offset)).isoformat()
+            brief = {"generated_for_date": day, "generated_at": f"{day}T04:00:00+00:00",
+                     "headline": f"Retained day {offset}", "note": f"Fact {offset}",
+                     "note_kind": "fact", "model": "test-model",
+                     "input_tokens": 1200, "output_tokens": 90}
+            store.save_brief(config, brief)
+            store.record_note(config, dict(brief, date=day))
+        store.record_note(config, {"date": day, "headline": "An additional rewrite",
+                                  "note": "A retained alternative.", "note_kind": "fact"})
+
+        with pg_pool.connection() as conn, conn.transaction(), conn.cursor() as cur:
+            cur.execute("INSERT INTO families (screen_token) VALUES (%s) RETURNING id",
+                        (config_module.new_screen_token(),))
+            other = cur.fetchone()[0]
+        try:
+            neighbour = PostgresStore(pg_pool, other)
+            neighbour.save_brief({}, dict(brief, headline="Other family's private headline"))
+            neighbour.record_note({}, {"date": day, "note": "Other family's private note"})
+            # A requested family id cannot override the authenticated session.
+            response = parent.get(f"/settings/account/export?family_id={other}")
+            exported = json.loads(response.get_data())
+            generations = exported["generations"]
+            assert len(generations) == 31
+            assert generations[0]["generated_for_date"] == "2026-09-08"
+            assert generations[0]["brief"]["headline"] == "Retained day 0"
+            assert generations[0]["model"] == "test-model"
+            assert generations[0]["input_tokens"] == 1200
+            assert len(exported["written_lines"]) == 30
+            assert exported["written_lines"][-1]["headline"] == "An additional rewrite"
+            assert "Retained day 0" not in json.dumps(exported["written_lines"])
+            assert "Other family's private" not in response.get_data(as_text=True)
+            assert response.headers["Cache-Control"] == "no-store"
+        finally:
+            accounts.delete_family(pg_pool, other)
+
     def test_it_comes_back_as_a_file(self, parent):
         got = parent.get("/settings/account/export")
         assert got.status_code == 200

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -340,7 +340,7 @@ class TestTheGlobalCap:
 # -- what a refusal does to the board ---------------------------------------
 
 class TestARefusalKeepsTheBoard:
-    class Broke:
+    class Broke(NoBudget):
         """A budget that refuses everything, with no database behind it."""
 
         def allow(self):

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -20,6 +20,7 @@ refusal writes nothing — is tested without one.
 
 import os
 import sys
+from concurrent.futures import ThreadPoolExecutor
 from datetime import date, datetime, timezone
 
 import pytest
@@ -92,6 +93,13 @@ class TestNoBudget:
         payload = runner.write_brief(store.load_config(), store,
                                      today=date(2026, 9, 3), client=FakeClient())
         assert payload["headline"] == "Big morning"
+
+    def test_self_hosted_generation_keeps_the_configured_model_and_tokens(self, store, key):
+        config = dict(store.load_config(), claude_model="self-hosted-model", max_tokens=2048)
+        client = FakeClient()
+        runner.write_brief(config, store, client=client)
+        assert client.messages.calls[0]["model"] == "self-hosted-model"
+        assert client.messages.calls[0]["max_tokens"] == 2048
 
 
 # -- the caps read from the environment -------------------------------------
@@ -190,10 +198,27 @@ class TestThePerFamilyCap:
             with pytest.raises(OverBudget):
                 budget.allow()
         assert spend_rows(pg_pool, pg_family)[0] == 2
+        assert budget.used_today() == (2, 2)
 
     def test_a_cap_of_zero_refuses_everything(self, pg_pool, pg_family, clean):
         with pytest.raises(OverBudget):
             PostgresBudget(pg_pool, pg_family, family_a_day=0).allow()
+        assert PostgresBudget(pg_pool, pg_family).used_today() == (0, 0)
+
+    def test_concurrent_charges_cannot_lose_counts_or_exceed_the_family_cap(
+            self, pg_pool, pg_family, clean):
+        budget = PostgresBudget(pg_pool, pg_family, family_a_day=3)
+
+        def charge(_):
+            try:
+                budget.allow()
+                return True
+            except OverBudget:
+                return False
+
+        with ThreadPoolExecutor(max_workers=2) as callers:
+            assert sum(callers.map(charge, range(10))) == 3
+        assert budget.used_today() == (3, 3)
 
     def test_the_refusal_is_a_generation_error(self, pg_pool, pg_family, clean):
         """So every caller's existing keep-last-good path handles it. A second
@@ -223,6 +248,43 @@ class TestThePerFamilyCap:
 # -- the global cap ---------------------------------------------------------
 
 class TestTheGlobalCap:
+    def test_zero_refuses_the_first_call_too(self, pg_pool, pg_family, clean):
+        budget = PostgresBudget(pg_pool, pg_family, global_floor=0, global_per_family=0)
+        with pytest.raises(OverBudget):
+            budget.allow()
+        assert budget.used_today() == (0, 0)
+
+    def test_deleting_and_signing_up_again_does_not_refund_calls(
+            self, pg_pool, pg_family, clean):
+        from dinkydash import accounts
+
+        caps = {"global_floor": 1, "global_per_family": 0}
+        address = "spending-parent@example.com"
+        family_id = None
+        try:
+            first = accounts.consume_link(pg_pool, accounts.issue_signup_link(pg_pool, address))
+            family_id = first[1]
+            budget = PostgresBudget(pg_pool, family_id, **caps)
+            budget.allow()
+            budget.record(1200, 90)
+            assert accounts.delete_family(pg_pool, family_id)
+            assert spend_rows(pg_pool, family_id) is None
+            with pg_pool.connection() as conn, conn.cursor() as cur:
+                cur.execute("SELECT id FROM users WHERE email = %s", (address,))
+                assert cur.fetchone() is None
+            assert budget.used_today() == (0, 1)
+
+            second = accounts.consume_link(pg_pool, accounts.issue_signup_link(pg_pool, address))
+            family_id = second[1]
+            assert family_id != first[1]
+            replacement = PostgresBudget(pg_pool, family_id, **caps)
+            with pytest.raises(OverBudget):
+                replacement.allow()
+            assert replacement.used_today() == (0, 1)
+        finally:
+            if family_id is not None:
+                accounts.delete_family(pg_pool, family_id)
+
     def test_it_refuses_a_family_that_is_within_its_own_limit(
             self, pg_pool, pg_family, clean):
         """The point of having a global one at all: one family behaving normally
@@ -417,3 +479,48 @@ class TestRewriteNowIsChargedToo:
         parent.post("/settings/generate")
         store = PostgresStore(pg_pool, pg_family)
         assert store.load_payload(store.load_config()).get("calendars_fetched_at")
+
+
+@pytest.mark.parametrize("caller", ["worker", "rewrite"])
+@pytest.mark.parametrize("stored_tokens", [100000, "invalid", 0])
+def test_hosted_callers_enforce_model_policy_at_the_api(
+        pg_pool, pg_family, key, monkeypatch, caller, stored_tokens):
+    import anthropic
+    from dinkydash.claude_client import DEFAULT_MAX_TOKENS, DEFAULT_MODEL
+    from dinkydash.pgstore import PostgresStore
+    from tests.conftest import client_for
+    from web import create_app
+    from worker import tick_all
+
+    store = PostgresStore(pg_pool, pg_family)
+    store.save_config(dict(yaml.safe_load(CONFIG), brief_time="00:00",
+                           claude_model="legacy-expensive-model", max_tokens=stored_tokens))
+    model = FakeClient()
+    monkeypatch.setattr(anthropic, "Anthropic", lambda: model)
+    monkeypatch.setenv("DINKYDASH_MODE", "cloud")
+    monkeypatch.setenv("DINKYDASH_SECRET_KEY", "test-session-key")
+    parent = client_for(create_app(pool=pg_pool))
+    with parent.session_transaction() as session:
+        session["user_id"] = 1
+        session["family_id"] = str(pg_family)
+
+    assert parent.post("/settings/system", data={
+        "family_name": "The Wilsons", "claude_model": "posted-expensive-model",
+        "max_tokens": "200000",
+    }).status_code == 302
+    before = store.load_config()
+    assert before["claude_model"] == "legacy-expensive-model"
+    assert before["max_tokens"] == stored_tokens
+
+    if caller == "worker":
+        assert tick_all(pg_pool) == 1
+    else:
+        assert parent.post("/settings/generate").status_code == 302
+
+    assert len(model.messages.calls) == 1
+    sent = model.messages.calls[0]
+    assert sent["model"] == DEFAULT_MODEL
+    assert sent["max_tokens"] == DEFAULT_MAX_TOKENS
+    assert store.load_payload(before)["model"] == DEFAULT_MODEL
+    assert store.load_config() == before
+    assert PostgresBudget(pg_pool, pg_family).used_today() == (1, 1)

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -1,0 +1,251 @@
+"""Trial deadlines, manual access and the board after a lapse (DIN-52)."""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from dinkydash import lifecycle, runner
+from dinkydash.budget import PostgresBudget
+from dinkydash.claude_client import GenerationError
+from tests.conftest import board_path, client_for
+from tests.test_generate import FakeClient
+
+
+@pytest.mark.parametrize("elapsed,show", [
+    (timedelta(0), True),
+    (timedelta(days=30, microseconds=-1), True),
+    (timedelta(days=30), False),
+    (timedelta(days=31), False),
+])
+def test_frozen_period_ends_at_exactly_thirty_days(elapsed, show):
+    ended = datetime(2026, 9, 9, tzinfo=timezone(timedelta(hours=2)))
+    access = lifecycle.Access(ended, ended.astimezone(timezone.utc) + elapsed)
+    assert access.ended
+    assert access.show_last_board is show
+    with pytest.raises(GenerationError, match="has ended"):
+        access.require_live()
+
+
+def test_active_access_has_no_display_grace_period():
+    access = lifecycle.Access(None, datetime.now(timezone.utc))
+    assert not access.ended and not access.show_last_board
+    access.require_live()
+
+
+def test_upgrade_gives_legacy_trials_deadlines_and_stamps_status_changes(pg_pool):
+    from dinkydash import db
+
+    with pg_pool.connection() as conn, conn.transaction(force_rollback=True), conn.cursor() as cur:
+        cur.execute("CREATE SCHEMA lapse_migration_test")
+        cur.execute("SET LOCAL search_path TO lapse_migration_test, public")
+        upgrade = db.MIGRATIONS_DIR / "005_family_lapse.sql"
+        for path in db.migrations():
+            if path == upgrade:
+                break
+            cur.execute(path.read_text())
+        cur.execute("""INSERT INTO families (screen_token, created_at)
+                       VALUES ('legacy-trial-token', '2026-01-01T12:00:00+02:00') RETURNING id""")
+        legacy = cur.fetchone()[0]
+        cur.execute("""INSERT INTO families (screen_token, status)
+                       VALUES ('legacy-lapsed-token', 'lapsed'), ('legacy-paid-token', 'active')""")
+        cur.execute(upgrade.read_text())
+        cur.execute("SELECT trial_ends_at FROM families WHERE id = %s", (legacy,))
+        assert cur.fetchone() == (datetime(2026, 1, 15, 10, tzinfo=timezone.utc),)
+        cur.execute("SELECT lapsed_at IS NOT NULL FROM families WHERE status = 'lapsed'")
+        assert cur.fetchone() == (True,)
+        cur.execute("UPDATE families SET status = 'lapsed' WHERE id = %s", (legacy,))
+        cur.execute("SELECT lapsed_at = now() FROM families WHERE id = %s", (legacy,))
+        assert cur.fetchone() == (True,)
+        cur.execute("UPDATE families SET status = 'active' WHERE id = %s", (legacy,))
+        cur.execute("SELECT lapsed_at FROM families WHERE id = %s", (legacy,))
+        assert cur.fetchone() == (None,)
+        cur.execute("""INSERT INTO families (screen_token) VALUES ('new-trial-token')
+                       RETURNING trial_ends_at - created_at""")
+        assert cur.fetchone() == (timedelta(days=14),)
+
+
+def update_family(pool, family_id, assignments, values=()):
+    # Only tests supply the SQL; values always remain bound parameters.
+    with pool.connection() as conn, conn.transaction(), conn.cursor() as cur:
+        cur.execute(f"UPDATE families SET {assignments} WHERE id = %s",
+                    (*values, family_id))
+
+
+@pytest.fixture
+def hosted(pg_pool, pg_family, monkeypatch):
+    import anthropic
+    from dinkydash.pgstore import PostgresStore
+    from web import create_app
+
+    monkeypatch.setenv("DINKYDASH_MODE", "cloud")
+    monkeypatch.setenv("DINKYDASH_SECRET_KEY", "test-session-key")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-not-a-real-key")
+    model = FakeClient()
+    monkeypatch.setattr(anthropic, "Anthropic", lambda: model)
+    store = PostgresStore(pg_pool, pg_family)
+    store.save_config({"family_name": "Invented family", "timezone": "Europe/Berlin",
+                       "brief_time": "00:00", "people": [],
+                       "recurring": [{"title": "Set the table", "choices": ["Alex", "Sam"]}],
+                       "special_dates": [{"title": "A holiday", "date": "12/25"}],
+                       "calendars": [{"label": "Family", "enabled": True,
+                                      "url": "https://example.com/private-xxxx/basic.ics"}]})
+    config = store.load_config()
+    store.save_agenda(config, {"events": [{"title": "Saved appointment", "all_day": False,
+                                          "time": "09:00", "date": "2026-09-08",
+                                          "start": "2026-09-08T09:00:00+02:00"}]})
+    store.save_brief(config, {"generated_for_date": "2026-09-08",
+                              "generated_at": "2026-09-08T04:00:00+00:00",
+                              "headline": "Saved headline", "note": "Saved note"})
+    parent = client_for(create_app(pool=pg_pool))
+    with parent.session_transaction() as session:
+        session["user_id"] = 1
+        session["family_id"] = str(pg_family)
+    return parent, store, model
+
+
+@pytest.mark.parametrize("offset,ended", [("1 day", False), ("0 seconds", True), ("-1 day", True)])
+def test_trial_deadline_is_enforced_before_the_worker_sweep(pg_pool, pg_family, offset, ended):
+    update_family(pg_pool, pg_family, "trial_ends_at = now() + %s::interval", (offset,))
+    access = lifecycle.access_for(pg_pool, pg_family)
+    assert access.ended is ended
+    from worker import family_ids
+    assert (pg_family in family_ids(pg_pool)) is not ended
+
+
+def test_sweep_preserves_the_deadline_and_is_repeatable(pg_pool, pg_family):
+    # Same instant expressed in a non-UTC timezone.
+    deadline = datetime(2026, 1, 2, 1, tzinfo=timezone(timedelta(hours=9)))
+    update_family(pg_pool, pg_family, "trial_ends_at = %s", (deadline,))
+    assert lifecycle.expire_trials(pg_pool) == 1
+    assert lifecycle.expire_trials(pg_pool) == 0
+    with pg_pool.connection() as conn, conn.cursor() as cur:
+        cur.execute("SELECT status, lapsed_at FROM families WHERE id = %s", (pg_family,))
+        assert cur.fetchone() == ("lapsed", deadline)
+
+
+@pytest.mark.parametrize("action", ["worker", "rewrite", "refresh", "check"])
+@pytest.mark.parametrize("persisted", [False, True])
+def test_expired_accounts_cannot_fetch_or_generate(
+        hosted, pg_pool, pg_family, monkeypatch, action, persisted):
+    from worker import tick_all
+
+    parent, store, model = hosted
+    update_family(pg_pool, pg_family, "trial_ends_at = now()")
+    if persisted:
+        lifecycle.expire_trials(pg_pool)
+    before = store.load_payload(store.load_config())
+    fetched = []
+
+    def fetch(*args, **kwargs):
+        fetched.append(True)
+        raise AssertionError("A lapsed family fetched a calendar")
+
+    monkeypatch.setattr(runner, "fetch_events", fetch)
+    monkeypatch.setattr("web.routes.settings.describe_feed", fetch)
+    if action == "worker":
+        # Even a family selected just before its deadline must be refused.
+        monkeypatch.setattr("worker.family_ids", lambda _: [pg_family])
+        tick_all(pg_pool)
+    elif action == "check":
+        response = parent.post("/settings/calendars/new", data={
+            "action": "check", "url": "https://example.com/private-xxxx/basic.ics"})
+        assert "has ended" in response.get_data(as_text=True)
+    else:
+        path = "/settings/generate" if action == "rewrite" else "/settings/refresh-now"
+        response = parent.post(path, follow_redirects=True)
+        assert "has ended" in response.get_data(as_text=True)
+    assert fetched == []
+    assert model.messages.calls == []
+    assert PostgresBudget(pg_pool, pg_family).used_today() == (0, 0)
+    assert store.load_payload(store.load_config()) == before
+
+
+def test_deadline_is_checked_again_after_a_slow_calendar_fetch(
+        hosted, pg_pool, pg_family, monkeypatch):
+    parent, store, model = hosted
+    update_family(pg_pool, pg_family, "trial_ends_at = now() + interval '1 day'")
+
+    def fetch(*args, **kwargs):
+        update_family(pg_pool, pg_family, "trial_ends_at = now()")
+        return [], []
+
+    monkeypatch.setattr(runner, "fetch_events", fetch)
+    parent.post("/settings/generate")
+    assert model.messages.calls == []
+    assert store.load_payload(store.load_config())["headline"] == "Saved headline"
+    assert PostgresBudget(pg_pool, pg_family).used_today() == (0, 0)
+
+
+def test_lapsed_board_dates_and_turns_do_not_advance(hosted, pg_pool, pg_family, monkeypatch):
+    from dinkydash import config as config_module
+
+    parent, _, model = hosted
+    update_family(pg_pool, pg_family, "trial_ends_at = now() - interval '1 day'")
+    path = board_path(pg_pool, pg_family)
+    first = parent.get(path)
+    monkeypatch.setattr(config_module, "today_for", lambda _: datetime(2030, 1, 1).date())
+    second = parent.get(path)
+    assert first.data == second.data
+    text = first.get_data(as_text=True)
+    for saved in ("Saved headline", "Saved appointment", "Saved note", "Tuesday, 8 September",
+                  "Set the table", "has ended", "dates and turns are paused"):
+        assert saved in text
+    assert "no-store" in first.headers["Cache-Control"]
+    assert first.headers["X-Robots-Tag"] == "noindex, nofollow"
+    assert model.messages.calls == []
+
+
+def test_thirty_days_later_only_the_ended_message_is_rendered(hosted, pg_pool, pg_family):
+    parent, _, model = hosted
+    update_family(pg_pool, pg_family, "trial_ends_at = now() - interval '30 days'")
+    page = parent.get(board_path(pg_pool, pg_family)).get_data(as_text=True)
+    assert "Your trial or subscription has ended" in page
+    for content in ("Invented family", "Saved headline", "Saved appointment", "Saved note",
+                    "Set the table", "A holiday"):
+        assert content not in page
+    assert 'http-equiv="refresh"' in page  # An eventual reactivation reaches the wall.
+    assert model.messages.calls == []
+
+
+def test_an_expired_family_with_no_brief_gets_a_message_not_a_waiting_screen(
+        hosted, pg_pool, pg_family):
+    parent, _, _ = hosted
+    with pg_pool.connection() as conn, conn.transaction(), conn.cursor() as cur:
+        cur.execute("DELETE FROM generations WHERE family_id = %s", (pg_family,))
+    update_family(pg_pool, pg_family, "trial_ends_at = now()")
+    page = parent.get(board_path(pg_pool, pg_family)).get_data(as_text=True)
+    assert "has ended" in page
+    assert "Writing" not in page and "Saved appointment" not in page
+
+
+def test_paid_reactivation_clears_lapse_and_ignores_the_old_trial_deadline(
+        hosted, pg_pool, pg_family, monkeypatch):
+    parent, _, model = hosted
+    update_family(pg_pool, pg_family, "trial_ends_at = now() - interval '40 days'")
+    lifecycle.expire_trials(pg_pool)
+    update_family(pg_pool, pg_family, "status = 'active'")
+    assert lifecycle.expire_trials(pg_pool) == 0
+    assert not lifecycle.access_for(pg_pool, pg_family).ended
+    with pg_pool.connection() as conn, conn.cursor() as cur:
+        cur.execute("SELECT lapsed_at FROM families WHERE id = %s", (pg_family,))
+        assert cur.fetchone() == (None,)
+    monkeypatch.setattr(runner, "fetch_events", lambda *a, **kw: ([], []))
+    parent.post("/settings/generate")
+    assert len(model.messages.calls) == 1
+    page = parent.get(board_path(pg_pool, pg_family)).get_data(as_text=True)
+    assert "has ended" not in page and "Big morning" in page
+    # A later subscription lapse starts a fresh grace period.
+    update_family(pg_pool, pg_family, "status = 'lapsed'")
+    access = lifecycle.access_for(pg_pool, pg_family)
+    assert access.show_last_board
+    assert access.now - access.lapsed_at < timedelta(minutes=1)
+
+
+def test_expiry_keeps_settings_and_export_access(hosted, pg_pool, pg_family):
+    parent, _, _ = hosted
+    update_family(pg_pool, pg_family, "trial_ends_at = now()")
+    home = parent.get("/settings/").get_data(as_text=True)
+    assert "has ended" in home
+    assert 'type="submit" disabled' in home
+    assert parent.get("/settings/account/export").status_code == 200
+    assert parent.post("/settings/system", data={"family_name": "Updated family"}).status_code == 302

--- a/tests/test_spend_migration.py
+++ b/tests/test_spend_migration.py
@@ -1,0 +1,40 @@
+"""Upgrade existing spend without losing charges during a rolling deployment."""
+
+from datetime import date
+
+
+def test_backfill_and_old_writers_keep_a_non_identifying_total(pg_pool):
+    from dinkydash import db
+
+    # An isolated copy of the previous schema, removed by transaction rollback.
+    with pg_pool.connection() as conn, conn.transaction(force_rollback=True):
+        with conn.cursor() as cur:
+            cur.execute("CREATE SCHEMA spend_migration_test")
+            cur.execute("SET LOCAL search_path TO spend_migration_test, public")
+            upgrade = db.MIGRATIONS_DIR / "004_global_model_spend.sql"
+            for path in db.migrations():
+                if path == upgrade:
+                    break
+                cur.execute(path.read_text())
+            cur.execute("""INSERT INTO families (screen_token)
+                           VALUES ('migration-test-one'), ('migration-test-two') RETURNING id""")
+            first, second = [row[0] for row in cur.fetchall()]
+            today, yesterday = date(2026, 9, 9), date(2026, 9, 8)
+            cur.executemany("INSERT INTO model_spend (day, family_id, calls) VALUES (%s, %s, %s)",
+                            [(today, first, 3), (today, second, 5), (yesterday, first, 7)])
+            cur.execute(upgrade.read_text())
+            cur.execute("SELECT day, calls FROM global_model_spend ORDER BY day")
+            assert cur.fetchall() == [(yesterday, 7), (today, 8)]
+
+            # Existing app versions write only model_spend during rollout.
+            cur.execute("""UPDATE model_spend SET calls = calls + 2
+                           WHERE day = %s AND family_id = %s""", (today, first))
+            cur.execute("UPDATE model_spend SET input_tokens = 1200, output_tokens = 90")
+            with conn.transaction(force_rollback=True):
+                cur.execute("UPDATE model_spend SET calls = calls + 1 WHERE day = %s", (today,))
+            cur.execute("DELETE FROM families")
+            cur.execute("SELECT * FROM global_model_spend ORDER BY day")
+            assert [column.name for column in cur.description] == ["day", "calls"]
+            assert cur.fetchall() == [(yesterday, 7), (today, 10)]
+            cur.execute("SELECT count(*) FROM model_spend")
+            assert cur.fetchone() == (0,)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -13,6 +13,7 @@ import logging
 
 import pytest
 
+from dinkydash.budget import NoBudget
 from worker import DEFAULT_INTERVAL, Stopping, interval, tick_all
 
 
@@ -49,18 +50,11 @@ class FakeStore:
         return {"family_id": self.family_id}
 
 
-class FakeBudget:
-    """A budget that allows everything and remembers it was asked."""
+class FakeBudget(NoBudget):
+    """An unrestricted test budget labelled with its family."""
 
     def __init__(self, family_id):
         self.family_id = family_id
-
-    def allow(self):
-        return None
-
-    def record(self, input_tokens, output_tokens):
-        return None
-
 
 def run(ids, tick, stopping=None, budget_factory=FakeBudget):
     """`tick_all` with every seam filled by a fake.

--- a/web/CLAUDE.md
+++ b/web/CLAUDE.md
@@ -78,6 +78,13 @@ manifest route is behind the login, and asking for it from outside would only ev
 *family's* config dict under that name and shadow the app's, which is why `create_app` sets a
 separate `cloud` boolean — the Sign out button on the settings home is the first thing to use it.
 
+Hosted refreshes and feed checks take the same account-access check as generation. Hiding a
+button is not enforcement. `current_access()` supplies the settings status; the token route
+resolves access for its own family and passes it to `render_board`. Lapsed boards hold the last
+brief's date for 30 days, then show only the ended message, with the same no-store headers and
+reload timer. Export, deletion and settings remain accessible. Exports include both all retained
+`generations` and the separate recent `content_history`; the latter alone omits older briefs.
+
 ## The board's layout
 
 **Changing the board layout.** Everything is sized in `rem` off one root value, so check all three

--- a/web/family.py
+++ b/web/family.py
@@ -36,6 +36,16 @@ def current_budget():
     return budget_module.for_family(_the_pool(), _family_on_the_session())
 
 
+def current_access():
+    """Hosted access for the signed-in parent; single mode has no account."""
+    from dinkydash.lifecycle import access_for
+    from . import CLOUD
+
+    if current_app.config["MODE"] != CLOUD:
+        return None
+    return access_for(_the_pool(), _family_on_the_session())
+
+
 def current_screen_token():
     """Return the screen token of the family on the session. Cloud mode only."""
     from dinkydash import screens

--- a/web/routes/board.py
+++ b/web/routes/board.py
@@ -71,7 +71,7 @@ def index():
     return render_board(current_store())
 
 
-def render_board(store, manifest_url=None):
+def render_board(store, manifest_url=None, access=None):
     """The board page for whichever family that store is for.
 
     Shared with `web/routes/screen.py`, so the signed-in view and the wall
@@ -79,11 +79,16 @@ def render_board(store, manifest_url=None):
     difference between them and it is one link in the head: the panel's
     manifest has to be reachable without a session, or "save to home screen"
     gets a redirect to `/login` instead of a name and an icon.
-    `tests/test_cloud_mode.py` asserts that it is the *only* difference.
+    Hosted callers also pass access state, so a lapsed panel cannot keep
+    recomputing the day. Active cloud boards retain parity with single mode.
     """
     config = store.load_config()
-    today = config_module.today_for(config)
-    view = board_view.build_view(config, store.load_payload(config), today)
+    payload = store.load_payload(config)
+    if access and access.ended:
+        view = board_view.build_lapsed_view(config, payload, access.show_last_board)
+    else:
+        today = config_module.today_for(config)
+        view = board_view.build_view(config, payload, today)
     return render_template("board.html", view=view,
                            manifest_url=manifest_url or url_for("board.manifest"))
 

--- a/web/routes/screen.py
+++ b/web/routes/screen.py
@@ -46,6 +46,7 @@ import logging
 from flask import (Blueprint, current_app, make_response, render_template,
                    request, url_for)
 
+from dinkydash.lifecycle import access_for
 from web import ratelimit
 from web.family import store_for_token
 from web.routes.board import manifest_for, render_board
@@ -92,7 +93,8 @@ def board(token):
     if store is None:
         return _refused()
     return _screen(render_board(
-        store, manifest_url=url_for("screen.manifest", token=token)))
+        store, manifest_url=url_for("screen.manifest", token=token),
+        access=access_for(current_app.config["POOL"], store.family_id)))
 
 
 @bp.route("/s/<token>/manifest.webmanifest")

--- a/web/routes/settings.py
+++ b/web/routes/settings.py
@@ -775,11 +775,9 @@ def system():
     **Which model runs is not a hosted family's setting**, because it is not
     their API key. Self-hosted, the key is theirs and so is the bill, so the
     model is a free text box with its price beside it. Hosted, the box would
-    let anybody move the whole account onto an expensive model on our key, and
-    `budget.py` would not notice: it counts *calls*, deliberately, because a
-    price table goes stale silently. So cloud mode drops the field from the
-    form and ignores it here — the template is the courtesy, this is the
-    control.
+    offer a choice the platform does not honour. Cloud mode hides and ignores
+    the field here; the shared generation budget also overrides saved model
+    and token settings before either hosted caller reaches the API.
     """
     config = current_config()
     if request.method == "POST":

--- a/web/routes/settings.py
+++ b/web/routes/settings.py
@@ -18,7 +18,7 @@ from flask import (Blueprint, abort, current_app, flash, redirect,
 
 from dinkydash import accounts
 from dinkydash import config as config_module
-from dinkydash import schedule, screens
+from dinkydash import lifecycle, schedule, screens
 from dinkydash.calendars import FeedError, addresses, describe_feed, feed_label
 from dinkydash.claude_client import GenerationError
 from dinkydash.context import compute_birthday_info, upcoming_for
@@ -26,7 +26,7 @@ from dinkydash.runner import refresh_calendars
 from dinkydash.runner import run as run_generation
 from web import CLOUD
 from web import manifest as manifest_module
-from web.family import current_budget, current_family_id, current_store
+from web.family import current_access, current_budget, current_family_id, current_store
 from web import session as session_module
 from web.session import guard
 from web.urls import absolute_url, board_path
@@ -241,6 +241,10 @@ def home():
         if fetched:
             status["detail"] += f" Calendars refreshed {fetched}."
 
+    access = current_access()
+    if access and access.ended:
+        status = {"state": "lapsed", "detail": lifecycle.ENDED_MESSAGE}
+
     calendars = config.get("calendars") or []
     broken = [c for c in (payload or {}).get("calendar_statuses", []) if c.get("ok") is False]
 
@@ -433,13 +437,14 @@ def check_feed(item, config):
         return {"ok": False, "message": "Paste a link first."}
     wanted = addresses(item.get("shared_with"))
     try:
+        current_budget().check_access()
         found = describe_feed(
             url, config_module.tzinfo_for(config),
             today=config_module.today_for(config),
             days_ahead=int(config.get("calendar_days_ahead") or 14),
             shared_with=wanted,
         )
-    except FeedError as exc:
+    except (FeedError, GenerationError) as exc:
         return {"ok": False, "message": str(exc)}
     days = found["days_ahead"]
     if not found["total"]:
@@ -629,7 +634,10 @@ def refresh_now():
     """Fetch the calendars and nothing else — the free half of "Rewrite now"."""
     config = current_config()
     try:
-        payload = refresh_calendars(config, current_store())
+        payload = refresh_calendars(config, current_store(), budget=current_budget())
+    except GenerationError as exc:
+        flash(str(exc), "error")
+        return redirect(url_for("settings.home"))
     except Exception as exc:  # a broken feed or an unwritable file shouldn't 500 the UI
         log.exception("Calendar refresh failed")
         flash(f"Could not refresh the calendars: {exc}", "error")
@@ -668,7 +676,7 @@ def account():
 
 @bp.route("/account/export")
 def export_account():
-    """Everything we hold about this family, as one JSON file.
+    """The family's settings, board and retained generation history as JSON.
 
     **The family's own data comes from the store**, which is the only thing that
     knows what it is. Two things it deliberately cannot answer are read directly
@@ -676,7 +684,7 @@ def export_account():
 
     * the plan, the trial and when the account was made, which are the
       platform's bookkeeping rather than the family's data;
-    * the **full** written history. `recent_notes` returns note *text* and
+    * all retained daily generations and recent rewrites. `recent_notes` returns note *text* and
       nothing else, because it exists to stop the model repeating itself — an
       export needs the date and the headline with it, and widening the store's
       operation to suit one caller would make every other caller carry it.
@@ -695,10 +703,8 @@ def export_account():
         "family": _family_facts(),
         "settings": config,
         "board": payload,
-        # Everything the model has written, not the 30 the board keeps for
-        # itself: `history_days` is a prompt setting, not a retention rule, and
-        # an export that quietly truncated would be the wrong answer to "give me
-        # my data".
+        "generations": _generations(),
+        # Recent rewrites can differ from the final brief saved for that date.
         "written_lines": _written_lines(),
     }
     body = json.dumps(export, indent=2, ensure_ascii=False, default=str)
@@ -710,8 +716,22 @@ def export_account():
     }
 
 
+def _generations():
+    """All retained daily briefs and their metadata, including older rows."""
+    with current_app.config["POOL"].connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            """SELECT generated_for_date, generated_at, status, brief, model,
+                      input_tokens, output_tokens, error
+               FROM generations WHERE family_id = %s ORDER BY generated_for_date""",
+            (current_family_id(),),
+        )
+        keys = ("generated_for_date", "generated_at", "status", "brief", "model",
+                "input_tokens", "output_tokens", "error")
+        return [dict(zip(keys, row)) for row in cur.fetchall()]
+
+
 def _written_lines():
-    """Every line the model has written for this family, with its date.
+    """Every retained history entry for this family, with its date.
 
     Read directly rather than through `store.recent_notes`, which returns note
     text alone — see `export_account`. Scoped to the session's family like
@@ -731,7 +751,7 @@ def _family_facts():
     """The platform's own bookkeeping about a family, for the export."""
     with current_app.config["POOL"].connection() as conn, conn.cursor() as cur:
         cur.execute(
-            """SELECT plan, status, trial_ends_at, created_at
+            """SELECT plan, status, trial_ends_at, created_at, lapsed_at
                FROM families WHERE id = %s""",
             (current_family_id(),),
         )
@@ -742,7 +762,7 @@ def _family_facts():
     # to somebody, saved to a downloads folder and forgotten; a live credential
     # should not ride along in one. It is on the screen page, where it can be
     # rotated in the same breath as being read.
-    return dict(zip(("plan", "status", "trial_ends_at", "created_at"), row))
+    return dict(zip(("plan", "status", "trial_ends_at", "created_at", "lapsed_at"), row))
 
 
 def delete_account():

--- a/web/templates/board.html
+++ b/web/templates/board.html
@@ -263,7 +263,14 @@
 </head>
 <body>
 
-{% if view.state == 'waiting' %}
+{% if view.state == 'ended' %}
+<div class="waiting">
+    <div class="family">DinkyDash</div>
+    <div class="waiting-head">Your trial or subscription has ended</div>
+    <div class="waiting-sub">Board updates are paused. Open your settings on a phone or computer to manage your account.</div>
+</div>
+
+{% elif view.state == 'waiting' %}
 <div class="waiting">
     <div class="family">DinkyDash</div>
     <div class="waiting-head">Writing {{ view.family_name or "your" }}{{ "'s" if view.family_name else "" }} first board&hellip;</div>
@@ -278,7 +285,11 @@
 
 {% else %}
 
-{% if view.stale %}
+{% if view.state == 'frozen' %}
+<div class="banner">
+    Your trial or subscription has ended. Showing the last saved board; its dates and turns are paused.
+</div>
+{% elif view.stale %}
 <div class="banner">
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.1" stroke-linecap="round"><circle cx="12" cy="12" r="9"></circle><path d="M12 7.6v5"></path><path d="M12 16.2h.01"></path></svg>
     This morning&rsquo;s brief didn&rsquo;t arrive. Times, turns and countdowns are today&rsquo;s &mdash; only the written line is older.

--- a/web/templates/settings/account.html
+++ b/web/templates/settings/account.html
@@ -40,8 +40,8 @@
     <div class="label">Take it with you</div>
     <div class="card pad" style="display:flex;flex-direction:column;gap:0.875rem;">
         <div class="hint">
-            Everything we hold about your family in one file: your details, your calendar
-            links, the agenda we last fetched, and every line the model has written.
+            Your family's details, calendar links, last fetched agenda, all retained daily
+            briefs and recent rewrite history in one file.
         </div>
         <a class="btn outline" href="{{ url_for('settings.export_account') }}">Download my data</a>
     </div>

--- a/web/templates/settings/home.html
+++ b/web/templates/settings/home.html
@@ -49,13 +49,13 @@
            while rewriting the line costs a call to Claude. #}
         <form class="inline-form" method="post" action="{{ url_for('settings.refresh_now') }}">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-            <button class="btn" type="submit">{{ icons.refresh() }} Refresh calendars</button>
+            <button class="btn" type="submit" {{ 'disabled' if status.state == 'lapsed' }}>{{ icons.refresh() }} Refresh calendars</button>
         </form>
         <div style="display:flex;gap:0.625rem;">
             <a class="btn outline" style="flex:1;" href="{{ board_link }}">{{ icons.screen() }} View board</a>
             <form class="inline-form" method="post" action="{{ url_for('settings.generate_now') }}" style="flex:1;">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                <button class="btn outline" type="submit">
+                <button class="btn outline" type="submit" {{ 'disabled' if status.state == 'lapsed' }}>
                     {{ "Write it now" if status.state == "waiting" else "Rewrite now" }}
                 </button>
             </form>

--- a/website/content/privacy.md
+++ b/website/content/privacy.md
@@ -5,7 +5,7 @@ template: page.html
 description: What DinkyDash stores, who it is sent to, how long it is kept, and how to get it back or delete it.
 ---
 
-*Last updated: 8 September 2026.*
+*Last updated: 9 September 2026.*
 
 DinkyDash puts a family's day on a screen. That means the things it holds are a
 household's names, dates of birth and movements — which is about as personal as
@@ -91,6 +91,9 @@ We would rather hold less, so most of this expires on its own.
   has been used is deleted on the same schedule.
 - **Your account, your family's details and the record of boards written**: kept
   while the account exists, and deleted when you delete it.
+- **Daily totals of model calls across the service**: kept without an account
+  identifier, including after account deletion, so deleting an account does not
+  reset the service's spending limit. These totals contain only a date and count.
 
 **Backups.** DigitalOcean takes daily backups of the database and keeps seven
 days of point-in-time recovery. Deleted data can therefore persist in a backup

--- a/website/content/privacy.md
+++ b/website/content/privacy.md
@@ -85,8 +85,11 @@ We would rather hold less, so most of this expires on its own.
 - **Your calendar events**: one rolling fourteen-day window per family,
   overwritten every time the calendars are refreshed. Nothing accumulates — the
   most we ever hold about your calendar is that one window.
-- **The written lines**: the last 30 are kept, so the model does not repeat
-  itself. Older ones are deleted as new ones arrive.
+- **The written lines**: daily briefs are kept while your account exists. A
+  separate recent history helps the model avoid repetition; it keeps at least
+  the last 30 entries and drops older ones as new ones arrive. Rewriting a day
+  replaces that day's saved brief, while an earlier version may remain in the
+  recent history until it is trimmed.
 - **Sign-in links**: deleted once expired, which is fifteen minutes. A link that
   has been used is deleted on the same schedule.
 - **Your account, your family's details and the record of boards written**: kept
@@ -94,6 +97,11 @@ We would rather hold less, so most of this expires on its own.
 - **Daily totals of model calls across the service**: kept without an account
   identifier, including after account deletion, so deleting an account does not
   reset the service's spending limit. These totals contain only a date and count.
+
+After your trial or subscription ends, the screen shows the last saved board
+with an ended-access message for 30 days, then only the message. This changes
+what the screen shows; it does not delete your stored account data. You can
+still sign in to export or delete it.
 
 **Backups.** DigitalOcean takes daily backups of the database and keeps seven
 days of point-in-time recovery. Deleted data can therefore persist in a backup
@@ -103,8 +111,8 @@ for up to seven days before it ages out.
 
 Both are buttons, not requests, and both are on your settings page.
 
-- **Export** gives you everything we hold about your family as one JSON file:
-  your details, your calendar links, the stored agenda, and every written line.
+- **Export** gives you your family's details, calendar links, stored agenda,
+  all retained daily briefs and recent rewrite history as one JSON file.
 - **Delete** removes your family, your account, your calendar links, the stored
   agenda, every written line and every sign-in link. It cannot be undone and we
   cannot restore it for you.

--- a/website/content/terms.md
+++ b/website/content/terms.md
@@ -5,7 +5,7 @@ template: page.html
 description: The terms for the hosted version of DinkyDash at app.dinkydash.co. Self-hosting is MIT-licensed and covered by the licence, not by these.
 ---
 
-*Last updated: 8 September 2026.*
+*Last updated: 9 September 2026.*
 
 These terms cover the **hosted** service at `app.dinkydash.co`. If you run
 DinkyDash yourself from the source code, the [MIT
@@ -66,6 +66,11 @@ the hosted service is $39 a year, or $6 a month if you would rather.
 Payment is not built yet. Until it is, nobody is charged anything and nothing
 is collected. When it arrives, this section will say who processes it and these
 terms will be updated before it takes effect.
+
+When your trial or subscription ends, calendar fetches and new written briefs
+stop. The screen keeps the last saved board with an ended-access message for
+30 days, then shows only the message. You can still sign in to manage, export
+or delete your data.
 
 ## Ending it
 

--- a/worker/__init__.py
+++ b/worker/__init__.py
@@ -19,10 +19,9 @@ container is what makes "how many web instances" a free decision.
 copied. It is the shared orchestration over config, store and clock, and
 `tests/test_runner.py` already imports that module the same way.
 
-One thing here is *not* per family: `sweep_logins` deletes expired magic-link
-tokens once a pass. It is here because this is the only process in cloud mode
-with a loop, and doing it on somebody's page load would make one visitor pay
-for everybody's tidying.
+Housekeeping runs once a pass: `sweep_logins` deletes expired magic-link tokens
+and `lifecycle.expire_trials` records ended trials. Account access is also
+checked before each fetch and model call, independently of the sweep.
 """
 
 import logging
@@ -73,6 +72,7 @@ def family_ids(pool):
         cur.execute(
             """SELECT id FROM families
                WHERE status <> 'lapsed'
+                 AND (status <> 'trialing' OR trial_ends_at > now())
                ORDER BY created_at""")
         return [row[0] for row in cur.fetchall()]
 
@@ -161,7 +161,7 @@ def main():  # pragma: no cover - the loop itself; tick_all is what is tested
         format="%(asctime)s [%(levelname)s] %(message)s",
     )
 
-    from dinkydash import db
+    from dinkydash import db, lifecycle
 
     stopping = Stopping()
     signal.signal(signal.SIGTERM, stopping.request)
@@ -173,6 +173,13 @@ def main():  # pragma: no cover - the loop itself; tick_all is what is tested
 
     while not stopping:
         started = time.monotonic()
+        try:
+            expired = lifecycle.expire_trials(pool)
+            if expired:
+                log.info("Ended %s expired trial(s).", expired)
+        except Exception:
+            # Callers still check the deadline themselves if housekeeping fails.
+            log.exception("Could not mark expired trials; retrying next pass.")
         ticked = tick_all(pool, stopping=stopping)
         swept = sweep_logins(pool)
         log.info("Pass complete: %s families ticked in %.1fs; %s dead login "


### PR DESCRIPTION
Keep global model-call usage charged after account deletion and enforce the platform model and output-token ceiling for hosted generation (DIN-49, DIN-51).
Export every retained daily brief alongside recent rewrite history (DIN-50).
Enforce 14-day trial deadlines across worker and manual actions, preserve the saved board date for 30 days after lapse, and resume on reactivation; the two migrations backfill usage and legacy deadlines, with matching plan, privacy and operating notes (DIN-52).
Validation: 966 tests passed with PostgreSQL, 659 passed without a database, migration upgrades were exercised against prior schemas, and frozen/ended screen layouts passed Chrome checks at the target sizes.
