### PR TITLE
Add worker heartbeats and a verified isolated restore drill

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,3 +56,8 @@ ANTHROPIC_API_KEY=
 # running away.
 # DINKYDASH_GLOBAL_CALL_FLOOR=50
 # DINKYDASH_GLOBAL_CALLS_PER_FAMILY=4
+
+# Optional worker liveness ping, sent only after a completed hosted worker pass.
+# This is a credential: keep it private. Configure the external check/alerts too.
+# Default cadence: 10-minute expected period + 10-minute grace (doc/monitoring.md).
+DINKYDASH_WORKER_HEARTBEAT_URL=

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,6 +61,14 @@ jobs:
       # either — a Pi has no database and should not carry a driver for one.
       - run: pip install -r requirements-dev.txt -r requirements-cloud.txt
 
+      # The restore drill creates its own socket-only cluster as the runner
+      # user. Match the production major; Ubuntu's default client is older.
+      - name: Install PostgreSQL 17 restore tools
+        run: |
+          sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y
+          printf 'create_main_cluster = false\n' | sudo tee /etc/postgresql-common/createcluster.conf > /dev/null
+          sudo apt-get install --yes postgresql-17
+
       # The password is the service container's own, invented above and
       # reachable only from this job — but it goes in PGPASSWORD rather than
       # inline in the URL, because `user:pass@host` is the shape a secret
@@ -69,6 +77,7 @@ jobs:
         env:
           PGPASSWORD: dinkydash
           DINKYDASH_TEST_DATABASE_URL: postgresql://dinkydash@localhost:5432/dinkydash_test
+          DINKYDASH_TEST_PG_BIN: /usr/lib/postgresql/17/bin
         run: python -m pytest tests/ -q
 
       # The suite a self-hoster actually runs: no database, no psycopg. The

--- a/PLAN.md
+++ b/PLAN.md
@@ -307,7 +307,13 @@ PR #86 uses `pg_advisory_xact_lock` for token issuance: the lock belongs to the 
 transaction. It does not introduce a session-scoped lock or require session pooling.
 
 Managed backups are documented in operations; the independent restore drill remains
-[DIN-56](https://linear.app/keepthescore/issue/DIN-56). Worker liveness alerts remain MVP work ([DIN-54](https://linear.app/keepthescore/issue/DIN-54));
+[DIN-56](https://linear.app/keepthescore/issue/DIN-56)'s responsibility. `ops.restore_drill` now restores a read-only
+logical backup into a disposable socket-only PostgreSQL instance, verifies scoped reads and app startup
+with outbound calls blocked, and removes the scratch data. A managed-source drill passed on 9 September;
+[doc/recovery.md](doc/recovery.md) defines the monthly cadence and failure procedure. Scheduling on the
+operator host still needs configuration. The drill also found an existing invalid screen token ([DIN-64](https://linear.app/keepthescore/issue/DIN-64)).
+The worker can send an empty HTTPS heartbeat after a completed pass; external liveness alerts and a
+delivery/recovery drill remain MVP work ([DIN-54](https://linear.app/keepthescore/issue/DIN-54), [doc/monitoring.md](doc/monitoring.md));
 Sentry instrumentation is Backlog ([DIN-35](https://linear.app/keepthescore/issue/DIN-35)).
 Cloud startup validates the session key and database configuration; model/email failures
 have their own runtime handling. Stripe credentials are not required before billing exists.
@@ -401,7 +407,7 @@ alone does not close the phase.
 - [x] Transactional email wired into signup/login ([DIN-36](https://linear.app/keepthescore/issue/DIN-36), [DIN-38](https://linear.app/keepthescore/issue/DIN-38)).
 - [ ] Sentry for web, worker and applicable frontend errors, with sensitive-data filtering ([DIN-35](https://linear.app/keepthescore/issue/DIN-35); Backlog).
 - [ ] Worker heartbeat and external health alerts, verified by a controlled failure ([DIN-54](https://linear.app/keepthescore/issue/DIN-54)).
-- [ ] Repeatable restore into an isolated database, with a successful drill recorded ([DIN-56](https://linear.app/keepthescore/issue/DIN-56)).
+- [x] Repeatable restore into an isolated database, with a successful drill recorded ([DIN-56](https://linear.app/keepthescore/issue/DIN-56)); monthly cadence defined, operator scheduler configuration pending.
 - [x] Preserve explicit preview database overrides ([DIN-48](https://linear.app/keepthescore/issue/DIN-48)).
 - [ ] Dedicated admin/registration analytics dashboard ([DIN-37](https://linear.app/keepthescore/issue/DIN-37); Backlog).
 

--- a/doc/monitoring.md
+++ b/doc/monitoring.md
@@ -1,0 +1,56 @@
+# Worker and web liveness
+
+The web service's `/healthz` says that its process can answer a request. It
+intentionally does not query Postgres or the worker, because App Platform uses
+it for deployment/restart decisions. Monitor it externally at
+`https://app.dinkydash.co/healthz`; an HTTP response outside 200–299, a timeout,
+or a TLS error must count as downtime. Use a one-minute check and a two-minute
+failure threshold, with both failure and recovery notifications.
+
+The worker sends an **empty HTTPS POST** after a completed pass when
+`DINKYDASH_WORKER_HEARTBEAT_URL` is configured. Store this URL as a secret: it
+may be a credential allowing someone to mask a stopped worker. Configure it on
+the worker component, not in family settings. No family ID, calendar URL,
+headline, exception text or count is sent to the monitor.
+
+For the default five-minute worker interval, configure the monitor with an
+expected period of **10 minutes and a 10-minute grace period**. This allows up
+to five minutes for a pass plus the normal five-minute sleep, and ten more
+minutes for a redeploy or transient delay. A pass that regularly takes longer
+requires capacity investigation and an explicit timeout adjustment. Keep this
+in sync if `DINKYDASH_WORKER_INTERVAL` changes.
+
+A heartbeat means every eligible family was considered. Handled calendar/model
+failures still count as a live worker; diagnosing those is separate from a
+stopped process (DIN-55). A database failure that aborts family enumeration or
+a shutdown that interrupts the pass sends no heartbeat. Ping failures log a
+sanitised warning and never stop future passes. Pings have a five-second HTTP
+timeout, no redirects, no environment proxy and no immediate retries.
+
+When the URL is absent, the worker starts normally and logs that missed passes
+cannot alert. When it is malformed, startup fails without printing its value.
+Installing the code is not the same as enabling an external alert.
+
+## Set up and prove the alerts
+
+1. Create a missed-heartbeat check with the period/grace above and an explicit
+   operator destination. Put its HTTPS ping URL in the worker's secret env var.
+2. Create a separate uptime check for the app's `/healthz` with the thresholds
+   above. Keep the external account/check IDs and recipient details in Linear.
+3. Create a **temporary independent test heartbeat** with a short period and
+   grace. Run an isolated test worker against synthetic data with model/email
+   credentials removed. After a completed pass, stop that test worker and wait
+   for the external failure notification; restart it and verify recovery.
+4. Test web downtime against an isolated endpoint, then recovery. Do not stop
+   the production worker or web service for either test.
+5. Record alert and recovery timestamps and the destination's receipt privately,
+   then delete or pause the temporary checks. A local HTTP stub proves request
+   formatting; it does not prove that an external notification arrives.
+
+No external monitoring account or destination is supplied by the repository.
+Do not mark DIN-54 complete until the configured checks and delivery drill have
+been recorded. See [recovery.md](recovery.md) for monthly restore monitoring.
+
+On 9 September 2026, both live `/healthz` endpoints returned HTTP 200 with
+`Cache-Control: no-store`. This is a point-in-time reachability check, not
+evidence of installed monitoring or notification delivery.

--- a/doc/recovery.md
+++ b/doc/recovery.md
@@ -1,0 +1,107 @@
+# Database recovery drills
+
+Run a restore drill on the **first day of each month at 07:00 UTC**, and after a
+PostgreSQL major upgrade or a change to migrations/storage. The operator owns the
+result: a non-zero exit or a missing monthly success is a failed drill requiring
+investigation that day. A backup policy alone is not evidence that the app can
+read restored data.
+
+## Run the drill
+
+Install the cloud requirements and PostgreSQL **17 server and client tools**.
+Use the same major as production. On macOS, `brew install postgresql@17` provides
+these under `/opt/homebrew/opt/postgresql@17/bin`; installing them need not start
+or replace the machine's existing PostgreSQL service. On Linux, pass the bin
+directory containing `initdb`, `pg_ctl`, `createdb`, `pg_dump` and `pg_restore`.
+Run as an ordinary user, not root.
+
+Supply the **direct** source connection in `DATABASE_URL_DIRECT` from the
+operator's private secret storage, then run:
+
+```bash
+python -m ops.restore_drill --pg-bin /opt/homebrew/opt/postgresql@17/bin
+```
+
+`--source-env NAME` selects a different environment variable. The tool never
+loads `.env` implicitly. It requires an explicit database name and refuses
+service indirection. Prefer a dedicated read-only source role with permission
+to dump the application's schema and data. Do not paste a connection string
+into a command argument, commit it, or put it in a CI log.
+
+There is **no target URL argument**. Every run creates a fresh local cluster
+under `/tmp`, in an owner-only directory. The cluster accepts only Unix socket
+connections from that directory; it has no TCP listener. A short
+`--scratch-parent` outside every repository can override `/tmp`. This cannot
+restore over an existing local or production database.
+
+The drill:
+
+1. Takes a fresh custom-format logical backup through a read-only source
+   session, with a bounded lock wait and connection timeout.
+2. Restores it into the newly created scratch database using `--no-owner`,
+   `--no-acl`, `--exit-on-error` and one transaction. The source's database name,
+   owners, grants and connection settings cannot redirect this restore.
+3. Applies any pending checked-out migrations **to the scratch copy only**,
+   checks migration records, and reads config, agenda, brief and recent history
+   through family-scoped stores for up to three restored families. An empty
+   source fails because there is no representative family to verify.
+4. Starts the real cloud WSGI dispatcher in-process, checks both hostnames,
+   renders the sampled boards and checks rejection of an unknown family.
+   All inherited app credentials are removed, model caps are zero, and Python
+   network connections and DNS are blocked. It never starts the worker, sends
+   a login request, or opens a browser to restored calendar URLs.
+5. Stops the scratch PostgreSQL server and removes the dump, connection service
+   file, server logs and restored data, including after normal failures and
+   SIGTERM. Success is reported only after cleanup succeeds.
+
+The report contains timestamps, counts and check results, never credentials,
+family identifiers or content. Keep even these reports in operator storage,
+not the public repository. Raw subprocess output is discarded: a PostgreSQL
+error can quote a connection string or an entire failed data row.
+
+A malformed stored screen token is counted separately in
+`sampled_invalid_screen_tokens`. Its scoped board must still render and its
+URL must still return 404. This is a source-data defect to investigate; do not
+rotate a production screen URL merely to make a drill green.
+
+## Schedule and failure reporting
+
+Use a private operator host with the source secret already available. A cron
+wrapper can load an owner-only environment file, change to the checked-out
+release and run the command above. Set the host's timezone to UTC or use a
+scheduler with an explicit UTC timezone. The cron expression is `0 7 1 * *`.
+Keep the report/log outside the checkout with mode 0600.
+
+Configure the external monitor to expect one successful monthly run (first of
+the month, 07:00 UTC), allowing a 24-hour grace period for maintenance. Send an
+empty success ping **only after exit 0**. The monitor must alert the operator
+if that ping is missing; a failed cron job must not report success. Test the
+alert destination before relying on it. The monitor/account destination is
+operator configuration, not a credential committed with this tool.
+
+On failure, retain the sanitised report, check tool/server version compatibility
+and source connectivity, then repeat the drill. Do not try a production restore
+as a troubleshooting step. If `pg_ctl` cannot stop the scratch server, the tool
+leaves its private directory in place and reports that path: stop that exact
+server before deleting the directory. After a machine crash or SIGKILL, check
+for `dinkydash-restore-*` directories under the chosen parent and remove them
+only after confirming their scratch server has stopped.
+
+This verifies a **fresh logical backup**, not DigitalOcean's managed
+point-in-time recovery interface, its retention, or a production cutover.
+It deliberately omits owner/ACL restoration. A disaster-recovery cutover also
+needs the managed cluster's roles/grants, application secrets, endpoint changes
+and a separately approved plan for reconciling deletions that postdate a backup.
+
+## Validation record — 9 September 2026
+
+A fresh read-only backup of the managed PostgreSQL 17 database was restored into
+an isolated PostgreSQL 17.11 instance. Schema checks, family-scoped reads, board
+rendering and cloud startup passed with outbound connections blocked. Cleanup
+completed. A legacy screen-token defect was recorded separately; production
+credentials and data were not changed. The detailed count/timing report lives
+with the DIN-56 issue, not in this repository.
+
+The monthly cadence and failure procedure are defined above. External scheduled
+execution and notification delivery still require the operator's monitoring
+configuration; this record does not claim a monthly job is already installed.

--- a/ops/__init__.py
+++ b/ops/__init__.py
@@ -1,0 +1,1 @@
+"""Operator tools; never imported by the board or worker."""

--- a/ops/restore_drill.py
+++ b/ops/restore_drill.py
@@ -1,0 +1,275 @@
+"""Restore a logical backup into a disposable, socket-only PostgreSQL cluster.
+
+Run with ``python -m ops.restore_drill --pg-bin /path/to/postgresql/bin``.
+The source comes from DATABASE_URL_DIRECT. No existing restore target is accepted.
+See doc/recovery.md for the isolation, monthly schedule and failure procedure.
+"""
+
+import argparse
+from contextlib import contextmanager
+from datetime import datetime, timezone
+import json
+import logging
+import os
+from pathlib import Path
+import secrets
+import shutil
+import signal
+import socket
+import subprocess
+import tempfile
+import time
+from unittest.mock import patch
+from uuid import uuid4
+
+
+REPO = Path(__file__).resolve().parents[1]
+TOOLS = ("initdb", "pg_ctl", "pg_dump", "pg_restore", "createdb")
+
+
+class DrillError(RuntimeError):
+    """An operator-safe failure message, without source or restored content."""
+
+
+def tool_environment():
+    # Do not inherit PGHOST/PGSERVICE/PGOPTIONS or a model/email credential.
+    return {key: os.environ[key] for key in ("PATH", "LANG", "LC_ALL", "HOME")
+            if key in os.environ}
+
+
+def command(pg_bin, name, args, env, *, timeout=300):
+    try:
+        subprocess.run([str(pg_bin / name), *map(str, args)], env=env,
+                       stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                       check=True, timeout=timeout)
+    except (OSError, subprocess.SubprocessError):
+        # pg_restore can quote a failed COPY row; libpq can quote credentials.
+        raise DrillError(f"{name} failed; private tool output was discarded.") from None
+
+
+def source_environment(source, root):
+    """Put the connection parameters in a private libpq service file, not argv."""
+    from psycopg.conninfo import conninfo_to_dict
+
+    try:
+        params = conninfo_to_dict(source)
+    except Exception:
+        raise DrillError("The source is not a valid PostgreSQL connection string.") from None
+    if "service" in params or not params.get("dbname"):
+        raise DrillError("The source must explicitly name a database, without service indirection.")
+    if any("\n" in value or "\r" in value or value != value.strip() for value in params.values()):
+        raise DrillError("The source contains values unsupported by a libpq service file.")
+    params["options"] = params.get("options", "") + " -c default_transaction_read_only=on"
+    params["connect_timeout"] = "15"
+    service = root / "source.service"
+    service.touch(mode=0o600)
+    service.write_text("[drill_source]\n" + "".join(f"{key}={value}\n" for key, value in params.items()))
+    return dict(tool_environment(), PGSERVICEFILE=str(service), PGSERVICE="drill_source")
+
+
+@contextmanager
+def isolated_cluster(pg_bin, scratch_parent=None):
+    """Only a newly initialised cluster, never an existing host or database."""
+    if scratch_parent is not None:
+        scratch_parent = Path(scratch_parent).resolve()
+        if scratch_parent == REPO or REPO in scratch_parent.parents or any(
+                (path / ".git").exists() for path in (scratch_parent, *scratch_parent.parents)):
+            raise DrillError("Scratch data must live outside the repository.")
+    # Avoid TMPDIR putting a database inside a checkout. /tmp also keeps Unix
+    # socket names below PostgreSQL's platform-specific length limit on macOS.
+    parent = scratch_parent or Path("/tmp")
+    root = Path(tempfile.mkdtemp(prefix="dinkydash-restore-", dir=parent))
+    data, sockets = root / "data", root / "socket"
+    env = tool_environment()
+    try:
+        if len(os.fsencode(sockets / ".s.PGSQL.5432")) >= 100:
+            raise DrillError("Scratch socket path is too long; use /tmp as the parent.")
+        os.chmod(root, 0o700)
+        sockets.mkdir(mode=0o700)
+        command(pg_bin, "initdb", ["-D", data, "-U", "restore_operator",
+                                   "--auth=trust", "--encoding=UTF8", "--no-locale"], env)
+        # PostgreSQL config syntax needs quotes doubled, not shell quoting.
+        socket_path = str(sockets).replace("'", "''")
+        with (data / "postgresql.conf").open("a") as config:
+            config.write(f"\nlisten_addresses = ''\nunix_socket_directories = '{socket_path}'\n"
+                         "unix_socket_permissions = 0700\n")
+        command(pg_bin, "pg_ctl", ["-D", data, "-l", root / "postgres.log",
+                                   "-w", "-t", "30", "start"], env, timeout=40)
+        local = dict(env, PGHOST=str(sockets), PGPORT="5432",
+                     PGUSER="restore_operator", PGDATABASE="dinkydash_restore_drill")
+        command(pg_bin, "createdb", ["dinkydash_restore_drill"], local)
+        from psycopg.conninfo import make_conninfo
+        url = make_conninfo(host=str(sockets), port=5432, user="restore_operator",
+                            dbname="dinkydash_restore_drill")
+        yield root, local, url
+    finally:
+        # Even a failed restore/start attempt must not leave a server alive.
+        # Never remove the data directory if stopping fails.
+        if (data / "postmaster.pid").exists():
+            try:
+                command(pg_bin, "pg_ctl", ["-D", data, "-m", "immediate",
+                                           "-w", "-t", "30", "stop"], env, timeout=40)
+            except DrillError:
+                raise DrillError(f"Scratch server could not stop; private data retained at {root}.") from None
+        shutil.rmtree(root)
+
+
+@contextmanager
+def offline_app(url):
+    """Allow only Unix sockets during app checks; discard all inherited secrets."""
+    original_connect = socket.socket.connect
+    original_connect_ex = socket.socket.connect_ex
+
+    def no_dns(*_args, **_kwargs):
+        raise DrillError("The restored app attempted an outbound DNS lookup.")
+
+    def guarded(method):
+        def connect(sock, address):
+            if sock.family != socket.AF_UNIX:
+                raise DrillError("The restored app attempted an outbound connection.")
+            return method(sock, address)
+        return connect
+
+    env = dict(tool_environment(), DINKYDASH_MODE="cloud",
+               DATABASE_URL=url, DATABASE_URL_DIRECT=url,
+               DINKYDASH_SECRET_KEY=secrets.token_urlsafe(32),
+               DINKYDASH_APP_HOST="restore.invalid",
+               DINKYDASH_SITE_URL="https://site.restore.invalid",
+               DINKYDASH_FAMILY_CALLS_A_DAY="0", DINKYDASH_GLOBAL_CALL_FLOOR="0",
+               DINKYDASH_GLOBAL_CALLS_PER_FAMILY="0")
+    disabled = logging.root.manager.disable
+    logging.disable(logging.CRITICAL)
+    try:
+        with patch.dict(os.environ, env, clear=True), \
+                patch.object(socket.socket, "connect", guarded(original_connect)), \
+                patch.object(socket.socket, "connect_ex", guarded(original_connect_ex)), \
+                patch.object(socket, "getaddrinfo", no_dns):
+            yield
+    finally:
+        logging.disable(disabled)
+
+
+def verify_restored(url):
+    """Migrate the scratch copy, read real tenants, and render in-process only."""
+    from dinkydash import config as config_module, db
+    from dinkydash import screens
+    from dinkydash.lifecycle import access_for
+    from dinkydash.pgstore import NoSuchFamily, PostgresStore
+
+    with offline_app(url):
+        with db.connect(url) as conn:
+            conn.execute("SET statement_timeout = '30s'")
+            applied = db.migrate(conn)
+            recorded = {row[0] for row in conn.execute("SELECT name FROM schema_migrations")}
+            expected = {path.name for path in db.migrations()}
+            if not expected <= recorded:
+                raise DrillError("The restored schema is incomplete.")
+            families = conn.execute(
+                "SELECT id, config, screen_token FROM families ORDER BY created_at LIMIT 3"
+            ).fetchall()
+            family_count = conn.execute("SELECT count(*) FROM families").fetchone()[0]
+            if not families:
+                raise DrillError("The backup has no families to verify; the drill is incomplete.")
+
+        pool = db.pool(url, min_size=1, max_size=2,
+                       kwargs={"options": "-c statement_timeout=30000"})
+        try:
+            pool.wait(timeout=10)
+            # The real cloud entry point creates both apps and dispatches on Host.
+            # It builds its own pool; inject this scratch pool at that boundary.
+            with patch.object(db, "pool", return_value=pool):
+                from wsgi import create_application
+                application = create_application()
+            from werkzeug.test import Client
+            from werkzeug.wrappers import Response
+            from web import create_app
+            from web.routes.board import render_board
+
+            board_app = create_app(pool=pool)
+            client = Client(application, Response)
+            for host, path in (("restore.invalid", "/healthz"),
+                               ("restore.invalid", "/login"),
+                               ("site.restore.invalid", "/")):
+                if client.get(path, base_url=f"https://{host}").status_code != 200:
+                    raise DrillError("The restored application did not start cleanly.")
+
+            invalid_tokens = 0
+            for family_id, saved_config, token in families:
+                store = PostgresStore(pool, family_id)
+                config = store.load_config()
+                if config != config_module.with_defaults(dict(saved_config or {})):
+                    raise DrillError("A restored family read returned the wrong config.")
+                store.load_payload(config)
+                store.recent_notes(config, 30)
+                # A legacy/malformed token can already exist in a source row.
+                # Verify the data still renders, and that the route preserves
+                # its rejection; report the source defect separately.
+                with board_app.test_request_context():
+                    render_board(store, access=access_for(pool, family_id))
+                valid_token = screens.looks_like_a_token(token)
+                invalid_tokens += not valid_token
+                status = client.get(f"/s/{token}", base_url="https://restore.invalid").status_code
+                if status != (200 if valid_token else 404):
+                    raise DrillError(f"A restored family board could not be rendered (HTTP {status}).")
+            try:
+                PostgresStore(pool, uuid4()).load_config()
+            except NoSuchFamily:
+                pass
+            else:
+                raise DrillError("An unknown family was able to read a config.")
+            return {"families_restored": family_count, "families_checked": len(families),
+                    "schema_migrations": len(recorded), "migrations_applied": len(applied),
+                    "app_startup": "passed", "outbound_connections": "blocked",
+                    "sampled_invalid_screen_tokens": invalid_tokens}
+        finally:
+            pool.close()
+
+
+def run(pg_bin, source, scratch_parent=None):
+    pg_bin = Path(pg_bin).resolve()
+    if not source:
+        raise DrillError("The source environment variable is missing or empty.")
+    if any(not (pg_bin / name).is_file() for name in TOOLS):
+        raise DrillError("The PostgreSQL bin directory must contain every required tool.")
+    started = time.monotonic()
+    with isolated_cluster(pg_bin, scratch_parent) as (root, local, url):
+        archive = root / "backup.dump"
+        archive.touch(mode=0o600)
+        # pg_dump itself is read-only; the session setting also enforces that.
+        env = source_environment(source, root)
+        command(pg_bin, "pg_dump", ["--format=custom", "--no-owner", "--no-acl",
+                                    "--lock-wait-timeout=15000", "--file", archive], env)
+        command(pg_bin, "pg_restore", ["--dbname=dinkydash_restore_drill", "--no-owner",
+                                       "--no-acl", "--exit-on-error", "--single-transaction",
+                                       archive], local)
+        report = verify_restored(url)
+    # Only a successful cleanup earns a successful drill.
+    return dict(report, status="passed", cleanup="passed",
+                backup_kind="fresh logical backup", finished_at=datetime.now(timezone.utc).isoformat(),
+                elapsed_seconds=round(time.monotonic() - started, 1))
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--pg-bin", required=True, help="PostgreSQL server/client bin directory")
+    parser.add_argument("--source-env", default="DATABASE_URL_DIRECT")
+    parser.add_argument("--scratch-parent", type=Path, help="Private temporary data parent, outside the repo")
+    args = parser.parse_args(argv)
+
+    def interrupted(*_):
+        raise KeyboardInterrupt
+
+    signal.signal(signal.SIGTERM, interrupted)
+    try:
+        report = run(args.pg_bin, os.environ.get(args.source_env), args.scratch_parent)
+    except (Exception, KeyboardInterrupt) as exc:
+        # No traceback: exceptions can contain connection strings or family data.
+        message = str(exc) if isinstance(exc, DrillError) else "Restore drill failed; private details suppressed."
+        print(json.dumps({"status": "failed", "message": message}))
+        return 1
+    print(json.dumps(report, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_restore_drill.py
+++ b/tests/test_restore_drill.py
@@ -1,0 +1,139 @@
+"""Restore drills never target an existing database or expose private output."""
+
+import os
+from pathlib import Path
+import socket
+import subprocess
+import tempfile
+
+import pytest
+
+from ops.restore_drill import (DrillError, command, isolated_cluster, main,
+                               offline_app, run, source_environment, tool_environment)
+
+
+def test_child_tools_do_not_inherit_production_configuration(monkeypatch):
+    for key in ("PGHOST", "PGSERVICE", "PGOPTIONS", "DATABASE_URL", "ANTHROPIC_API_KEY",
+                "SENDGRID_API_KEY", "STRIPE_SECRET_KEY"):
+        monkeypatch.setenv(key, "private-value")
+    assert not set(tool_environment()) & {
+        "PGHOST", "PGSERVICE", "PGOPTIONS", "DATABASE_URL", "ANTHROPIC_API_KEY",
+        "SENDGRID_API_KEY", "STRIPE_SECRET_KEY",
+    }
+
+
+def test_scratch_under_the_repository_is_refused():
+    from ops.restore_drill import REPO
+    with pytest.raises(DrillError, match="outside the repository"):
+        with isolated_cluster(Path("/unused"), REPO / ".context"):
+            pytest.fail("Should refuse before creating a database")
+
+
+def test_private_tool_errors_are_not_exposed(monkeypatch):
+    def fail(*args, **kwargs):
+        raise subprocess.CalledProcessError(1, args[0], stderr=b"private-calendar-and-password")
+    monkeypatch.setattr(subprocess, "run", fail)
+    with pytest.raises(DrillError) as error:
+        command(Path("/unused"), "pg_restore", [], {})
+    assert "private-calendar-and-password" not in str(error.value)
+    assert "pg_restore failed" in str(error.value)
+
+
+def test_source_credentials_are_private_and_read_only(tmp_path):
+    pytest.importorskip("psycopg")
+    env = source_environment("dbname=source user=reader password=fake-password", tmp_path)
+    service = Path(env["PGSERVICEFILE"])
+    assert service.stat().st_mode & 0o777 == 0o600
+    assert "default_transaction_read_only=on" in service.read_text()
+    assert "password=fake-password" in service.read_text()
+    assert "fake-password" not in str(env)
+
+
+def test_app_checks_block_network_and_remove_credentials(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "private-key")
+    monkeypatch.setenv("DATABASE_URL", "private-production-url")
+    with offline_app("host=/private/scratch dbname=drill"):
+        assert "ANTHROPIC_API_KEY" not in os.environ
+        assert os.environ["DATABASE_URL"] == "host=/private/scratch dbname=drill"
+        with pytest.raises(DrillError, match="DNS"):
+            socket.getaddrinfo("example.com", 443)
+        with socket.socket() as sock:
+            with pytest.raises(DrillError, match="outbound"):
+                sock.connect(("127.0.0.1", 443))
+            with pytest.raises(DrillError, match="outbound"):
+                sock.connect_ex(("127.0.0.1", 443))
+    assert os.environ["DATABASE_URL"] == "private-production-url"
+    assert os.environ["ANTHROPIC_API_KEY"] == "private-key"
+
+
+def test_cli_fails_closed_without_a_source(monkeypatch, capsys):
+    monkeypatch.delenv("RESTORE_TEST_SOURCE", raising=False)
+    assert main(["--pg-bin", "/unused", "--source-env", "RESTORE_TEST_SOURCE"]) == 1
+    assert '"status": "failed"' in capsys.readouterr().out
+
+
+def test_failed_start_is_cleaned_up(monkeypatch, tmp_path):
+    def fail(*args, **kwargs):
+        raise DrillError("initdb failed")
+    monkeypatch.setattr("ops.restore_drill.command", fail)
+    with pytest.raises(DrillError):
+        with isolated_cluster(Path("/unused"), tmp_path):
+            pytest.fail("Should never start")
+    assert not list(tmp_path.iterdir())
+
+
+@pytest.fixture
+def scratch_parent():
+    # Unix socket names have a ~100-byte limit; pytest's macOS TMPDIR is longer.
+    with tempfile.TemporaryDirectory(prefix="dd-test-", dir="/tmp") as directory:
+        yield Path(directory)
+
+
+@pytest.fixture
+def pg_bin():
+    value = os.environ.get("DINKYDASH_TEST_PG_BIN")
+    if not value:
+        pytest.skip("DINKYDASH_TEST_PG_BIN is not set (full restore integration)")
+    return Path(value)
+
+
+@pytest.mark.parametrize("legacy_token", [False, True])
+def test_round_trip_real_backup_and_cleanup(pg_pool, pg_family, pg_bin, scratch_parent, legacy_token):
+    from dinkydash import config as config_module
+    from dinkydash.pgstore import PostgresStore
+    from tests.conftest import database_url
+    from psycopg.conninfo import make_conninfo
+
+    if legacy_token:
+        with pg_pool.connection() as conn:
+            conn.execute("UPDATE families SET screen_token = %s WHERE id = %s",
+                         ("00112233445566778899aabb", pg_family))
+
+    store = PostgresStore(pg_pool, pg_family)
+    config = config_module.with_defaults({"family_name": "Restore test family", "timezone": "UTC"})
+    store.save_config(config)
+    store.save_brief(config, {"generated_for_date": "2026-09-09",
+                             "generated_at": "2026-09-09T06:00:00+00:00",
+                             "headline": "A synthetic headline", "note": "A synthetic note"})
+    # CI deliberately keeps its invented password in PGPASSWORD, outside the
+    # URL. The drill accepts only explicit source parameters, not PG defaults.
+    source = make_conninfo(database_url(), password=os.environ.get("PGPASSWORD"))
+    report = run(pg_bin, source, scratch_parent)
+    assert report["status"] == "passed"
+    assert report["families_checked"] >= 1
+    assert report["cleanup"] == "passed"
+    assert report["sampled_invalid_screen_tokens"] == int(legacy_token)
+    assert not list(scratch_parent.iterdir())
+    # Source is intact, including its brief, after the scratch cluster is gone.
+    assert store.load_payload(config)["headline"] == "A synthetic headline"
+
+
+def test_failed_restore_cleans_up_the_real_server(pg_bin, scratch_parent, monkeypatch):
+    def fail_dump(pg_bin, name, args, env, **kwargs):
+        if name == "pg_dump":
+            raise DrillError("Synthetic backup failure")
+        return command(pg_bin, name, args, env, **kwargs)
+    monkeypatch.setattr("ops.restore_drill.command", fail_dump)
+    with pytest.raises(DrillError, match="Synthetic backup failure"):
+        run(pg_bin, "dbname=not_used", scratch_parent)
+    assert not list(scratch_parent.iterdir())

--- a/tests/test_worker_heartbeat.py
+++ b/tests/test_worker_heartbeat.py
@@ -1,0 +1,114 @@
+"""Liveness means a completed pass, not successful model or calendar calls."""
+
+import logging
+
+import pytest
+import requests
+
+import worker
+from worker import heartbeat
+
+
+@pytest.fixture
+def pass_calls(monkeypatch):
+    calls = []
+    monkeypatch.setattr("dinkydash.lifecycle.expire_trials", lambda pool: calls.append("expire"))
+    monkeypatch.setattr(worker, "tick_all", lambda *a, **kw: calls.append("tick") or 0)
+    monkeypatch.setattr(worker, "sweep_logins", lambda pool: calls.append("sweep") or 0)
+    monkeypatch.setattr(heartbeat, "ping", lambda url: calls.append("ping"))
+    return calls
+
+
+def test_ping_follows_a_completed_pass_even_with_no_successful_families(pass_calls):
+    worker.run_pass(object(), worker.Stopping(), "https://monitor.example/fake-token")
+    assert pass_calls == ["expire", "tick", "sweep", "ping"]
+
+
+def test_interrupted_pass_does_not_ping(pass_calls, monkeypatch):
+    stopping = worker.Stopping()
+    def interrupted(*a, **kw):
+        pass_calls.append("tick")
+        stopping.request()
+        return 1
+    monkeypatch.setattr(worker, "tick_all", interrupted)
+    worker.run_pass(object(), stopping, "https://monitor.example/fake-token")
+    assert pass_calls == ["expire", "tick", "sweep"]
+
+
+def test_database_enumeration_failure_does_not_ping(pass_calls, monkeypatch):
+    def fail(*a, **kw):
+        raise RuntimeError("Database is unavailable")
+    monkeypatch.setattr(worker, "tick_all", fail)
+    with pytest.raises(RuntimeError):
+        worker.run_pass(object(), worker.Stopping(), "https://monitor.example/fake-token")
+    assert pass_calls == ["expire"]
+
+
+def test_missing_configuration_is_visible_and_sends_nothing(monkeypatch, caplog):
+    monkeypatch.delenv(heartbeat.ENVIRONMENT_KEY, raising=False)
+    with caplog.at_level(logging.WARNING):
+        assert heartbeat.configured_url() is None
+    assert "not configured" in caplog.text
+    assert heartbeat.ping(None) is False
+
+
+@pytest.mark.parametrize("url", ["http://monitor.example/fake-token", "https://u:p@monitor.example/",
+                                 "https://monitor.example/fake-token#fragment", "https://x:bad/",
+                                 "https:///missing-host", "https://[broken"])
+def test_invalid_url_is_rejected_without_echoing_it(monkeypatch, url):
+    monkeypatch.setenv(heartbeat.ENVIRONMENT_KEY, url)
+    with pytest.raises(ValueError) as error:
+        heartbeat.configured_url()
+    assert url not in str(error.value)
+
+
+def test_https_ping_url_is_loaded(monkeypatch):
+    monkeypatch.setenv(heartbeat.ENVIRONMENT_KEY, " https://monitor.example/fake-token ")
+    assert heartbeat.configured_url() == "https://monitor.example/fake-token"
+
+
+@pytest.fixture
+def sent(monkeypatch):
+    class Session:
+        trust_env = True
+        status_code = 200
+        error = None
+        def __init__(self):
+            self.calls = []
+        def __enter__(self):
+            return self
+        def __exit__(self, *args):
+            return False
+        def post(self, url, **kwargs):
+            self.calls.append((url, kwargs))
+            if self.error:
+                raise self.error
+            return self
+    session = Session()
+    monkeypatch.setattr(requests, "Session", lambda: session)
+    return session
+
+
+def test_ping_carries_no_data_and_uses_a_bounded_direct_request(sent):
+    assert heartbeat.ping("https://monitor.example/fake-token") is True
+    assert sent.trust_env is False
+    assert sent.calls == [("https://monitor.example/fake-token", {
+        "data": b"", "timeout": 5, "allow_redirects": False, "stream": True,
+    })]
+
+
+@pytest.mark.parametrize("code", [301, 401, 429, 500])
+def test_rejections_do_not_retry_or_expose_the_url(sent, code, caplog):
+    sent.status_code = code
+    assert heartbeat.ping("https://monitor.example/fake-token") is False
+    assert len(sent.calls) == 1
+    assert "fake-token" not in caplog.text
+    assert str(code) in caplog.text
+
+
+@pytest.mark.parametrize("kind", [requests.Timeout, requests.ConnectionError])
+def test_transport_failure_does_not_stop_the_worker_or_log_credentials(sent, kind, caplog):
+    sent.error = kind("Could not connect to https://monitor.example/fake-token")
+    assert heartbeat.ping("https://monitor.example/fake-token") is False
+    assert len(sent.calls) == 1
+    assert "fake-token" not in caplog.text

--- a/worker/__init__.py
+++ b/worker/__init__.py
@@ -155,35 +155,52 @@ def interval():
         return DEFAULT_INTERVAL
 
 
+def run_pass(pool, stopping, heartbeat_url=None):
+    """Run housekeeping and every family, then report liveness if not interrupted.
+
+    A handled per-family/provider error still counts as a live worker. A failed
+    family enumeration or a stop during the pass does not emit a heartbeat.
+    """
+    from dinkydash import lifecycle
+    from .heartbeat import ping
+
+    started = time.monotonic()
+    try:
+        expired = lifecycle.expire_trials(pool)
+        if expired:
+            log.info("Ended %s expired trial(s).", expired)
+    except Exception:
+        log.exception("Could not mark expired trials; retrying next pass.")
+    ticked = tick_all(pool, stopping=stopping)
+    swept = sweep_logins(pool)
+    if stopping:
+        log.info("Pass interrupted for shutdown; no heartbeat sent.")
+        return
+    log.info("Pass complete: %s families ticked in %.1fs; %s dead login "
+             "token(s) deleted.", ticked, time.monotonic() - started, swept)
+    ping(heartbeat_url)
+
+
 def main():  # pragma: no cover - the loop itself; tick_all is what is tested
     logging.basicConfig(
         level=logging.INFO,
         format="%(asctime)s [%(levelname)s] %(message)s",
     )
 
-    from dinkydash import db, lifecycle
+    from dinkydash import db
+    from .heartbeat import configured_url
 
     stopping = Stopping()
     signal.signal(signal.SIGTERM, stopping.request)
     signal.signal(signal.SIGINT, stopping.request)
 
+    heartbeat_url = configured_url()
     pool = db.pool()
     every = interval()
     log.info("Worker started; a pass every %s seconds.", every)
 
     while not stopping:
-        started = time.monotonic()
-        try:
-            expired = lifecycle.expire_trials(pool)
-            if expired:
-                log.info("Ended %s expired trial(s).", expired)
-        except Exception:
-            # Callers still check the deadline themselves if housekeeping fails.
-            log.exception("Could not mark expired trials; retrying next pass.")
-        ticked = tick_all(pool, stopping=stopping)
-        swept = sweep_logins(pool)
-        log.info("Pass complete: %s families ticked in %.1fs; %s dead login "
-                 "token(s) deleted.", ticked, time.monotonic() - started, swept)
+        run_pass(pool, stopping, heartbeat_url)
 
         # Sleep in slices so SIGTERM is noticed in seconds rather than minutes.
         # App Platform kills a container that ignores it for too long, and

--- a/worker/heartbeat.py
+++ b/worker/heartbeat.py
@@ -1,0 +1,48 @@
+"""An empty HTTPS ping after a completed worker pass; no tenant data leaves."""
+
+import logging
+import os
+from urllib.parse import urlsplit
+
+import requests
+
+log = logging.getLogger("dinkydash.worker")
+ENVIRONMENT_KEY = "DINKYDASH_WORKER_HEARTBEAT_URL"
+
+
+def configured_url():
+    url = os.environ.get(ENVIRONMENT_KEY, "").strip()
+    if not url:
+        log.warning("Worker heartbeat is not configured; missed passes cannot alert.")
+        return None
+    try:
+        parts = urlsplit(url)
+        valid = (parts.scheme == "https" and parts.hostname and not parts.username
+                 and not parts.password and not parts.fragment)
+        parts.port  # Reject malformed ports without including the URL in the error.
+    except ValueError:
+        valid = False
+    if not valid:
+        raise ValueError(f"{ENVIRONMENT_KEY} must be an HTTPS URL without userinfo or a fragment.")
+    return url
+
+
+def ping(url):
+    """Try once, with no body, redirects, proxy, or credential-bearing logging.
+
+    The monitor should expect a pass every five minutes plus its duration, and
+    allow a redeploy grace period. Failure never stops the next family's board.
+    """
+    if not url:
+        return False
+    try:
+        with requests.Session() as session:
+            session.trust_env = False
+            with session.post(url, data=b"", timeout=5, allow_redirects=False,
+                              stream=True) as response:
+                if 200 <= response.status_code < 300:
+                    return True
+                log.warning("Worker heartbeat failed (HTTP %s).", response.status_code)
+    except requests.RequestException:
+        log.warning("Worker heartbeat could not reach the monitor; retrying after the next pass.")
+    return False


### PR DESCRIPTION
A healthy web process can hide a stopped worker, and the database had no repeatable restore drill. The worker now emits an empty HTTPS heartbeat after a completed pass, with bounded requests, sanitised failures and no heartbeat on interrupted passes. The new operator tool takes a read-only logical backup, restores it into a fresh socket-only PostgreSQL cluster, checks family-scoped reads and cloud startup with outbound connections blocked, and removes all scratch data.

A managed-source restore drill passed on 9 September 2026. It also found an existing screen token outside the current alphabet; DIN-64 tracks that source-data issue. No production data or credential was changed. Recovery documentation defines a monthly cadence and failure handling; CI exercises synthetic backup/restore and cleanup with PostgreSQL 17.

Validation: 994 tests passed with PostgreSQL and restore integration; 684 passed and 310 skipped without a database/tool configuration. `git diff --check` passed. Both live `/healthz` endpoints returned 200.

DIN-56 is implemented and verified. DIN-54 remains incomplete pending the operator's monitoring service/destination, external check configuration, and witnessed failure/recovery notifications. No production deployment, monthly scheduler installation or external alert delivery is claimed by this PR.

Closes DIN-56
Related: DIN-54, DIN-64
