### PR TITLE
Add hosted Stripe subscriptions and cancellation

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -110,6 +110,27 @@ envs:
     scope: RUN_TIME
     type: SECRET
 
+  # Optional until the account-specific test-mode checks in doc/billing.md pass.
+  # Kept at app scope so webhooks and the worker use the same Stripe account.
+  - key: STRIPE_SECRET_KEY
+    scope: RUN_TIME
+    type: SECRET
+  - key: STRIPE_WEBHOOK_SECRET
+    scope: RUN_TIME
+    type: SECRET
+  - key: STRIPE_MONTHLY_PRICE_ID
+    scope: RUN_TIME
+    type: SECRET
+  - key: STRIPE_YEARLY_PRICE_ID
+    scope: RUN_TIME
+    type: SECRET
+  - key: STRIPE_PORTAL_CONFIGURATION_ID
+    scope: RUN_TIME
+    type: SECRET
+  - key: STRIPE_AUTOMATIC_TAX
+    scope: RUN_TIME
+    type: SECRET
+
   # The spend breaker (DIN-43), in model calls a day. Written out at their
   # defaults rather than left implicit, because a ceiling nobody can see is a
   # ceiling nobody raises — and because **this spec is the whole app**: a value

--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,7 @@
 # Copy to .env and fill in. .env is gitignored and must never be committed.
 #
-# Nothing in the app reads FLASK_ENV, SECRET_KEY, DATABASE_URL or UPLOAD_FOLDER;
-# the session key comes from DINKYDASH_SECRET_KEY in the environment, not from
-# here.
+# Cloud configuration uses the names below; FLASK_ENV, SECRET_KEY and
+# UPLOAD_FOLDER are not read. Explicit environment values take precedence.
 #
 # Get a key at https://console.anthropic.com/settings/keys. It is used once a
 # day, for the headline and the one written line. Everything else on the board
@@ -23,7 +22,11 @@ ANTHROPIC_API_KEY=
 # Which app answers on which hostname, for wsgi.py. One container serves both.
 # DINKYDASH_APP_HOST=app.dinkydash.co
 
-# Transactional email — magic links (decision 13). This must be a **send-only**
+# Hosted persistence (the migration job uses the direct connection).
+# DATABASE_URL=
+# DATABASE_URL_DIRECT=
+
+# Transactional email — magic links and subscription notices. Use a **send-only**
 # key: SendGrid → Create API Key → Restricted Access → Mail Send, everything
 # else No Access. A full-access key here could send as any of the six domains
 # on the account, read billing and mint further keys.
@@ -56,3 +59,14 @@ ANTHROPIC_API_KEY=
 # running away.
 # DINKYDASH_GLOBAL_CALL_FLOOR=50
 # DINKYDASH_GLOBAL_CALLS_PER_FAMILY=4
+
+# Stripe, hosted only. Start with test-mode credentials and the matching prices,
+# portal configuration and webhook secret. No customer is created at signup.
+# Checkout stays disabled until every value is set, including the explicit tax
+# choice. See doc/billing.md before enabling payments; never put live keys here.
+# STRIPE_SECRET_KEY=
+# STRIPE_WEBHOOK_SECRET=
+# STRIPE_MONTHLY_PRICE_ID=
+# STRIPE_YEARLY_PRICE_ID=
+# STRIPE_PORTAL_CONFIGURATION_ID=
+# STRIPE_AUTOMATIC_TAX=true

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,6 +1,6 @@
 # DinkyDash Hosted MVP — Plan
 
-*Updated 9 September 2026: main through PR #94; Stripe implementation added, account-specific test-mode verification pending (DIN-53).*
+*Updated 9 September 2026: main through PR #94; Stripe sandbox lifecycle verified in PR #95, with a manual card-update check and live configuration pending (DIN-53).*
 
 This is the engineering plan for the hosted app and its shared self-hosted codebase.
 Positioning, pricing reasoning and launch strategy live in Linear on the DIN team.
@@ -24,15 +24,17 @@ It also exports retained daily generations ([DIN-50](https://linear.app/keepthes
 manual-action restrictions and the 30-day lapsed display period ([DIN-52](https://linear.app/keepthescore/issue/DIN-52)).
 The billing implementation adds Checkout, Customer Portal, signed and idempotent webhooks,
 payment recovery and lifecycle email ([DIN-53](https://linear.app/keepthescore/issue/DIN-53)).
-Checkout remains disabled until explicit Stripe configuration is supplied. Real Stripe
-test-mode verification and the account's price/tax setup still need completion; see [billing operations](doc/billing.md).
+Checkout remains disabled until explicit Stripe configuration is supplied. Sandbox
+signup, Checkout, billing-period changes, renewal failure/recovery, cancellation and
+deletion have passed. A manual portal card-update check and live price/tax setup
+remain; see [billing operations](doc/billing.md).
 
 Todo is reserved for the hosted MVP: signup and trial use, payment/cancellation,
 privacy and spending controls, basic monitoring/recovery, and real-device validation.
 Optional features, promotion and additional operational tooling are Backlog.
 Hosted readiness is still open. The remaining sequence is:
 
-1. Verify Stripe conversion, subscription changes, taxes and cancellation in the intended test account before accepting payment ([DIN-53](https://linear.app/keepthescore/issue/DIN-53)).
+1. Finish the manual portal card-update check and confirm live Stripe configuration and tax totals before accepting real payments ([DIN-53](https://linear.app/keepthescore/issue/DIN-53)).
 2. Add liveness alerts and recovery checks ([DIN-54](https://linear.app/keepthescore/issue/DIN-54),
    [DIN-56](https://linear.app/keepthescore/issue/DIN-56)), and finish the trust work in Phase 5.
 3. Replace hosted waitlist/form links with the signup/login page ([DIN-63](https://linear.app/keepthescore/issue/DIN-63)).
@@ -58,7 +60,7 @@ work for a self-hoster without Postgres, email or billing services.
 | 4 | Screen access through a bearer URL | Current tokens are 12 random characters from an unambiguous alphabet; parents can rotate them. |
 | 5 | Render the real board shown on the site | Agenda, chore turns, countdowns, headline and one written line. Person cards are not a parity requirement. Emoji avatars; no photo uploads. |
 | 6 | A 14-day hosted trial, no card on signup | App-managed trial with enforced expiry and a 30-day frozen-board display (DIN-52). |
-| 7 | Stripe for paid subscriptions | Create a customer when a parent starts Checkout. Portal, webhook reconciliation and notices are implemented; account setup and test-mode verification remain [DIN-53](https://linear.app/keepthescore/issue/DIN-53). |
+| 7 | Stripe for paid subscriptions | Create a customer when a parent starts Checkout. Sandbox lifecycle verified; remaining card-update and live-account checks are [DIN-53](https://linear.app/keepthescore/issue/DIN-53). |
 | 8 | Published privacy policy and terms based on the existing company documents | Disclosures must match implemented storage, deletion and outbound calls. Outstanding work is in Phase 5. |
 | 9 | Community-supported self-hosting; MIT licence | Keep the from-source/Pi workflow operational with the user's own API key. |
 | 10 | The config dict is the storage contract | Comment-preserving YAML in single mode; the same shape in Postgres `jsonb` in cloud mode. |
@@ -77,7 +79,7 @@ work for a self-hoster without Postgres, email or billing services.
 | Board | `/` | `/s/<token>` |
 | Scheduler | `generate.py --tick` from cron | `worker/`, one pass every five minutes |
 | Model configuration | User's model, token limit and API key | Platform key, model and output-token ceiling ([DIN-51](https://linear.app/keepthescore/issue/DIN-51)) |
-| Billing | None | Planned; [DIN-52](https://linear.app/keepthescore/issue/DIN-52) and [DIN-53](https://linear.app/keepthescore/issue/DIN-53) |
+| Billing | None | App-managed trial, Stripe Checkout and Customer Portal; [DIN-52](https://linear.app/keepthescore/issue/DIN-52) and [DIN-53](https://linear.app/keepthescore/issue/DIN-53) |
 
 `create_app(store=None, *, pool=None)` accepts a store only in single mode and a
 shared pool only in cloud mode. `web/family.py` constructs a request's cloud store from
@@ -389,11 +391,14 @@ the real-device checks remain [DIN-58](https://linear.app/keepthescore/issue/DIN
 - [x] Enforce expiry, restrict manual actions, and render the agreed lapsed state ([DIN-52](https://linear.app/keepthescore/issue/DIN-52)).
 - [x] Checkout, Customer Portal, verified/idempotent webhooks, pricing and lifecycle notifications ([DIN-53](https://linear.app/keepthescore/issue/DIN-53)).
 - [x] Disclose Stripe's conditional billing data flow and SendGrid subscription notices.
-- [ ] Apply and verify the agreed price/tax configuration in the intended Stripe test account ([DIN-53](https://linear.app/keepthescore/issue/DIN-53)).
+- [x] Verify sandbox signup, Checkout, portal billing-period changes, renewal failure/recovery, cancellation, duplicate/older webhooks and account deletion ([DIN-53](https://linear.app/keepthescore/issue/DIN-53)).
+- [ ] Complete the manual portal card-update check and verify live price/tax configuration ([DIN-53](https://linear.app/keepthescore/issue/DIN-53)).
 
-**Done when:** signup → trial → paid → cancel passes in Stripe test mode. Trial
-expiry and billing have automated database tests with simulated provider responses;
-real Checkout, payment, portal changes, dunning and cancellation still need that verification.
+**Core sequence verified:** signup → trial → paid → cancel passed in the approved
+Stripe sandbox on 9 September 2026. Test clocks exercised failed renewal, recovery
+and cancellation at period end; real signed events updated an isolated database.
+Notification delivery was captured locally. The remaining manual card-update,
+email-delivery and live-account checks still gate real payments.
 
 ### Phase 5 — Legal & trust
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,6 +1,6 @@
 # DinkyDash Hosted MVP — Plan
 
-*Updated 9 September 2026: main through PR #93, plus spending, export and trial-expiry fixes (DIN-49–52).*
+*Updated 9 September 2026: main through PR #94; Stripe implementation added, account-specific test-mode verification pending (DIN-53).*
 
 This is the engineering plan for the hosted app and its shared self-hosted codebase.
 Positioning, pricing reasoning and launch strategy live in Linear on the DIN team.
@@ -18,17 +18,21 @@ PR #91 implemented privacy-safe calendar publication ([DIN-46](https://linear.ap
 and removed generated text and malformed screen credentials from service logs ([DIN-47](https://linear.app/keepthescore/issue/DIN-47)).
 PR #93 preserves explicit preview database overrides ([DIN-48](https://linear.app/keepthescore/issue/DIN-48))
 and connects calendar fetches only to validated public addresses ([DIN-61](https://linear.app/keepthescore/issue/DIN-61)).
-The current batch preserves charged global usage after account deletion ([DIN-49](https://linear.app/keepthescore/issue/DIN-49))
+PR #94 preserves charged global usage after account deletion ([DIN-49](https://linear.app/keepthescore/issue/DIN-49))
 and enforces the platform's model and token ceiling for hosted generation ([DIN-51](https://linear.app/keepthescore/issue/DIN-51)).
 It also exports retained daily generations ([DIN-50](https://linear.app/keepthescore/issue/DIN-50)) and enforces trial expiry,
 manual-action restrictions and the 30-day lapsed display period ([DIN-52](https://linear.app/keepthescore/issue/DIN-52)).
+The billing implementation adds Checkout, Customer Portal, signed and idempotent webhooks,
+payment recovery and lifecycle email ([DIN-53](https://linear.app/keepthescore/issue/DIN-53)).
+Checkout remains disabled until explicit Stripe configuration is supplied. Real Stripe
+test-mode verification and the account's price/tax setup still need completion; see [billing operations](doc/billing.md).
 
 Todo is reserved for the hosted MVP: signup and trial use, payment/cancellation,
 privacy and spending controls, basic monitoring/recovery, and real-device validation.
 Optional features, promotion and additional operational tooling are Backlog.
 Hosted readiness is still open. The remaining sequence is:
 
-1. Complete Stripe conversion, subscription changes and cancellation before accepting payment ([DIN-53](https://linear.app/keepthescore/issue/DIN-53)).
+1. Verify Stripe conversion, subscription changes, taxes and cancellation in the intended test account before accepting payment ([DIN-53](https://linear.app/keepthescore/issue/DIN-53)).
 2. Add liveness alerts and recovery checks ([DIN-54](https://linear.app/keepthescore/issue/DIN-54),
    [DIN-56](https://linear.app/keepthescore/issue/DIN-56)), and finish the trust work in Phase 5.
 3. Replace hosted waitlist/form links with the signup/login page ([DIN-63](https://linear.app/keepthescore/issue/DIN-63)).
@@ -53,14 +57,14 @@ work for a self-hoster without Postgres, email or billing services.
 | 3 | Multiple iCal feeds, no calendar OAuth | Paste provider URLs; each feed can have its own `shared_with` filter. |
 | 4 | Screen access through a bearer URL | Current tokens are 12 random characters from an unambiguous alphabet; parents can rotate them. |
 | 5 | Render the real board shown on the site | Agenda, chore turns, countdowns, headline and one written line. Person cards are not a parity requirement. Emoji avatars; no photo uploads. |
-| 6 | A 14-day hosted trial, no card on signup | Store trial state in the app. Expiry enforcement is still [DIN-52](https://linear.app/keepthescore/issue/DIN-52). |
-| 7 | Stripe for paid subscriptions | Create a Stripe customer at conversion. Checkout, portal and webhook handling remain [DIN-53](https://linear.app/keepthescore/issue/DIN-53). |
+| 6 | A 14-day hosted trial, no card on signup | App-managed trial with enforced expiry and a 30-day frozen-board display (DIN-52). |
+| 7 | Stripe for paid subscriptions | Create a customer when a parent starts Checkout. Portal, webhook reconciliation and notices are implemented; account setup and test-mode verification remain [DIN-53](https://linear.app/keepthescore/issue/DIN-53). |
 | 8 | Published privacy policy and terms based on the existing company documents | Disclosures must match implemented storage, deletion and outbound calls. Outstanding work is in Phase 5. |
 | 9 | Community-supported self-hosting; MIT licence | Keep the from-source/Pi workflow operational with the user's own API key. |
 | 10 | The config dict is the storage contract | Comment-preserving YAML in single mode; the same shape in Postgres `jsonb` in cloud mode. |
 | 11 | Calendar cadence and brief time are family settings | Both modes use the same pure scheduling calculation. |
 | 12 | DigitalOcean App Platform and Managed Postgres in Frankfurt, with Cloudflare | One web service, one worker and a pre-deploy migration job; no Dockerfile or separate staging app currently. |
-| 13 | SendGrid for transactional email | `dinkydash/mail.py` sends login/signup mail; single mode does not need email credentials. |
+| 13 | SendGrid for transactional email | `dinkydash/mail.py` sends login/signup mail and subscription notices; single mode does not need email credentials. |
 
 ## Architecture
 
@@ -231,8 +235,8 @@ The remaining `describe_feed` server-date fallback is tracked in [DIN-62](https:
 | `.do/app.yaml`, `.python-version`, `requirements-cloud.txt` | Hosted components, Python build and dependencies |
 | `tests/`, `.github/workflows/test.yml` | Both-mode validation and CI |
 
-Billing and admin functionality are future work; there is no planned ORM/model layer
-or duplicate self-hosted config loader.
+Billing lives in `dinkydash/billing.py` and its cloud-only route blueprint. Admin
+functionality remains future work; there is no planned ORM/model layer or duplicate config loader.
 
 ### URL map
 
@@ -244,8 +248,10 @@ or duplicate self-hosted config loader.
 | `/s/<token>` | Not used | Bearer-token board |
 | `/preview` | Three sizes of the local board | Authenticated preview of the tokenised board |
 | `/healthz` | Process health | Process health, not worker/database health |
+| `/settings/billing`, `/settings/billing/{checkout,portal,sync}` | Not registered | Subscription page and CSRF-protected POST actions |
+| `/stripe/webhook` | Not registered | Raw-body signature verification; independent of browser sessions |
 
-Stripe routes are not implemented; their contract belongs to [DIN-53](https://linear.app/keepthescore/issue/DIN-53).
+Stripe state is read afresh under a family lock; the Checkout return URL cannot grant access.
 
 ### Data model sketch
 
@@ -253,7 +259,7 @@ The SQL files in [migrations/](migrations/) are authoritative. The current table
 
 | Table | Stored data / current use |
 |---|---|
-| `families` | Config, screen token, account status, trial deadline and lapse timestamp |
+| `families` | Config, screen token, trial/lapse deadlines, Stripe identifiers, subscription status and access deadline |
 | `users` | Family membership and login address |
 | `login_tokens` | Hashed single-use token, expiry, and either user or signup email |
 | `agendas` | One overwritten calendar window and fetch status per family |
@@ -261,6 +267,9 @@ The SQL files in [migrations/](migrations/) are authoritative. The current table
 | `content_history` | Recent generated copy, trimmed to the configured history length (at least 30) |
 | `model_spend` | Daily per-family calls and reported tokens |
 | `global_model_spend` | Daily call totals without family identifiers; survives deletion |
+| `billing_checkouts` | Durable Checkout attempt and exact request parameters for safe retries |
+| `stripe_events` | Processed event IDs; no webhook bodies |
+| `billing_notifications` | Deduplicated lifecycle notices and delivery/retry timestamps; no message bodies |
 | `calendar_health` | Schema exists; recurring-failure tracking is not yet wired up |
 | `schema_migrations` | Applied migration versions |
 
@@ -310,7 +319,8 @@ Managed backups are documented in operations; the independent restore drill rema
 [DIN-56](https://linear.app/keepthescore/issue/DIN-56). Worker liveness alerts remain MVP work ([DIN-54](https://linear.app/keepthescore/issue/DIN-54));
 Sentry instrumentation is Backlog ([DIN-35](https://linear.app/keepthescore/issue/DIN-35)).
 Cloud startup validates the session key and database configuration; model/email failures
-have their own runtime handling. Stripe credentials are not required before billing exists.
+have their own runtime handling. Stripe credentials remain optional while Checkout is disabled.
+Once billing is used, both the web service and worker require its account configuration.
 
 ## Phases
 
@@ -377,11 +387,13 @@ the real-device checks remain [DIN-58](https://linear.app/keepthescore/issue/DIN
 
 - [x] Store the trial deadline when a verified signup creates a family ([DIN-41](https://linear.app/keepthescore/issue/DIN-41)).
 - [x] Enforce expiry, restrict manual actions, and render the agreed lapsed state ([DIN-52](https://linear.app/keepthescore/issue/DIN-52)).
-- [ ] Checkout, Customer Portal, verified/idempotent webhooks, pricing and lifecycle notifications ([DIN-53](https://linear.app/keepthescore/issue/DIN-53)).
-- [ ] Apply the agreed price/tax configuration and update processor disclosures when enabling Stripe ([DIN-53](https://linear.app/keepthescore/issue/DIN-53)).
+- [x] Checkout, Customer Portal, verified/idempotent webhooks, pricing and lifecycle notifications ([DIN-53](https://linear.app/keepthescore/issue/DIN-53)).
+- [x] Disclose Stripe's conditional billing data flow and SendGrid subscription notices.
+- [ ] Apply and verify the agreed price/tax configuration in the intended Stripe test account ([DIN-53](https://linear.app/keepthescore/issue/DIN-53)).
 
 **Done when:** signup → trial → paid → cancel passes in Stripe test mode. Trial
-expiry is implemented; checkout, payment and cancellation still need that verification.
+expiry and billing have automated database tests with simulated provider responses;
+real Checkout, payment, portal changes, dunning and cancellation still need that verification.
 
 ### Phase 5 — Legal & trust
 

--- a/dinkydash/accounts.py
+++ b/dinkydash/accounts.py
@@ -190,7 +190,7 @@ def address_for(pool, user_id):
         return row[0] if row else None
 
 
-def delete_family(pool, family_id):
+def delete_family(pool, family_id, *, billing=None):
     """Delete a family and its dependent rows in one transaction.
 
     Signup tokens have no user foreign key, so delete those by address explicitly.
@@ -198,6 +198,11 @@ def delete_family(pool, family_id):
     """
     with pool.connection() as conn, conn.transaction():
         with conn.cursor() as cur:
+            cur.execute("SELECT id FROM families WHERE id = %s FOR UPDATE", (family_id,))
+            if not cur.fetchone():
+                return False
+            from .billing import Billing
+            (billing or Billing.from_env()).delete_customer(cur, family_id)
             cur.execute("SELECT email FROM users WHERE family_id = %s", (family_id,))
             addresses = [row[0] for row in cur.fetchall()]
             if addresses:

--- a/dinkydash/billing.py
+++ b/dinkydash/billing.py
@@ -1,0 +1,437 @@
+"""Hosted subscriptions. Stripe owns payments; Postgres owns family access.
+
+Only payment entry points import the SDK. Every account action takes a trusted
+family id. Billing writes serialize on that family's row, including deletion;
+bounded Stripe requests happen while holding it, so two Checkouts cannot race.
+Webhook snapshots are notifications to read Stripe's current subscriptions, not
+instructions to overwrite state with an old snapshot.
+"""
+
+import json
+import logging
+import os
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+
+log = logging.getLogger(__name__)
+PAYMENT_GRACE = timedelta(days=7)
+EVENTS = frozenset({
+    "checkout.session.completed",
+    "customer.subscription.created", "customer.subscription.updated",
+    "customer.subscription.deleted", "invoice.paid", "invoice.payment_failed",
+    "invoice.payment_action_required",
+})
+TERMINAL = {"canceled", "incomplete_expired"}
+
+
+class BillingError(Exception):
+    """A safe, parent-facing error; never Stripe's response or billing details."""
+
+
+@dataclass
+class Billing:
+    secret_key: str = field(default="", repr=False)
+    webhook_secret: str = field(default="", repr=False)
+    monthly_price: str = ""
+    yearly_price: str = ""
+    portal_configuration: str = ""
+    automatic_tax: bool | None = None
+    origin: str = ""
+    _client: object = field(default=None, repr=False)
+
+    @classmethod
+    def from_env(cls):
+        tax = os.environ.get("STRIPE_AUTOMATIC_TAX", "").lower()
+        host = os.environ.get("DINKYDASH_APP_HOST", "").strip()
+        return cls(
+            secret_key=os.environ.get("STRIPE_SECRET_KEY", ""),
+            webhook_secret=os.environ.get("STRIPE_WEBHOOK_SECRET", ""),
+            monthly_price=os.environ.get("STRIPE_MONTHLY_PRICE_ID", ""),
+            yearly_price=os.environ.get("STRIPE_YEARLY_PRICE_ID", ""),
+            portal_configuration=os.environ.get("STRIPE_PORTAL_CONFIGURATION_ID", ""),
+            automatic_tax={"true": True, "false": False}.get(tax),
+            origin=f"https://{host}" if host else "",
+        )
+
+    @property
+    def ready(self):
+        return bool(self.secret_key and self.webhook_secret and self.monthly_price
+                    and self.yearly_price and self.portal_configuration
+                    and self.automatic_tax is not None and self.origin)
+
+    @property
+    def client(self):
+        if not self.secret_key:
+            raise BillingError("Billing is temporarily unavailable. Please try again later.")
+        if self._client is None:
+            import stripe
+            self._client = stripe.StripeClient(
+                self.secret_key, max_network_retries=1,
+                http_client=stripe.RequestsClient(timeout=8),
+            )
+        return self._client
+
+    def call(self, method, *args, **kwargs):
+        import stripe
+        try:
+            return method(*args, **kwargs).to_dict()
+        except stripe.StripeError as exc:
+            log.warning("Stripe request failed (%s).", type(exc).__name__)
+            raise BillingError("Billing is temporarily unavailable. Please try again later.") from None
+
+    def prices(self):
+        if not self.ready:
+            raise BillingError("Subscriptions are not available yet. Your account stays accessible.")
+        prices = {}
+        for interval, price_id in (("month", self.monthly_price), ("year", self.yearly_price)):
+            price = self.call(self.client.v1.prices.retrieve, price_id)
+            recurring = price.get("recurring") or {}
+            if (not price.get("active") or price.get("currency") != "usd"
+                    or not isinstance(price.get("unit_amount"), int)
+                    or price["unit_amount"] <= 0 or recurring.get("interval") != interval
+                    or recurring.get("interval_count") != 1
+                    or recurring.get("usage_type") != "licensed"
+                    or price.get("tax_behavior") not in {"inclusive", "exclusive"}):
+                raise BillingError("Subscription pricing is being updated. Please try again later.")
+            prices[interval] = {
+                "id": price_id, "amount": f"${price['unit_amount'] / 100:g}",
+                "tax_included": price["tax_behavior"] == "inclusive",
+                "product": price["product"],
+            }
+        if prices["month"]["product"] != prices["year"]["product"]:
+            raise BillingError("Subscription pricing is being updated. Please try again later.")
+        return prices
+
+    def checkout(self, pool, family_id, interval):
+        if interval not in {"month", "year"}:
+            raise BillingError("Choose monthly or yearly billing.")
+        prices = self.prices()
+        self.check_portal(prices)
+        if self.automatic_tax:
+            settings = self.call(self.client.v1.tax.settings.retrieve)
+            if settings["status"] != "active":
+                raise BillingError("Subscription tax setup is being completed. Please try again later.")
+        # Commit the customer separately. Checkout cannot start until its owner
+        # is durable locally; a retry of customer creation uses fixed parameters.
+        with pool.connection() as conn, conn.cursor() as cur:
+            row = family(cur, family_id, lock=True)
+            if not row["stripe_customer_id"]:
+                customer = self.call(
+                    self.client.v1.customers.create,
+                    {"metadata": {"family_id": str(family_id)}},
+                    options={"idempotency_key": f"customer:{family_id}"},
+                )
+                cur.execute("UPDATE families SET stripe_customer_id = %s WHERE id = %s",
+                            (customer["id"], family_id))
+
+        with pool.connection() as conn, conn.cursor() as cur:
+            row = family(cur, family_id, lock=True)
+            subscriptions = self.subscriptions(row)
+            self.apply(cur, row, subscriptions)
+            if any(s["status"] not in TERMINAL for s in subscriptions):
+                raise BillingError("A subscription already exists. Open Manage subscription to continue.")
+            cur.execute("SELECT attempt, params, session_id FROM billing_checkouts WHERE family_id = %s",
+                        (family_id,))
+            previous = cur.fetchone()
+            expired = False
+            if previous and previous[2]:
+                session = self.call(self.client.v1.checkout.sessions.retrieve, previous[2])
+                if session["status"] == "open":
+                    return session["url"]
+                if session["status"] == "complete":
+                    if not subscriptions:
+                        raise BillingError("Your payment is being confirmed. Please check back shortly.")
+                    expired = True  # A completed, now canceled subscription can restart.
+                expired = expired or session["status"] == "expired"
+            if expired or not previous or previous[1]["expires_at"] <= row["now"].timestamp():
+                params = {
+                    "mode": "subscription", "customer": row["stripe_customer_id"],
+                    # Delayed bank payments can remain 'active' after failure.
+                    # Keep the MVP's subscription-status access rule to cards.
+                    "payment_method_types": ["card"],
+                    "line_items": [{"price": prices[interval]["id"], "quantity": 1}],
+                    "subscription_data": {"metadata": {"family_id": str(family_id)}},
+                    "success_url": self.origin + "/settings/billing?checkout=returned",
+                    "cancel_url": self.origin + "/settings/billing",
+                    "automatic_tax": {"enabled": self.automatic_tax},
+                    "billing_address_collection": "required",
+                    "customer_update": {"address": "auto", "name": "auto"},
+                    "allow_promotion_codes": True,
+                    "expires_at": int((row["now"] + timedelta(hours=1)).timestamp()),
+                }
+                cur.execute(
+                    """INSERT INTO billing_checkouts (family_id, params) VALUES (%s, %s::jsonb)
+                       ON CONFLICT (family_id) DO UPDATE
+                       SET attempt = gen_random_uuid(), params = EXCLUDED.params, session_id = NULL""",
+                    (family_id, json.dumps(params)),
+                )
+        # The attempt and exact parameters survive an API timeout or DB rollback.
+        with pool.connection() as conn, conn.cursor() as cur:
+            family(cur, family_id, lock=True)
+            cur.execute("SELECT attempt, params FROM billing_checkouts WHERE family_id = %s", (family_id,))
+            attempt, params = cur.fetchone()
+            session = self.call(self.client.v1.checkout.sessions.create, params,
+                                options={"idempotency_key": f"checkout:{attempt}"})
+            cur.execute("UPDATE billing_checkouts SET session_id = %s WHERE family_id = %s",
+                        (session["id"], family_id))
+            return session["url"]
+
+    def check_portal(self, prices):
+        """Do not accept a first payment into a portal that cannot cancel it."""
+        configuration = self.call(self.client.v1.billing_portal.configurations.retrieve,
+                                  self.portal_configuration)
+        features = configuration["features"]
+        cancel = features["subscription_cancel"]
+        update = features["subscription_update"]
+        products = update.get("products") or []
+        price_ids = {p["id"] for p in prices.values()}
+        changeable = any(p["product"] == prices["month"]["product"]
+                         and price_ids.issubset(p["prices"]) for p in products)
+        if not (configuration["active"] and cancel["enabled"] and cancel["mode"] == "at_period_end"
+                and features["invoice_history"]["enabled"]
+                and features["payment_method_update"]["enabled"]
+                and update["enabled"] and "price" in update["default_allowed_updates"] and changeable):
+            raise BillingError("Subscription management is being set up. Please try again later.")
+
+    def portal(self, pool, family_id):
+        if not self.portal_configuration or not self.origin:
+            raise BillingError("Subscription management is temporarily unavailable.")
+        with pool.connection() as conn, conn.cursor() as cur:
+            row = family(cur, family_id, lock=True)
+            if not row["stripe_customer_id"]:
+                raise BillingError("Choose a subscription first.")
+            session = self.call(self.client.v1.billing_portal.sessions.create, {
+                "customer": row["stripe_customer_id"],
+                "configuration": self.portal_configuration,
+                "return_url": self.origin + "/settings/billing",
+            })
+            return session["url"]
+
+    def subscriptions(self, row):
+        if not row["stripe_customer_id"]:
+            return []
+        result = self.call(self.client.v1.subscriptions.list, {
+            "customer": row["stripe_customer_id"], "status": "all", "limit": 100,
+            "expand": ["data.latest_invoice"],
+        })
+        # One plan per family; refusing an unexpected overflow is safer than
+        # overlooking a payable subscription and starting another one.
+        if result["has_more"]:
+            raise BillingError("Please contact support to check your subscription.")
+        return list(result["data"])
+
+    def sync(self, pool, family_id):
+        with pool.connection() as conn, conn.cursor() as cur:
+            row = family(cur, family_id, lock=True)
+            self.apply(cur, row, self.subscriptions(row))
+
+    def event(self, pool, raw, signature):
+        import stripe
+        if not self.webhook_secret or not self.secret_key:
+            raise BillingError("Billing is not configured.")
+        event = stripe.Webhook.construct_event(raw, signature, self.webhook_secret).to_dict()
+        live = self.secret_key.startswith(("sk_live_", "rk_live_"))
+        if event.get("livemode") is not live or event.get("account"):
+            raise ValueError("Unexpected Stripe mode or connected account.")
+        if event["type"] not in EVENTS:
+            return
+        customer_id = event["data"]["object"].get("customer")
+        if not isinstance(customer_id, str):
+            return
+        with pool.connection() as conn, conn.cursor() as cur:
+            cur.execute("SELECT id FROM families WHERE stripe_customer_id = %s FOR UPDATE", (customer_id,))
+            found = cur.fetchone()
+            if not found:  # Deleted accounts and other products never create a family.
+                return
+            family_id = found[0]
+            cur.execute(
+                """INSERT INTO stripe_events (event_id, family_id) VALUES (%s, %s)
+                   ON CONFLICT DO NOTHING RETURNING event_id""", (event["id"], family_id),
+            )
+            if not cur.fetchone():
+                return
+            row = family(cur, family_id)
+            self.apply(cur, row, self.subscriptions(row))
+
+    def apply(self, cur, row, subscriptions):
+        """Apply current remote state under the family lock, never event order."""
+        cur.execute("UPDATE families SET billing_synced_at = now() WHERE id = %s", (row["id"],))
+        owned = [s for s in subscriptions if s.get("metadata", {}).get("family_id") == str(row["id"])]
+        if not owned:
+            return
+        # A canceled previous subscription cannot overwrite its replacement.
+        subscription = max(owned, key=lambda s: (s["status"] not in TERMINAL, s["created"]))
+        remote = subscription["status"]
+        items = subscription["items"]["data"]
+        period_end = timestamp(max((i["current_period_end"] for i in items), default=0))
+        invoice = subscription.get("latest_invoice") or {}
+        canceling = bool(subscription.get("cancel_at_period_end") or subscription.get("cancel_at"))
+        cancel_at = (timestamp(subscription.get("cancel_at")) or period_end) if canceling else None
+        deadline = None
+        lapse = row["lapsed_at"]
+        if remote in {"active", "trialing"}:
+            status = "active"
+            if canceling:
+                deadline = cancel_at
+        elif remote == "past_due":
+            # Invoice creation is stable across retries; an old failure event
+            # or another retry must not restart the seven-day grace period.
+            status = "past_due"
+            deadline = timestamp(invoice["created"]) + PAYMENT_GRACE
+            if cancel_at:
+                deadline = min(deadline, cancel_at)
+        elif remote in {"incomplete", "incomplete_expired"}:
+            status = "trialing" if row["trial_ends_at"] and row["trial_ends_at"] > row["now"] else "lapsed"
+            lapse = lapse or row["trial_ends_at"] or row["now"]
+        else:  # canceled, unpaid or paused: no new paid work.
+            status = "lapsed"
+            lapse = lapse or timestamp(subscription.get("ended_at")) or row["now"]
+        if deadline and deadline <= row["now"]:
+            status, lapse = "lapsed", deadline
+        cur.execute(
+            """UPDATE families SET status = %s, lapsed_at = %s, stripe_subscription_id = %s,
+                   subscription_status = %s, subscription_period_end = %s,
+                   subscription_cancel_at = %s, billing_access_until = %s,
+                   billing_synced_at = now(), updated_at = now()
+               WHERE id = %s""",
+            (status, lapse if status == "lapsed" else None, subscription["id"], remote,
+             period_end, cancel_at, deadline, row["id"]),
+        )
+        if remote in {"past_due", "unpaid"} and invoice.get("id"):
+            notice(cur, row["id"], "payment:" + invoice["id"], "payment_failed")
+        if canceling and status != "lapsed":
+            notice(cur, row["id"], f"cancel:{subscription['id']}:{cancel_at.isoformat()}",
+                   "cancellation_scheduled")
+        if status == "lapsed" and remote not in {"incomplete", "incomplete_expired"}:
+            notice(cur, row["id"], f"ended:{subscription['id']}:{lapse.isoformat()}", "subscription_ended")
+
+    def delete_customer(self, cur, family_id):
+        """Called inside account deletion's transaction, before removing its owner.
+
+        Stripe customer deletion immediately cancels every subscription and is
+        repeatable if the local commit fails. No local delete on a remote failure.
+        """
+        row = family(cur, family_id, lock=True)
+        if row["stripe_customer_id"]:
+            customer = self.call(self.client.v1.customers.retrieve, row["stripe_customer_id"])
+            if not customer.get("deleted"):
+                self.call(self.client.v1.customers.delete, row["stripe_customer_id"])
+
+
+def timestamp(value):
+    return datetime.fromtimestamp(value, timezone.utc) if value else None
+
+
+def family(cur, family_id, *, lock=False):
+    cur.execute(
+        """SELECT id, status, trial_ends_at, lapsed_at, stripe_customer_id,
+                  stripe_subscription_id, subscription_status, subscription_period_end,
+                  subscription_cancel_at, billing_access_until, now() AS now
+           FROM families WHERE id = %s""" + (" FOR UPDATE" if lock else ""), (family_id,),
+    )
+    row = cur.fetchone()
+    if row is None:
+        from .pgstore import NoSuchFamily
+        raise NoSuchFamily(f"No family {family_id}")
+    return dict(zip((column.name for column in cur.description), row))
+
+
+def notice(cur, family_id, key, kind):
+    cur.execute(
+        """INSERT INTO billing_notifications (family_id, notice_key, kind)
+           VALUES (%s, %s, %s) ON CONFLICT DO NOTHING""", (family_id, key, kind),
+    )
+
+
+def housekeeping(pool, billing):
+    """Recover missed webhooks hourly, then deliver pending lifecycle mail.
+
+    The existing worker supplies the schedule. At most twenty accounts per pass
+    keeps payment-provider trouble from starving the board tick indefinitely.
+    """
+    if not billing.secret_key:
+        return
+    with pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            """SELECT id FROM families WHERE stripe_customer_id IS NOT NULL
+               AND (billing_synced_at IS NULL OR billing_synced_at < now() - interval '1 hour')
+               ORDER BY billing_synced_at NULLS FIRST LIMIT 20""",
+        )
+        ids = [r[0] for r in cur.fetchall()]
+    for family_id in ids:
+        try:
+            billing.sync(pool, family_id)
+        except BillingError:
+            log.warning("Subscription reconciliation will retry next pass.")
+            break  # An API outage should cost one bounded request, not twenty.
+    if not billing.ready:
+        return
+    with pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            """INSERT INTO billing_notifications (family_id, notice_key, kind)
+               SELECT id, 'trial-ending', 'trial_ending' FROM families
+               WHERE status = 'trialing' AND trial_ends_at > now()
+                 AND trial_ends_at <= now() + interval '3 days'
+               ON CONFLICT DO NOTHING""",
+        )
+    deliver_notifications(pool, billing.origin)
+
+
+def notification_text(kind, row):
+    """Recheck relevance at send time: a recovered payment needs no warning."""
+    if kind == "trial_ending" and row["status"] == "trialing" and row["trial_ends_at"] > row["now"]:
+        return ("Your DinkyDash trial is ending",
+                f"Your trial ends on {row['trial_ends_at']:%-d %B %Y}. Choose a subscription "
+                "to keep your board updating. No payment has been scheduled.")
+    if kind == "payment_failed" and row["subscription_status"] in {"past_due", "unpaid"}:
+        return ("Your DinkyDash payment needs attention",
+                "Your subscription payment could not be completed. Please update your payment "
+                "method in Manage subscription. Board updates pause seven days after the "
+                "unpaid invoice was created, or sooner if the subscription ends.")
+    if kind == "cancellation_scheduled" and row["subscription_cancel_at"] and row["status"] != "lapsed":
+        return ("Your DinkyDash cancellation is scheduled",
+                f"Your subscription will end on {row['subscription_cancel_at']:%-d %B %Y}. "
+                "You can undo cancellation in Manage subscription. Any unpaid invoices still need attention.")
+    if kind == "subscription_ended" and row["status"] == "lapsed":
+        return ("Your DinkyDash subscription has ended",
+                "Board updates are paused. The last saved board remains on your screen for "
+                "30 days. You can still sign in to restart, export your data or delete your account.")
+    return None
+
+
+def deliver_notifications(pool, origin):
+    """At-least-once mail delivery, retried after failures without storing bodies.
+
+    A crash after SendGrid accepts a message but before commit can repeat it;
+    ordinary webhook retries and concurrent workers cannot enqueue it twice.
+    """
+    from . import mail
+    for _ in range(20):
+        with pool.connection() as conn, conn.cursor() as cur:
+            cur.execute(
+                """SELECT n.family_id, n.notice_key, n.kind,
+                          (SELECT email FROM users WHERE family_id = n.family_id ORDER BY id LIMIT 1)
+                   FROM billing_notifications n
+                   WHERE n.sent_at IS NULL AND n.retry_at <= now()
+                   ORDER BY n.created_at FOR UPDATE OF n SKIP LOCKED LIMIT 1""",
+            )
+            pending = cur.fetchone()
+            if not pending:
+                return
+            family_id, key, kind, address = pending
+            message = notification_text(kind, family(cur, family_id))
+            try:
+                if message and address:
+                    subject, body = message
+                    mail.send(address, subject, body + "\n\n" + origin + "/settings/billing")
+            except mail.MailError:
+                log.warning("A billing notification could not be sent; retrying later.")
+                cur.execute(
+                    """UPDATE billing_notifications SET retry_at = now() + interval '15 minutes'
+                       WHERE family_id = %s AND notice_key = %s""", (family_id, key),
+                )
+            else:
+                cur.execute(
+                    """UPDATE billing_notifications SET sent_at = now()
+                       WHERE family_id = %s AND notice_key = %s""", (family_id, key),
+                )

--- a/dinkydash/billing.py
+++ b/dinkydash/billing.py
@@ -179,7 +179,8 @@ class Billing:
     def check_portal(self, prices):
         """Do not accept a first payment into a portal that cannot cancel it."""
         configuration = self.call(self.client.v1.billing_portal.configurations.retrieve,
-                                  self.portal_configuration)
+                                  self.portal_configuration,
+                                  {"expand": ["features.subscription_update.products"]})
         features = configuration["features"]
         cancel = features["subscription_cancel"]
         update = features["subscription_update"]

--- a/dinkydash/lifecycle.py
+++ b/dinkydash/lifecycle.py
@@ -39,6 +39,7 @@ def access_for(pool, family_id):
                           WHEN status = 'lapsed' THEN lapsed_at
                           WHEN status = 'trialing' AND trial_ends_at <= now()
                               THEN trial_ends_at
+                          WHEN billing_access_until <= now() THEN billing_access_until
                       END, now()
                FROM families WHERE id = %s""", (family_id,),
         )
@@ -50,12 +51,15 @@ def access_for(pool, family_id):
 
 
 def expire_trials(pool):
-    """Persist ended trials once; a delayed or repeated sweep keeps the deadline."""
+    """Persist trial, cancellation and payment-grace deadlines exactly once."""
     with pool.connection() as conn, conn.transaction(), conn.cursor() as cur:
         cur.execute(
             """UPDATE families
-               SET status = 'lapsed', lapsed_at = trial_ends_at, updated_at = now()
-               WHERE status = 'trialing' AND trial_ends_at <= now()
+               SET status = 'lapsed',
+                   lapsed_at = CASE WHEN status = 'trialing' THEN trial_ends_at ELSE billing_access_until END,
+                   updated_at = now()
+               WHERE (status = 'trialing' AND trial_ends_at <= now())
+                  OR (status <> 'lapsed' AND billing_access_until <= now())
                RETURNING id""",
         )
         return len(cur.fetchall())

--- a/doc/billing.md
+++ b/doc/billing.md
@@ -27,8 +27,12 @@ Before enabling payments, check the intended Stripe account in **test mode**:
    Explicitly choose `STRIPE_AUTOMATIC_TAX=true` or `false`; there is no default.
    Automatic tax requires active Stripe Tax settings. Code cannot decide whether
    the business needs a tax registration.
-3. Create a dedicated Customer Portal configuration. Enable invoice history,
-   card updates, cancellation **at period end**, and subscription price
+3. Create a dedicated Customer Portal configuration. For card updates, create a
+   [payment method configuration](https://docs.stripe.com/payments/payment-method-configurations)
+   with only cards and their wallets enabled, then set its ID in
+   `features.payment_method_update.payment_method_configuration`. Otherwise the
+   portal inherits the account's payment methods, including any bank debits.
+   Enable invoice history, card updates, cancellation **at period end**, and subscription price
    changes for both prices on this product. Configure and review prorations for
    billing-period changes in Stripe. Set `STRIPE_PORTAL_CONFIGURATION_ID`.
    Checkout checks these cancellation and management capabilities before charging.

--- a/doc/billing.md
+++ b/doc/billing.md
@@ -1,0 +1,100 @@
+# Hosted billing
+
+Billing is cloud-only. `requirements-cloud.txt` pins the official Stripe SDK;
+single mode neither imports it nor registers payment routes. The 14-day trial
+lives in Postgres and creates no Stripe customer. Checkout starts paid access
+immediately, even during a trial. The return URL never grants access.
+The MVP accepts cards and their supported wallets. Delayed bank-payment methods
+need separate invoice-based access handling: Stripe can leave those subscriptions
+active even after a failed payment ([subscription lifecycle](https://docs.stripe.com/billing/subscriptions/overview)).
+
+## Configuration
+
+Set the variables in `.env.example` on both the web service and the worker.
+Credentials and price/account decisions belong in private configuration and the
+Linear strategy document, never in this repository. Missing configuration keeps
+Checkout disabled while login, settings, export and unbilled account deletion work.
+Existing subscribers still need the secret key and portal configuration to manage
+billing or delete their accounts safely.
+
+Before enabling payments, check the intended Stripe account in **test mode**:
+
+1. Create the agreed monthly and annual USD recurring prices on one product,
+   with explicit inclusive/exclusive tax behaviour. Set their IDs. Existing
+   subscriptions keep their original price when the configured IDs change.
+   Checkout accepts promotion codes; configure any agreed offer in Stripe.
+2. Confirm the business's tax settings, product tax code and registrations.
+   Explicitly choose `STRIPE_AUTOMATIC_TAX=true` or `false`; there is no default.
+   Automatic tax requires active Stripe Tax settings. Code cannot decide whether
+   the business needs a tax registration.
+3. Create a dedicated Customer Portal configuration. Enable invoice history,
+   card updates, cancellation **at period end**, and subscription price
+   changes for both prices on this product. Configure and review prorations for
+   billing-period changes in Stripe. Set `STRIPE_PORTAL_CONFIGURATION_ID`.
+   Checkout checks these cancellation and management capabilities before charging.
+4. Configure payment recovery in Stripe: retry failed renewals, then cancel or
+   mark unpaid. DinkyDash gives seven days from the unpaid invoice's creation
+   before pausing board updates, and does not itself retry card charges.
+5. Set `DINKYDASH_APP_HOST` to the trusted app hostname. Checkout/portal returns
+   and notification links use this origin, never a form field or Host header.
+6. Register `POST /stripe/webhook` as a snapshot event destination using the
+   SDK's API version, **2026-08-26.dahlia**. Subscribe only to the event types in
+   `dinkydash.billing.EVENTS` and set that destination's signing secret.
+   Use matching test or live keys, prices, portal configuration and signing secret;
+   connected-account events and events from the wrong mode are rejected.
+
+The webhook verifies signatures against the raw, size-limited body before any
+database work. It is the only CSRF exemption; Checkout, portal and status-refresh
+POSTs still require a signed-in family and its CSRF token.
+
+## State and recovery
+
+Payment writes serialize on the family row, including account deletion. Unlike
+calendar fetching, these short billing operations hold the row lock across a
+bounded Stripe call to prevent competing purchases. Checkout stores its exact
+request and idempotency key before the API call; a retry reuses that request.
+An open Checkout is reused for up to an hour, including if another tab chooses
+a different billing period. Expired Checkouts can be replaced after checking
+there is no existing payable subscription.
+
+Webhooks record processed IDs and reconcile current Stripe subscriptions in the
+same transaction. They do not apply event timestamps or stale payload state.
+Canceled older subscriptions cannot overwrite a replacement. A failed transaction
+returns a retryable response and does not mark the event processed. The worker
+also reconciles up to twenty accounts per pass whose last check was over an hour
+ago, recovering missed deliveries.
+
+Active subscriptions update boards; scheduled cancellation ends access at its
+deadline. Failed renewals get seven days from invoice creation, which repeated
+payment attempts cannot extend. Unpaid, paused and canceled subscriptions lapse.
+Access deadlines are checked on the request/tick path even if housekeeping is late.
+The existing 30-day frozen-board display applies after access ends.
+
+The worker queues a reminder three days before an app-managed trial ends and
+delivers payment-failure, cancellation and ended-subscription notices through
+SendGrid. Delivery records deduplicate ordinary webhook retries; failures retry
+after fifteen minutes and stale notices are skipped after recovery. Delivery is
+at least once: a crash after SendGrid accepts mail but before the database commits
+can repeat a message. Bodies and webhook payloads are not stored.
+
+Account deletion removes the Stripe customer first, which stops its subscriptions
+and prevents new ones. If Stripe fails, the local account remains so deletion can
+be retried. A delayed webhook for a deleted family cannot recreate it. Stripe may
+retain payment records under its own policy; local billing rows cascade with the
+family. Exports include subscription identifiers, status and dates, but exclude
+Checkout URLs and session credentials.
+
+## Verification before the first real payment
+
+`tests/test_billing.py` exercises real database transactions and signed webhooks
+with simulated Stripe/email responses. That is not a Stripe test-mode checkout.
+On the configured test account, complete a fresh signup, trial, Checkout payment,
+portal billing-period change, failed renewal/recovery, period-end cancellation,
+and account deletion. Resend duplicate and older events after state changes;
+verify access and notification delivery. Check the final tax totals and invoices.
+Keep the test customer, destination and account identifiers in private notes.
+
+Use [Stripe's testing guide](https://docs.stripe.com/testing),
+[webhook delivery guidance](https://docs.stripe.com/webhooks), and
+[Customer Portal setup](https://docs.stripe.com/customer-management/integrate-customer-portal).
+Only enable live credentials after that account-specific verification succeeds.

--- a/migrations/006_billing.sql
+++ b/migrations/006_billing.sql
@@ -1,0 +1,37 @@
+ALTER TABLE families
+    ADD COLUMN stripe_subscription_id TEXT UNIQUE,
+    ADD COLUMN subscription_status TEXT,
+    ADD COLUMN subscription_period_end TIMESTAMPTZ,
+    ADD COLUMN subscription_cancel_at TIMESTAMPTZ,
+    ADD COLUMN billing_access_until TIMESTAMPTZ,
+    ADD COLUMN billing_synced_at TIMESTAMPTZ;
+
+-- Save the exact request before contacting Stripe. A timeout or a failed local
+-- commit must retry the same Checkout, even if the parent changes their choice.
+CREATE TABLE billing_checkouts (
+    family_id UUID PRIMARY KEY REFERENCES families (id) ON DELETE CASCADE,
+    attempt UUID NOT NULL DEFAULT gen_random_uuid(),
+    params JSONB NOT NULL,
+    session_id TEXT
+);
+
+-- No webhook payloads: they contain billing details we do not need to retain.
+CREATE TABLE stripe_events (
+    event_id TEXT PRIMARY KEY,
+    family_id UUID NOT NULL REFERENCES families (id) ON DELETE CASCADE,
+    processed_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Delivery belongs to the worker, never the webhook's response transaction.
+CREATE TABLE billing_notifications (
+    family_id UUID NOT NULL REFERENCES families (id) ON DELETE CASCADE,
+    notice_key TEXT NOT NULL,
+    kind TEXT NOT NULL CHECK (kind IN ('trial_ending', 'payment_failed',
+                                      'cancellation_scheduled', 'subscription_ended')),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    retry_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    sent_at TIMESTAMPTZ,
+    PRIMARY KEY (family_id, notice_key)
+);
+CREATE INDEX billing_notifications_pending ON billing_notifications (created_at)
+    WHERE sent_at IS NULL;

--- a/requirements-cloud.txt
+++ b/requirements-cloud.txt
@@ -30,3 +30,7 @@ psycopg-pool==3.3.1
 # Cloud only, and imported lazily in `settings.qr_svg`: a Pi has no screen token
 # and must not install a library it can never use.
 segno==1.6.6
+
+# Hosted Checkout, Customer Portal and signature verification. The official SDK
+# supplies the versioned API and tested webhook verifier; never imported on a Pi.
+stripe==15.6.1

--- a/tests/test_billing.py
+++ b/tests/test_billing.py
@@ -414,6 +414,20 @@ def test_portal_must_support_cancellation_before_customer_created(service, pg_po
     assert not service.client.customers
 
 
+def test_portal_products_are_only_returned_when_expanded(service):
+    retrieve = service.client.v1.billing_portal.configurations.retrieve
+    configuration = retrieve.return_value.to_dict()
+
+    def response(configuration_id, params=None):
+        result = copy.deepcopy(configuration)
+        if "features.subscription_update.products" not in (params or {}).get("expand", []):
+            result["features"]["subscription_update"].pop("products")
+        return sdk(result)
+
+    retrieve.side_effect = response
+    service.check_portal(service.prices())
+
+
 def test_portal_with_no_update_products_is_unavailable(service):
     portal = service.client.v1.billing_portal.configurations.retrieve.return_value
     portal["features"]["subscription_update"]["products"] = None

--- a/tests/test_billing.py
+++ b/tests/test_billing.py
@@ -1,0 +1,553 @@
+"""Payment boundaries with a real database and signed, reordered deliveries.
+
+The fake replaces Stripe's network only. Sessions, CSRF, transactions, access
+checks, signature verification and notification delivery decisions are real.
+No test calls Stripe, SendGrid or a model provider.
+"""
+
+import copy
+import hashlib
+import hmac
+import json
+import time
+from concurrent.futures import ThreadPoolExecutor
+from datetime import timedelta
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+from flask.testing import FlaskClient
+
+from dinkydash import accounts, billing, lifecycle, mail
+from tests.conftest import client_for
+from web import create_app
+
+
+class Stripe:
+    def __init__(self):
+        self.sessions = {}
+        self.attempts = {}
+        self.subscriptions = []
+        self.customers = {}
+        self.v1 = SimpleNamespace(
+            prices=SimpleNamespace(retrieve=Mock(side_effect=self.price)),
+            customers=SimpleNamespace(create=Mock(side_effect=self.customer),
+                                      retrieve=Mock(side_effect=lambda cid: sdk(self.customers[cid])),
+                                      delete=Mock(side_effect=self.delete_customer)),
+            checkout=SimpleNamespace(sessions=SimpleNamespace(
+                create=Mock(side_effect=self.checkout),
+                retrieve=Mock(side_effect=lambda sid: sdk(self.sessions[sid])),
+            )),
+            subscriptions=SimpleNamespace(list=Mock(side_effect=lambda params: sdk({
+                "data": copy.deepcopy([s for s in self.subscriptions if s["customer"] == params["customer"]]),
+                "has_more": False,
+            }))),
+            billing_portal=SimpleNamespace(configurations=SimpleNamespace(retrieve=Mock(return_value=sdk({
+                "active": True, "features": {
+                    "subscription_cancel": {"enabled": True, "mode": "at_period_end"},
+                    "invoice_history": {"enabled": True}, "payment_method_update": {"enabled": True},
+                    "subscription_update": {"enabled": True, "default_allowed_updates": ["price"],
+                        "products": [{"product": "prod_example", "prices": ["price_month_example", "price_year_example"]}]},
+                },
+            }))), sessions=SimpleNamespace(create=Mock(return_value=sdk({
+                "url": "https://billing.stripe.com/p/session_example",
+            })))),
+            tax=SimpleNamespace(settings=SimpleNamespace(retrieve=Mock(return_value=sdk({"status": "active"})))),
+        )
+
+    def price(self, price_id):
+        annual = price_id == "price_year_example"
+        return sdk({"id": price_id, "active": True, "currency": "usd",
+                "unit_amount": 3900 if annual else 600, "tax_behavior": "exclusive",
+                "product": "prod_example", "recurring": {
+                    "interval": "year" if annual else "month", "interval_count": 1, "usage_type": "licensed",
+                }})
+
+    def customer(self, params, options):
+        cid = "cus_" + params["metadata"]["family_id"]
+        self.customers[cid] = {"id": cid}
+        return sdk(self.customers[cid])
+
+    def checkout(self, params, options):
+        key = options["idempotency_key"]
+        if key in self.attempts:
+            old_params, sid = self.attempts[key]
+            assert old_params == params
+            return sdk(self.sessions[sid])
+        sid = "cs_example_" + str(len(self.sessions))
+        self.attempts[key] = (copy.deepcopy(params), sid)
+        self.sessions[sid] = {"id": sid, "status": "open", "url": f"https://checkout.stripe.com/c/pay/{sid}"}
+        return sdk(self.sessions[sid])
+
+    def delete_customer(self, cid):
+        self.customers[cid] = {"id": cid, "deleted": True}
+        self.subscriptions = [s for s in self.subscriptions if s["customer"] != cid]
+        return sdk(self.customers[cid])
+
+
+def sdk(data):
+    import stripe
+    return stripe.StripeObject.construct_from(data, None)
+
+
+@pytest.fixture
+def service():
+    pytest.importorskip("stripe")
+    return billing.Billing(
+        secret_key="sk_test_example", webhook_secret="whsec_example",
+        monthly_price="price_month_example", yearly_price="price_year_example",
+        portal_configuration="bpc_example", automatic_tax=False,
+        origin="https://app.example.com", _client=Stripe(),
+    )
+
+
+@pytest.fixture
+def parent(monkeypatch, pg_pool, pg_family, service):
+    monkeypatch.setenv("DINKYDASH_MODE", "cloud")
+    monkeypatch.setenv("DINKYDASH_SECRET_KEY", "billing-test-session-key")
+    app = create_app(pool=pg_pool)
+    app.config["BILLING"] = service
+    with pg_pool.connection() as conn, conn.cursor() as cur:
+        cur.execute("INSERT INTO users (family_id, email) VALUES (%s, %s) RETURNING id",
+                    (pg_family, "parent@example.com"))
+        user_id = cur.fetchone()[0]
+    client = client_for(app)
+    with client.session_transaction() as session:
+        session.update(user_id=user_id, family_id=str(pg_family))
+    return client
+
+
+def state(pool, family_id):
+    with pool.connection() as conn, conn.cursor() as cur:
+        return billing.family(cur, family_id)
+
+
+def sql(pool, query, params=()):
+    with pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(query, params)
+        return cur.fetchall() if cur.description else []
+
+
+def subscription(service, family_id, status="active", **changes):
+    now = int(time.time())
+    result = {"id": "sub_example", "customer": "cus_" + str(family_id),
+              "metadata": {"family_id": str(family_id)}, "created": now,
+              "status": status, "cancel_at_period_end": False,
+              "items": {"data": [{"current_period_start": now, "current_period_end": now + 2592000}]},
+              "latest_invoice": {"id": "in_example", "created": now, "status": "paid"}}
+    result.update(changes)
+    service.client.subscriptions = [result]
+    return result
+
+
+def webhook(client, service, family_id, event_id="evt_example", event_type="invoice.paid", **changes):
+    payload = {"id": event_id, "object": "event", "type": event_type, "livemode": False,
+               "created": 100, "data": {"object": {"customer": "cus_" + str(family_id)}}}
+    payload.update(changes)
+    raw = json.dumps(payload).encode()
+    stamp = str(int(time.time()))
+    digest = hmac.new(service.webhook_secret.encode(), stamp.encode() + b"." + raw, hashlib.sha256).hexdigest()
+    return client.post("/stripe/webhook", data=raw, content_type="application/json",
+                       headers={"Stripe-Signature": f"t={stamp},v1={digest}"})
+
+
+def start(service, pool, family_id):
+    return service.checkout(pool, family_id, "year")
+
+
+def test_signup_and_billing_page_do_not_create_customer(parent, service, pg_pool, pg_family):
+    page = parent.get("/settings/billing")
+    assert page.status_code == 200
+    assert b"$39 / year" in page.data and b"$6 / month" in page.data
+    assert not service.client.customers
+    assert not state(pg_pool, pg_family)["stripe_customer_id"]
+    assert page.headers["Cache-Control"] == "no-store"
+
+
+def test_checkout_server_owns_price_customer_and_redirects(parent, service, pg_pool, pg_family):
+    result = parent.post("/settings/billing/checkout", data={
+        "interval": "year", "price": "price_attacker", "customer": "cus_attacker",
+        "family_id": "somebody-else", "return_url": "https://example.org/steal",
+    })
+    assert result.status_code == 303
+    params = service.client.v1.checkout.sessions.create.call_args.args[0]
+    assert params["customer"] == "cus_" + str(pg_family)
+    assert params["line_items"] == [{"price": service.yearly_price, "quantity": 1}]
+    assert params["success_url"] == "https://app.example.com/settings/billing?checkout=returned"
+    assert params["subscription_data"] == {"metadata": {"family_id": str(pg_family)}}
+    assert params["automatic_tax"] == {"enabled": False}
+    assert params["payment_method_types"] == ["card"]
+    assert state(pg_pool, pg_family)["status"] == "trialing"
+    assert b"Payment confirmation" in parent.get("/settings/billing?checkout=returned").data
+    assert state(pg_pool, pg_family)["status"] == "trialing"
+
+
+def test_parallel_checkout_reuses_one_session(service, pg_pool, pg_family):
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        results = list(executor.map(lambda _: start(service, pg_pool, pg_family), range(2)))
+    assert results[0] == results[1]
+    assert len(service.client.sessions) == len(service.client.customers) == 1
+
+
+def test_timeout_after_stripe_accepts_reuses_exact_request(service, pg_pool, pg_family):
+    import stripe
+    remote = service.client.checkout
+    def timeout(params, options):
+        remote(params, options)
+        raise stripe.APIConnectionError("private billing details must not be exposed")
+    service.client.v1.checkout.sessions.create.side_effect = timeout
+    with pytest.raises(billing.BillingError, match="temporarily unavailable"):
+        start(service, pg_pool, pg_family)
+    assert len(service.client.sessions) == 1
+    service.client.v1.checkout.sessions.create.side_effect = remote
+    service.checkout(pg_pool, pg_family, "month")  # The saved annual request wins.
+    assert len(service.client.sessions) == 1
+    assert service.client.v1.checkout.sessions.create.call_args.args[0]["line_items"][0]["price"] == service.yearly_price
+
+
+def test_expired_checkout_gets_new_attempt(service, pg_pool, pg_family):
+    original = start(service, pg_pool, pg_family)
+    next(iter(service.client.sessions.values()))["status"] = "expired"
+    assert service.checkout(pg_pool, pg_family, "month") != original
+
+
+@pytest.mark.parametrize("status", ["active", "past_due", "unpaid", "incomplete"])
+def test_existing_subscription_prevents_second_charge(service, pg_pool, pg_family, status):
+    start(service, pg_pool, pg_family)
+    subscription(service, pg_family, status)
+    with pytest.raises(billing.BillingError, match="already exists"):
+        start(service, pg_pool, pg_family)
+    assert len(service.client.sessions) == 1
+
+
+def test_canceled_subscription_can_restart(service, pg_pool, pg_family):
+    original = start(service, pg_pool, pg_family)
+    next(iter(service.client.sessions.values()))["status"] = "complete"
+    subscription(service, pg_family, "canceled", ended_at=int(time.time()))
+    assert start(service, pg_pool, pg_family) != original
+
+
+def test_complete_trial_paid_cancel_and_reactivate(parent, service, pg_pool, pg_family):
+    start(service, pg_pool, pg_family)
+    sql(pg_pool, "UPDATE families SET status = 'lapsed' WHERE id = %s", (pg_family,))
+    remote = subscription(service, pg_family)
+    assert webhook(parent, service, pg_family).status_code == 204
+    assert state(pg_pool, pg_family)["status"] == "active"
+    assert not lifecycle.access_for(pg_pool, pg_family).ended
+    remote["cancel_at_period_end"] = True
+    assert webhook(parent, service, pg_family, "evt_cancel", "customer.subscription.updated").status_code == 204
+    assert not lifecycle.access_for(pg_pool, pg_family).ended
+    assert state(pg_pool, pg_family)["subscription_cancel_at"]
+    remote.update(status="canceled", ended_at=int(time.time()))
+    assert webhook(parent, service, pg_family, "evt_ended", "customer.subscription.deleted").status_code == 204
+    assert lifecycle.access_for(pg_pool, pg_family).ended
+    subscription(service, pg_family, id="sub_restarted")
+    assert webhook(parent, service, pg_family, "evt_reactivated").status_code == 204
+    assert state(pg_pool, pg_family)["lapsed_at"] is None
+
+
+def test_duplicate_and_out_of_order_events_use_current_subscription(parent, service, pg_pool, pg_family):
+    start(service, pg_pool, pg_family)
+    old = subscription(service, pg_family, "canceled", ended_at=int(time.time()))
+    current = subscription(service, pg_family, id="sub_current", created=int(time.time()) + 1)
+    service.client.subscriptions = [old, current]
+    for identifier in ("evt_new", "evt_new", "evt_old"):
+        assert webhook(parent, service, pg_family, identifier, "customer.subscription.deleted").status_code == 204
+    row = state(pg_pool, pg_family)
+    assert row["status"] == "active" and row["stripe_subscription_id"] == "sub_current"
+    assert len(sql(pg_pool, "SELECT event_id FROM stripe_events WHERE family_id = %s", (pg_family,))) == 2
+    assert not sql(pg_pool, "SELECT kind FROM billing_notifications WHERE family_id = %s", (pg_family,))
+
+
+def test_webhook_failure_rolls_back_dedup_and_retries(parent, service, pg_pool, pg_family):
+    import stripe
+    start(service, pg_pool, pg_family)
+    subscription(service, pg_family)
+    listing = service.client.v1.subscriptions.list.side_effect
+    service.client.v1.subscriptions.list.side_effect = stripe.APIConnectionError("private billing details")
+    assert webhook(parent, service, pg_family).status_code == 503
+    assert not sql(pg_pool, "SELECT event_id FROM stripe_events WHERE family_id = %s", (pg_family,))
+    service.client.v1.subscriptions.list.side_effect = listing
+    assert webhook(parent, service, pg_family).status_code == 204
+    assert state(pg_pool, pg_family)["status"] == "active"
+
+
+def test_webhook_requires_signature_correct_mode_and_size(parent, service, pg_pool, pg_family):
+    start(service, pg_pool, pg_family)
+    subscription(service, pg_family)
+    plain = FlaskClient(parent.application, parent.application.response_class)
+    assert plain.post("/stripe/webhook", data=b"{}").status_code == 400
+    assert webhook(plain, service, pg_family, livemode=True).status_code == 400
+    assert webhook(plain, service, pg_family, account="acct_other").status_code == 400
+    assert plain.post("/stripe/webhook", data=b" " * (256 * 1024 + 1)).status_code == 413
+    assert state(pg_pool, pg_family)["status"] == "trialing"
+    assert webhook(plain, service, pg_family).status_code == 204  # No session or CSRF needed here alone.
+
+
+@pytest.mark.parametrize("path", ["checkout", "portal", "sync"])
+def test_payment_actions_require_session_and_csrf(parent, service, pg_pool, pg_family, path):
+    plain = FlaskClient(parent.application, parent.application.response_class)
+    assert plain.post("/settings/billing/" + path).status_code == 400
+    anonymous = client_for(parent.application)
+    assert anonymous.post("/settings/billing/" + path).location.endswith("/login")
+    assert anonymous.get("/settings/billing").location.endswith("/login")
+    assert not service.client.customers
+
+
+def test_portal_customer_comes_only_from_session(parent, service, pg_pool, pg_family):
+    start(service, pg_pool, pg_family)
+    result = parent.post("/settings/billing/portal", data={"customer": "cus_someone_else"})
+    assert result.status_code == 303
+    assert service.client.v1.billing_portal.sessions.create.call_args.args[0] == {
+        "customer": "cus_" + str(pg_family), "configuration": "bpc_example",
+        "return_url": "https://app.example.com/settings/billing",
+    }
+
+
+def test_failed_payment_grace_is_not_extended_by_duplicate_events(parent, service, pg_pool, pg_family):
+    start(service, pg_pool, pg_family)
+    now = int(time.time())
+    remote = subscription(service, pg_family, "past_due", latest_invoice={"id": "in_unpaid", "created": now})
+    assert webhook(parent, service, pg_family).status_code == 204
+    assert not lifecycle.access_for(pg_pool, pg_family).ended
+    deadline = state(pg_pool, pg_family)["billing_access_until"]
+    assert deadline == billing.timestamp(now) + timedelta(days=7)
+    assert webhook(parent, service, pg_family, "evt_retry", "invoice.payment_failed").status_code == 204
+    assert state(pg_pool, pg_family)["billing_access_until"] == deadline
+    remote["latest_invoice"]["created"] = now - 8 * 86400
+    assert webhook(parent, service, pg_family, "evt_late").status_code == 204
+    assert lifecycle.access_for(pg_pool, pg_family).ended
+    remote["status"] = "active"
+    assert webhook(parent, service, pg_family, "evt_recovered").status_code == 204
+    assert not lifecycle.access_for(pg_pool, pg_family).ended
+
+
+def test_deadline_enforced_without_webhook_or_worker(service, pg_pool, pg_family):
+    from worker import family_ids
+    sql(pg_pool, """UPDATE families SET status = 'active',
+        billing_access_until = now() - interval '1 day' WHERE id = %s""", (pg_family,))
+    before = lifecycle.access_for(pg_pool, pg_family)
+    assert before.ended and pg_family not in family_ids(pg_pool)
+    lifecycle.expire_trials(pg_pool)
+    assert lifecycle.access_for(pg_pool, pg_family).lapsed_at == before.lapsed_at
+
+
+def test_delete_stops_stripe_before_erasing_family(parent, service, pg_pool, pg_family):
+    start(service, pg_pool, pg_family)
+    subscription(service, pg_family)
+    assert parent.post("/settings/account", data={"confirm": "parent@example.com"}).status_code == 302
+    assert service.client.customers["cus_" + str(pg_family)]["deleted"]
+    assert not sql(pg_pool, "SELECT id FROM families WHERE id = %s", (pg_family,))
+    assert not sql(pg_pool, "SELECT family_id FROM billing_checkouts WHERE family_id = %s", (pg_family,))
+    assert webhook(parent, service, pg_family).status_code == 204
+    assert not sql(pg_pool, "SELECT id FROM families WHERE id = %s", (pg_family,))
+
+
+def test_delete_failure_keeps_account_and_can_retry(parent, service, pg_pool, pg_family):
+    import stripe
+    start(service, pg_pool, pg_family)
+    service.client.v1.customers.delete.side_effect = stripe.APIConnectionError("private billing details")
+    result = parent.post("/settings/account", data={"confirm": "parent@example.com"}, follow_redirects=True)
+    assert b"account has been kept" in result.data
+    assert b"private billing details" not in result.data
+    assert state(pg_pool, pg_family)
+    service.client.customers["cus_" + str(pg_family)]["deleted"] = True  # Remote success, lost response.
+    assert accounts.delete_family(pg_pool, pg_family, billing=service)
+
+
+def test_notifications_retry_dedup_and_recheck_relevance(parent, service, pg_pool, pg_family, monkeypatch):
+    sql(pg_pool, "UPDATE families SET trial_ends_at = now() + interval '2 days' WHERE id = %s", (pg_family,))
+    sender = Mock(side_effect=mail.MailError("offline"))
+    monkeypatch.setattr(mail, "send", sender)
+    billing.housekeeping(pg_pool, service)
+    assert sender.call_count == 1
+    billing.housekeeping(pg_pool, service)
+    assert sender.call_count == 1  # Backoff, no duplicated queue entry.
+    sql(pg_pool, "UPDATE billing_notifications SET retry_at = now() WHERE family_id = %s", (pg_family,))
+    sender.side_effect = None
+    billing.housekeeping(pg_pool, service)
+    assert sender.call_count == 2
+    assert sender.call_args.args[0] == "parent@example.com"
+    assert "https://app.example.com/settings/billing" in sender.call_args.args[2]
+    billing.housekeeping(pg_pool, service)
+    assert sender.call_count == 2
+    start(service, pg_pool, pg_family)
+    remote = subscription(service, pg_family, "past_due")
+    webhook(parent, service, pg_family)
+    remote["status"] = "active"
+    webhook(parent, service, pg_family, "evt_recovery")
+    billing.deliver_notifications(pg_pool, service.origin)
+    assert sender.call_count == 2  # Recovery made the unsent failure mail stale.
+
+
+@pytest.mark.parametrize("kind", ["payment_failed", "cancellation_scheduled", "subscription_ended"])
+def test_required_subscription_notifications(parent, service, pg_pool, pg_family, monkeypatch, kind):
+    start(service, pg_pool, pg_family)
+    changes = {"status": "past_due"} if kind == "payment_failed" else (
+        {"cancel_at_period_end": True} if kind == "cancellation_scheduled" else {"status": "canceled"})
+    subscription(service, pg_family, **changes)
+    webhook(parent, service, pg_family)
+    sender = Mock()
+    monkeypatch.setattr(mail, "send", sender)
+    billing.deliver_notifications(pg_pool, service.origin)
+    assert sender.call_count == 1
+    webhook(parent, service, pg_family, "evt_duplicate_object")
+    billing.deliver_notifications(pg_pool, service.origin)
+    assert sender.call_count == 1
+
+
+def test_missing_configuration_disables_checkout_but_not_account(parent, service, pg_pool, pg_family):
+    service.automatic_tax = None  # Tax treatment must be an explicit operator choice.
+    page = parent.get("/settings/billing")
+    assert page.status_code == 200 and b"not available yet" in page.data
+    result = parent.post("/settings/billing/checkout", data={"interval": "year"}, follow_redirects=True)
+    assert b"not available yet" in result.data
+    assert not service.client.customers
+    assert parent.get("/settings/account/export").status_code == 200
+
+
+def test_portal_must_support_cancellation_before_customer_created(service, pg_pool, pg_family):
+    portal = service.client.v1.billing_portal.configurations.retrieve.return_value
+    portal["features"]["subscription_cancel"]["enabled"] = False
+    with pytest.raises(billing.BillingError, match="being set up"):
+        start(service, pg_pool, pg_family)
+    assert not service.client.customers
+
+
+def test_portal_with_no_update_products_is_unavailable(service):
+    portal = service.client.v1.billing_portal.configurations.retrieve.return_value
+    portal["features"]["subscription_update"]["products"] = None
+    with pytest.raises(billing.BillingError, match="being set up"):
+        service.check_portal(service.prices())
+
+
+def test_billing_migration_preserves_existing_trials_and_paid_accounts(pg_pool):
+    from dinkydash import db
+    with pg_pool.connection() as conn, conn.transaction(force_rollback=True), conn.cursor() as cur:
+        cur.execute("CREATE SCHEMA billing_migration_test")
+        cur.execute("SET LOCAL search_path TO billing_migration_test, public")
+        upgrade = db.MIGRATIONS_DIR / "006_billing.sql"
+        for path in db.migrations():
+            if path == upgrade:
+                break
+            cur.execute(path.read_text())
+        cur.execute("""INSERT INTO families (screen_token, status, stripe_customer_id)
+                       VALUES ('legacy-trial', 'trialing', NULL),
+                              ('legacy-paid', 'active', 'cus_legacy_example'),
+                              ('legacy-ended', 'lapsed', NULL)""")
+        cur.execute("SELECT id, status, trial_ends_at, stripe_customer_id, lapsed_at FROM families ORDER BY id")
+        original = cur.fetchall()
+        cur.execute(upgrade.read_text())
+        cur.execute("SELECT id, status, trial_ends_at, stripe_customer_id, lapsed_at FROM families ORDER BY id")
+        assert cur.fetchall() == original
+        cur.execute("SELECT billing_access_until, subscription_cancel_at FROM families")
+        assert cur.fetchall() == [(None, None)] * 3
+
+
+def test_automatic_tax_requires_active_setup(service, pg_pool, pg_family):
+    service.automatic_tax = True
+    service.client.v1.tax.settings.retrieve.return_value = sdk({"status": "pending"})
+    with pytest.raises(billing.BillingError, match="tax setup"):
+        start(service, pg_pool, pg_family)
+    assert not service.client.customers
+    service.client.v1.tax.settings.retrieve.return_value = sdk({"status": "active"})
+    start(service, pg_pool, pg_family)
+    assert service.client.v1.checkout.sessions.create.call_args.args[0]["automatic_tax"] == {"enabled": True}
+
+
+@pytest.mark.parametrize("changes", [
+    {"currency": "eur"}, {"unit_amount": None}, {"active": False},
+    {"tax_behavior": "unspecified"}, {"recurring": {"interval": "week"}},
+])
+def test_unsupported_prices_are_not_offered(service, changes):
+    def changed_price(pid):
+        price = service.client.price(pid).to_dict()
+        price.update(changes)
+        return sdk(price)
+    service.client.v1.prices.retrieve.side_effect = changed_price
+    with pytest.raises(billing.BillingError, match="pricing is being updated"):
+        service.prices()
+
+
+def test_real_sdk_serializes_checkout_and_normalizes_resources(service):
+    import stripe
+    from urllib.parse import parse_qs
+    class Transport(stripe.HTTPClient):
+        name = "test"
+        def request(self, method, url, headers, post_data=None, **kwargs):
+            assert method == "post" and url == "https://api.stripe.com/v1/checkout/sessions"
+            assert headers["Stripe-Version"] == stripe.api_version
+            assert headers["Idempotency-Key"] == "saved-attempt"
+            data = parse_qs(post_data)
+            assert data["automatic_tax[enabled]"] == ["true"]
+            assert data["line_items[0][price]"] == ["price_year_example"]
+            return json.dumps({"id": "cs_example", "object": "checkout.session",
+                               "status": "open", "url": "https://checkout.stripe.com/example"}), 200, {}
+    service._client = stripe.StripeClient("sk_test_example", http_client=Transport(), max_network_retries=0)
+    session = service.call(service.client.v1.checkout.sessions.create, {
+        "mode": "subscription", "automatic_tax": {"enabled": True},
+        "line_items": [{"price": "price_year_example", "quantity": 1}],
+    }, options={"idempotency_key": "saved-attempt"})
+    assert session.get("status") == "open"
+
+
+def test_old_or_modified_signatures_fail_before_database_access(service):
+    import stripe
+    raw = b'{"id":"evt_example","object":"event","type":"invoice.paid"}'
+    stamp = str(int(time.time()) - 600)
+    digest = hmac.new(service.webhook_secret.encode(), stamp.encode() + b"." + raw, hashlib.sha256).hexdigest()
+    with pytest.raises(stripe.SignatureVerificationError):
+        service.event(None, raw, f"t={stamp},v1={digest}")
+    with pytest.raises(stripe.SignatureVerificationError):
+        service.event(None, raw + b" ", f"t={stamp},v1={digest}")
+
+
+def test_parallel_deliveries_only_apply_one_event(parent, service, pg_pool, pg_family):
+    start(service, pg_pool, pg_family)
+    subscription(service, pg_family, "past_due")
+    service.client.v1.subscriptions.list.reset_mock()
+    def deliver(_):
+        return webhook(parent.application.test_client(), service, pg_family).status_code
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        assert list(executor.map(deliver, range(2))) == [204, 204]
+    assert service.client.v1.subscriptions.list.call_count == 1
+    assert len(sql(pg_pool, "SELECT notice_key FROM billing_notifications WHERE family_id = %s", (pg_family,))) == 1
+
+
+def test_cancellation_deadline_precedes_payment_grace(parent, service, pg_pool, pg_family):
+    start(service, pg_pool, pg_family)
+    end = int(time.time()) + 86400
+    subscription(service, pg_family, "past_due", cancel_at=end)
+    webhook(parent, service, pg_family)
+    row = state(pg_pool, pg_family)
+    assert row["billing_access_until"] == row["subscription_cancel_at"] == billing.timestamp(end)
+
+
+def test_worker_recovers_missing_webhook_and_export_excludes_checkout_credentials(parent, service, pg_pool, pg_family, monkeypatch):
+    monkeypatch.setattr(mail, "send", Mock())
+    start(service, pg_pool, pg_family)
+    subscription(service, pg_family)
+    sql(pg_pool, "UPDATE families SET billing_synced_at = NULL WHERE id = %s", (pg_family,))
+    billing.housekeeping(pg_pool, service)
+    assert state(pg_pool, pg_family)["status"] == "active"
+    export = parent.get("/settings/account/export").get_json()
+    assert export["family"]["stripe_subscription_id"] == "sub_example"
+    assert "checkout.stripe.com" not in json.dumps(export)
+    assert "cs_example" not in json.dumps(export)
+
+
+def test_single_mode_never_imports_stripe(monkeypatch, tmp_path):
+    import builtins
+    from dinkydash.store import FileStore
+    original = builtins.__import__
+    def refuse(name, *args, **kwargs):
+        if name == "stripe" or name.startswith("stripe."):
+            raise AssertionError("A self-hoster imported Stripe")
+        return original(name, *args, **kwargs)
+    monkeypatch.setattr(builtins, "__import__", refuse)
+    monkeypatch.setenv("DINKYDASH_MODE", "single")
+    app = create_app(FileStore(tmp_path / "config.yaml"))
+    client = app.test_client()
+    assert client.get("/settings/billing").status_code == 404
+    assert client.get("/stripe/webhook").status_code == 404
+    assert all(rule.endpoint != "billing.webhook" for rule in app.url_map.iter_rules())

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -65,6 +65,11 @@ def create_app(store=None, *, pool=None):
         from .routes.screen import bp as screen_bp
         app.register_blueprint(screen_bp)
 
+        from dinkydash.billing import Billing
+        from .routes.billing import bp as billing_bp
+        app.config["BILLING"] = Billing.from_env()
+        app.register_blueprint(billing_bp)
+
         from dinkydash.pgstore import NoSuchFamily
 
         @app.errorhandler(NoSuchFamily)

--- a/web/routes/billing.py
+++ b/web/routes/billing.py
@@ -1,0 +1,77 @@
+"""Signed-in payment actions and the one independently signed Stripe endpoint."""
+
+from flask import Blueprint, abort, current_app, flash, redirect, render_template, request, url_for
+
+from dinkydash.billing import BillingError, family
+from web.family import current_family_id
+from web.session import guard
+
+bp = Blueprint("billing", __name__)
+
+
+@bp.before_request
+def authenticate():
+    if request.endpoint != "billing.webhook":
+        return guard()
+
+
+@bp.after_request
+def private(response):
+    response.headers["Cache-Control"] = "no-store"
+    return response
+
+
+@bp.errorhandler(BillingError)
+def unavailable(exc):
+    flash(str(exc), "error")
+    return redirect(url_for("billing.home"))
+
+
+@bp.get("/settings/billing")
+def home():
+    with current_app.config["POOL"].connection() as conn, conn.cursor() as cur:
+        row = family(cur, current_family_id())
+    prices, error = {}, None
+    try:
+        prices = current_app.config["BILLING"].prices()
+    except BillingError as exc:
+        error = str(exc)
+    return render_template("settings/billing.html", account=row, prices=prices, error=error,
+                           returned=request.args.get("checkout") == "returned")
+
+
+@bp.post("/settings/billing/checkout")
+def checkout():
+    target = current_app.config["BILLING"].checkout(
+        current_app.config["POOL"], current_family_id(), request.form.get("interval"),
+    )
+    return redirect(target, code=303)
+
+
+@bp.post("/settings/billing/portal")
+def portal():
+    target = current_app.config["BILLING"].portal(current_app.config["POOL"], current_family_id())
+    return redirect(target, code=303)
+
+
+@bp.post("/settings/billing/sync")
+def sync():
+    current_app.config["BILLING"].sync(current_app.config["POOL"], current_family_id())
+    return redirect(url_for("billing.home"))
+
+
+@bp.post("/stripe/webhook")
+def webhook():
+    # A distinct endpoint exemption in check_csrf preserves the unparsed bytes.
+    # Payment data is neither logged nor retained; the event id is enough.
+    request.max_content_length = 256 * 1024
+    import stripe
+    try:
+        current_app.config["BILLING"].event(
+            current_app.config["POOL"], request.get_data(), request.headers.get("Stripe-Signature", ""),
+        )
+    except (ValueError, stripe.SignatureVerificationError):
+        abort(400)
+    except BillingError:
+        return "Please retry", 503
+    return "", 204

--- a/web/routes/settings.py
+++ b/web/routes/settings.py
@@ -751,7 +751,9 @@ def _family_facts():
     """The platform's own bookkeeping about a family, for the export."""
     with current_app.config["POOL"].connection() as conn, conn.cursor() as cur:
         cur.execute(
-            """SELECT plan, status, trial_ends_at, created_at, lapsed_at
+            """SELECT plan, status, trial_ends_at, created_at, lapsed_at,
+                      stripe_customer_id, stripe_subscription_id, subscription_status,
+                      subscription_period_end, subscription_cancel_at, billing_access_until
                FROM families WHERE id = %s""",
             (current_family_id(),),
         )
@@ -762,7 +764,9 @@ def _family_facts():
     # to somebody, saved to a downloads folder and forgotten; a live credential
     # should not ride along in one. It is on the screen page, where it can be
     # rotated in the same breath as being read.
-    return dict(zip(("plan", "status", "trial_ends_at", "created_at", "lapsed_at"), row))
+    return dict(zip(("plan", "status", "trial_ends_at", "created_at", "lapsed_at",
+                     "stripe_customer_id", "stripe_subscription_id", "subscription_status",
+                     "subscription_period_end", "subscription_cancel_at", "billing_access_until"), row))
 
 
 def delete_account():
@@ -783,7 +787,12 @@ def delete_account():
         flash("Type the email address on this account to confirm.", "error")
         return redirect(url_for("settings.account"))
 
-    accounts.delete_family(pool, current_family_id())
+    from dinkydash.billing import BillingError
+    try:
+        accounts.delete_family(pool, current_family_id(), billing=current_app.config["BILLING"])
+    except BillingError:
+        flash("We could not stop your billing, so your account has been kept. Please try again later.", "error")
+        return redirect(url_for("settings.account"))
     session_module.sign_out()
     return redirect(url_for("auth.login", deleted=1))
 

--- a/web/session.py
+++ b/web/session.py
@@ -147,6 +147,9 @@ def check_csrf():
     """
     if request.method in SAFE_METHODS:
         return None
+    if request.endpoint == "billing.webhook":
+        # Cloud-only route; authenticates the raw body with Stripe's signature.
+        return None
     held = session.get(CSRF_KEY) or ""
     sent = request.form.get(CSRF_FIELD) or request.headers.get("X-CSRF-Token") or ""
     # Compared as bytes, and not for tidiness: `compare_digest` raises

--- a/web/templates/settings/account.html
+++ b/web/templates/settings/account.html
@@ -57,8 +57,12 @@
             names and interests go to Claude so it can write the headline and the one line.
         </div>
         <div class="hint">
-            <strong>SendGrid</strong> sees who is signing in, and nothing else — your address
-            and the link, never a calendar.
+            <strong>SendGrid</strong> delivers sign-in links and subscription notices using your
+            email address. It never receives a calendar.
+        </div>
+        <div class="hint">
+            <strong>Stripe</strong> handles billing when you choose a subscription. It receives
+            your billing details, never your calendars or family details.
         </div>
         <div class="hint">
             The full list is in the <a href="https://dinkydash.co/privacy/">privacy policy</a>.
@@ -73,6 +77,8 @@
             This removes your family, this account, your calendar links, the stored agenda and
             every written line. <strong>Every screen showing your board stops working.</strong>
             It cannot be undone, and we cannot get it back for you.
+            Any subscription is cancelled immediately before your account is removed.
+            Stripe may retain payment records; see the privacy policy for details.
         </div>
         <form method="post" style="display:flex;flex-direction:column;gap:0.875rem;">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">

--- a/web/templates/settings/billing.html
+++ b/web/templates/settings/billing.html
@@ -1,0 +1,61 @@
+{% extends "settings/base.html" %}
+{% import "settings/_icons.html" as icons %}
+{% block title %}Subscription{% endblock %}
+{% block appbar %}
+<a class="back" href="{{ url_for('settings.home') }}">{{ icons.back() }}</a>
+<h1>Subscription</h1>
+{% endblock %}
+{% block content %}
+{% if returned %}
+<div class="note-box">Thanks for visiting Checkout. Payment confirmation can take a moment; your current access is shown below.</div>
+{% endif %}
+<div class="card pad" style="display:flex;flex-direction:column;gap:0.875rem;">
+    {% if account.status == 'trialing' and account.trial_ends_at > account.now %}
+    <strong>Your free trial ends {{ account.trial_ends_at.strftime('%-d %B %Y') }}</strong>
+    <div class="hint">No card is needed for the trial. You will only be charged if you choose a subscription.</div>
+    {% elif account.status == 'lapsed' or (account.billing_access_until and account.billing_access_until <= account.now) or account.status == 'trialing' %}
+    <strong>Board updates are paused</strong>
+    <div class="hint">Your trial or subscription has ended. You can restart below, or manage an existing subscription.</div>
+    {% elif account.status == 'past_due' %}
+    <strong>Your payment needs attention</strong>
+    <div class="hint">Update your payment method in Manage subscription. Board updates pause on {{ account.billing_access_until.strftime('%-d %B %Y') }} if payment is still unpaid.</div>
+    {% elif account.subscription_cancel_at %}
+    <strong>Cancels {{ account.subscription_cancel_at.strftime('%-d %B %Y') }}</strong>
+    <div class="hint">Your board keeps updating until then. You can undo cancellation in Manage subscription.</div>
+    {% else %}
+    <strong>Your subscription is active</strong>
+    {% if account.subscription_period_end %}<div class="hint">Current billing period ends {{ account.subscription_period_end.strftime('%-d %B %Y') }}.</div>{% endif %}
+    {% endif %}
+    {% if account.stripe_customer_id %}
+    <form method="post" action="{{ url_for('billing.portal') }}">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+        <button class="btn" type="submit">Manage subscription</button>
+    </form>
+    <div class="hint">Change billing frequency, update your card, view invoices or cancel through Stripe.</div>
+    <form method="post" action="{{ url_for('billing.sync') }}">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+        <button class="btn outline" type="submit">Check payment status</button>
+    </form>
+    {% endif %}
+</div>
+
+{% if error %}<div class="note-box">{{ error }}</div>{% endif %}
+{% if not account.stripe_subscription_id or account.subscription_status in ['canceled', 'incomplete_expired'] %}
+<div>
+    <div class="label">One plan for your family</div>
+    <div class="card pad" style="display:flex;flex-direction:column;gap:0.875rem;">
+        <div class="hint">All your people, calendars, chores, countdowns and screens are included.</div>
+        {% for interval in ['year', 'month'] if interval in prices %}
+        <form method="post" action="{{ url_for('billing.checkout') }}">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+            <input type="hidden" name="interval" value="{{ interval }}">
+            <button class="btn {{ 'outline' if interval == 'month' }}" type="submit">{{ prices[interval].amount }} / {{ interval }}</button>
+            <div class="hint" style="margin-top:0.375rem;">USD. {{ 'Tax included where applicable.' if prices[interval].tax_included else 'Applicable tax is shown at Checkout.' }}</div>
+        </form>
+        {% endfor %}
+        <div class="hint">A subscription starts when you pay, including during your free trial, and renews automatically. Cancel in Manage subscription to stop the next renewal. An unfinished Checkout is reused for up to an hour.</div>
+    </div>
+</div>
+{% endif %}
+<div class="hint">Stripe receives your billing details when you choose to pay. Your calendars and family details stay out of Stripe. Read our <a href="https://dinkydash.co/privacy/">privacy policy</a> and <a href="https://dinkydash.co/terms/">terms</a>.</div>
+{% endblock %}

--- a/web/templates/settings/home.html
+++ b/web/templates/settings/home.html
@@ -144,6 +144,12 @@
 <div>
     <div class="label">Your account</div>
     <div class="card">
+        <a class="row" href="{{ url_for('billing.home') }}">
+            <div class="row-main">
+                <div class="row-title">Subscription</div>
+                <div class="row-sub">Your trial, payments and cancellation</div>
+            </div>{{ icons.chevron() }}
+        </a>
         <a class="row" href="{{ url_for('settings.account') }}">
             <div class="row-main">
                 <div class="row-title">Your data</div>

--- a/website/content/privacy.md
+++ b/website/content/privacy.md
@@ -33,6 +33,7 @@ either something you typed or something the software produced.
 | **The written line** | Written by Claude each morning | The board's headline and note |
 | **Sign-in links** | Generated when you ask for one | Hashed, never stored as a working link |
 | **Counts of model calls** | Recorded when the board is written | So one account cannot run up an unbounded bill |
+| **Subscription records** | Stripe, after you choose to pay | Customer/subscription identifiers, payment status, renewal and cancellation dates; no card details |
 
 **We do not use cookies for tracking.** The hosted app sets one cookie, and it
 is the session that keeps you signed in. There is no analytics on
@@ -42,8 +43,7 @@ Analytics, which is cookieless and collects no personal data.
 
 ## Where it goes
 
-Two things leave our servers, they are different in kind, and it matters which
-is which.
+The services below receive only what they need for their part of the app.
 
 **Anthropic sees your family's day.** Once each morning the day's agenda — the
 event titles and times, your family's names and interests — is sent to
@@ -51,9 +51,16 @@ Anthropic so Claude can write the headline and the one written line. That is
 the feature. Nothing else about you is sent, and it is not used to train
 models.
 
-**SendGrid sees who is signing in, and nothing else.** When you ask for a sign-in
-link, your email address and the link go to SendGrid to be delivered. SendGrid
-never sees a calendar, a name or a date of birth.
+**SendGrid delivers sign-in links and subscription notices.** Your email address,
+sign-in link or trial/payment/cancellation notice goes to SendGrid for delivery.
+It never receives your calendars, family names or dates of birth.
+
+**Stripe handles payments when you choose a subscription.** Starting Checkout
+creates a Stripe customer with an internal account identifier. You enter your
+billing email, name, address and payment details directly on Stripe's pages.
+We receive subscription status and identifiers, not your card details. Your
+calendars and family details are never sent to Stripe. Signing up for the free
+trial does not create a Stripe customer.
 
 If you would rather Anthropic saw nothing, self-host: the board works with no
 API key at all, and simply goes without the written line.
@@ -64,7 +71,8 @@ API key at all, and simply goes without the written line.
 |---|---|---|
 | **Anthropic** | Writes the daily line from the day's agenda | United States |
 | **DigitalOcean** | Runs the app and the database | Frankfurt, Germany (US company) |
-| **SendGrid** (Twilio) | Delivers sign-in emails | United States |
+| **SendGrid** (Twilio) | Delivers sign-in emails and subscription notices | United States |
+| **Stripe** | Processes subscriptions and payments when you choose to pay | See [Stripe's privacy policy](https://stripe.com/privacy) for its entities and international processing |
 | **Cloudflare** | DNS, and TLS at the edge | Global (US company) |
 
 The app and the database are in **Frankfurt**. DigitalOcean and Cloudflare are
@@ -74,9 +82,6 @@ by standard contractual clauses.
 **Google Fonts is not on this list, and that is deliberate.** The typeface is
 served from our own servers, so no page of DinkyDash — not the board, not the
 settings, not this site — asks Google for anything or tells them you were here.
-
-Payment processing will be added to this list when payment exists. It does not
-yet.
 
 ## How long it is kept
 
@@ -97,6 +102,11 @@ We would rather hold less, so most of this expires on its own.
 - **Daily totals of model calls across the service**: kept without an account
   identifier, including after account deletion, so deleting an account does not
   reset the service's spending limit. These totals contain only a date and count.
+- **Our subscription records, processed payment-event identifiers and notification
+  delivery records**: kept while the account exists and deleted with it. We do
+  not store webhook bodies or copies of your billing address or card details.
+  Stripe keeps its own payment records under its [privacy policy](https://stripe.com/privacy),
+  including records it needs to meet legal obligations.
 
 After your trial or subscription ends, the screen shows the last saved board
 with an ended-access message for 30 days, then only the message. This changes
@@ -116,6 +126,9 @@ Both are buttons, not requests, and both are on your settings page.
 - **Delete** removes your family, your account, your calendar links, the stored
   agenda, every written line and every sign-in link. It cannot be undone and we
   cannot restore it for you.
+  If you have started billing, deletion first cancels your subscriptions and
+  deletes the Stripe customer. If Stripe cannot confirm this, we keep the account
+  and ask you to retry, so billing is not left running without an account.
 
 You also have the right to correct what we hold — which the settings page does
 directly — to object to processing, and to ask for your data in a portable form,

--- a/website/content/terms.md
+++ b/website/content/terms.md
@@ -63,9 +63,18 @@ run it, change it, run it for other people.
 **The first fourteen days are free and we do not ask for a card.** After that
 the hosted service is $39 a year, or $6 a month if you would rather.
 
-Payment is not built yet. Until it is, nobody is charged anything and nothing
-is collected. When it arrives, this section will say who processes it and these
-terms will be updated before it takes effect.
+When subscriptions are available in your settings, Stripe processes the payment.
+You choose a billing period and see the final total, including any applicable tax,
+in Checkout before paying. A subscription starts when you pay, including during
+the free trial, and renews automatically for the billing period you chose.
+Use **Settings → Subscription → Manage subscription** to change billing frequency,
+update payment details, view invoices or cancel the next renewal. Cancellation
+keeps your access until the end of the current billing period.
+
+If a renewal payment fails, we email you and Stripe retries according to the
+payment recovery settings. Board updates pause seven days after the unpaid
+invoice was created, or sooner if the subscription ends. Successful payment
+restores access.
 
 When your trial or subscription ends, calendar fetches and new written briefs
 stop. The screen keeps the last saved board with an ended-access message for
@@ -77,6 +86,8 @@ or delete your data.
 **You can stop at any time.** Deleting your account is a button on your settings
 page, it takes effect immediately, and it removes your data — see the [privacy
 policy](/privacy/) for exactly what goes.
+Deleting an account also cancels its subscriptions immediately. To keep your
+remaining paid access, cancel the renewal through Manage subscription instead.
 
 We may end an account without notice if it is being used for something on the
 list above. Otherwise, if we ever have to close a paid account, you get thirty
@@ -103,8 +114,8 @@ statutory rights as a consumer, which these terms do not affect.
 
 The [privacy policy](/privacy/) is part of these terms. The short version: your
 family's day goes to Anthropic each morning so Claude can write a line, your
-email address goes to SendGrid so a sign-in link can be delivered, and nothing
-is sold to anybody.
+email address goes to SendGrid for sign-in links and subscription notices, and
+Stripe receives billing details when you choose to pay. Nothing is sold to anybody.
 
 ## Changes
 

--- a/worker/__init__.py
+++ b/worker/__init__.py
@@ -73,6 +73,7 @@ def family_ids(pool):
             """SELECT id FROM families
                WHERE status <> 'lapsed'
                  AND (status <> 'trialing' OR trial_ends_at > now())
+                 AND (billing_access_until IS NULL OR billing_access_until > now())
                ORDER BY created_at""")
         return [row[0] for row in cur.fetchall()]
 
@@ -161,13 +162,14 @@ def main():  # pragma: no cover - the loop itself; tick_all is what is tested
         format="%(asctime)s [%(levelname)s] %(message)s",
     )
 
-    from dinkydash import db, lifecycle
+    from dinkydash import billing, db, lifecycle
 
     stopping = Stopping()
     signal.signal(signal.SIGTERM, stopping.request)
     signal.signal(signal.SIGINT, stopping.request)
 
     pool = db.pool()
+    payments = billing.Billing.from_env()
     every = interval()
     log.info("Worker started; a pass every %s seconds.", every)
 
@@ -176,12 +178,17 @@ def main():  # pragma: no cover - the loop itself; tick_all is what is tested
         try:
             expired = lifecycle.expire_trials(pool)
             if expired:
-                log.info("Ended %s expired trial(s).", expired)
+                log.info("Expired %s account access deadline(s).", expired)
         except Exception:
             # Callers still check the deadline themselves if housekeeping fails.
             log.exception("Could not mark expired trials; retrying next pass.")
         ticked = tick_all(pool, stopping=stopping)
         swept = sweep_logins(pool)
+        try:
+            billing.housekeeping(pool, payments)
+        except Exception:
+            # Stripe/SendGrid exception strings can carry personal billing data.
+            log.warning("Billing housekeeping failed; retrying next pass.")
         log.info("Pass complete: %s families ticked in %.1fs; %s dead login "
                  "token(s) deleted.", ticked, time.monotonic() - started, swept)
 


### PR DESCRIPTION
Hosted families can convert their trial to a paid subscription through Stripe Checkout and manage or cancel billing in the Customer Portal; account deletion stops Stripe billing before removing local data.

Signed webhooks and worker reconciliation enforce paid access, payment grace and cancellation deadlines, and queue lifecycle emails.

Validation: 1,626 tests with PostgreSQL, 1,149 without a database, green CI, and real sandbox signup, Checkout, plan changes, manual card updates, failed renewal/recovery, cancellation, duplicate/older webhooks and account deletion.

Live payments remain gated by production configuration, tax verification and actual email-delivery checks.
