### PR TITLE
Refuse impossible dates of birth in the settings form

### DIFF
--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -6,6 +6,7 @@ above shifted everybody below onto somebody else's edit form.
 """
 
 import json
+from datetime import date, timedelta
 
 import pytest
 
@@ -101,6 +102,64 @@ class TestEditing:
     def test_an_unknown_id_is_a_404(self, client, config_path):
         client.get("/settings/people")
         assert client.get("/settings/people/nosuchid").status_code == 404
+
+
+class TestDatesOfBirth:
+    """A browser's date input accepts any year from 0001, and a flick of the
+    year wheel on a phone saved "0017-03-04" without complaint — the People
+    page then read "2009 years old". The form refuses what cannot be a date of
+    birth, and says which year it received."""
+
+    def test_a_year_before_1900_is_refused(self, client, config_path):
+        client.get("/settings/people")
+        page = client.post("/settings/people/new",
+                           data={"name": "Otto", "date_of_birth": "0017-03-04"})
+        assert page.status_code == 200
+        assert "Date of birth has the year 0017" in page.get_data(as_text=True)
+        assert len(people(config_path)) == 3
+
+    def test_a_date_in_the_future_is_refused(self, client, config_path):
+        client.get("/settings/people")
+        # Two days on: the family's date is in Berlin, this machine's may not be.
+        soon = (date.today() + timedelta(days=2)).isoformat()
+        page = client.post("/settings/people/new",
+                           data={"name": "Otto", "date_of_birth": soon})
+        assert "Date of birth is in the future" in page.get_data(as_text=True)
+        assert len(people(config_path)) == 3
+
+    def test_a_baby_born_today_is_fine(self, client, config_path):
+        client.get("/settings/people")
+        today = config_module.today_for(config_module.load_config(config_path))
+        client.post("/settings/people/new",
+                    data={"name": "Otto", "date_of_birth": today.isoformat()})
+        assert len(people(config_path)) == 4
+
+    def test_a_shape_that_is_not_a_date_is_still_refused(self, client, config_path):
+        client.get("/settings/people")
+        page = client.post("/settings/people/new",
+                           data={"name": "Otto", "date_of_birth": "17-03-04"})
+        assert "should look like 2017-03-15" in page.get_data(as_text=True)
+        assert len(people(config_path)) == 3
+
+    def test_a_stored_bad_year_must_be_fixed_before_the_person_saves(self, tmp_path):
+        # The remediation path for a row that got in before the check existed:
+        # renaming the person is refused until the year is corrected.
+        path = tmp_path / "config.yaml"
+        path.write_text(CONFIG.replace('"2019-06-20"', '"0978-06-20"'))
+        client = client_for(create_app(FileStore(path)))
+        client.get("/settings/people")
+        theo = ids_for(path)[1]
+        page = client.post(f"/settings/people/{theo}",
+                           data={"name": "Theodore", "date_of_birth": "0978-06-20"})
+        assert "Date of birth has the year 0978" in page.get_data(as_text=True)
+        assert people(path)[1]["name"] == "Theo"
+
+    def test_the_input_carries_the_same_bounds(self, client, config_path):
+        client.get("/settings/people")
+        today = config_module.today_for(config_module.load_config(config_path))
+        page = client.get("/settings/people/new").get_data(as_text=True)
+        assert 'min="1900-01-01"' in page
+        assert f'max="{today.isoformat()}"' in page
 
 
 class TestDeleting:

--- a/web/CLAUDE.md
+++ b/web/CLAUDE.md
@@ -12,6 +12,12 @@ form both render from it, and `parse_field` reads it back. `kind` is one of `tex
 `monthday`, `textarea`, `checkbox`, `emoji`, `color`, `people`, `emails`. A new `kind` needs a
 branch in `parse_field` and a branch in `web/templates/settings/edit.html`; nothing else.
 
+**`date` means a date of birth, and it is bounded.** The input carries `min` and `max` of
+1900-01-01 and today, and `validate` refuses anything outside them, naming the year it received.
+Both halves are needed: a phone's year wheel scrolls down to the year 1, and a mistyped year
+used to be saved silently and show up on the People page as somebody 2,009 years old. A `date`
+field that is not a birthday needs a kind of its own rather than a looser bound on this one.
+
 **Adding a whole settings section.** Add an entry to `SECTIONS` and a row to
 `web/templates/settings/home.html`. The list, edit, delete and reorder routes are generic and need
 no changes.

--- a/web/routes/settings.py
+++ b/web/routes/settings.py
@@ -35,6 +35,13 @@ log = logging.getLogger(__name__)
 
 bp = Blueprint("settings", __name__)
 
+# The one `date` field is a date of birth, so the form bounds it between this
+# year and today, and `validate` refuses anything outside. A browser's date
+# input accepts any year from 0001 — a flick of the year wheel on a phone, or
+# a dropped keystroke, saved "0017-03-04" without complaint, and the People
+# page then read "2009 years old". Nobody alive was born before 1900.
+EARLIEST_BIRTH_YEAR = 1900
+
 
 @bp.before_request
 def _needs_a_session():
@@ -197,8 +204,13 @@ def parse_field(field, form, existing):
     return value
 
 
-def validate(section, item):
-    """Return a list of human-readable problems with a submitted item."""
+def validate(section, item, today):
+    """Return a list of human-readable problems with a submitted item.
+
+    `today` is the family's own date: a date of birth after it is a typo,
+    and so is one before EARLIEST_BIRTH_YEAR. The message names the year the
+    form received, because the input itself can show "0017" quite quietly.
+    """
     problems = []
     for name, label, kind, required, _help in section["fields"]:
         value = item.get(name)
@@ -206,9 +218,16 @@ def validate(section, item):
             problems.append(f"{label} is needed.")
         if kind == "date" and value:
             try:
-                datetime.strptime(str(value), "%Y-%m-%d")
+                dob = datetime.strptime(str(value), "%Y-%m-%d").date()
             except ValueError:
                 problems.append(f"{label} should look like 2017-03-15.")
+            else:
+                if dob.year < EARLIEST_BIRTH_YEAR:
+                    problems.append(f"{label} has the year {dob.year:04d}. "
+                                    f"Check the year and try again.")
+                elif dob > today:
+                    problems.append(f"{label} is in the future. "
+                                    f"Check the year and try again.")
         if kind == "emails":
             for address in value or []:
                 if "@" not in address:
@@ -370,6 +389,7 @@ def section_edit(section_name, item_id):
     section = section_or_404(section_name)
     config = current_config()
     items = config.setdefault(section["key"], [])
+    today = config_module.today_for(config)
 
     is_new = item_id == "new"
     if is_new:
@@ -391,7 +411,7 @@ def section_edit(section_name, item_id):
             checked = check_feed(submitted, config)
             item = submitted
         else:
-            problems = validate(section, submitted)
+            problems = validate(section, submitted, today)
             if not problems:
                 if is_new:
                     submitted["id"] = config_module.new_id(
@@ -419,6 +439,7 @@ def section_edit(section_name, item_id):
         "settings/edit.html", section=section, section_name=section_name,
         item=item, item_id=item_id, is_new=is_new, problems=problems,
         checked=checked, config=config, months=MONTHS,
+        date_min=f"{EARLIEST_BIRTH_YEAR}-01-01", date_max=today.isoformat(),
         emoji=EMOJI_SUGGESTIONS.get(section_name, []),
         colors=config_module.AVATAR_COLORS, people=config_module.people_names(config),
     )

--- a/web/templates/settings/edit.html
+++ b/web/templates/settings/edit.html
@@ -38,7 +38,8 @@
                    placeholder="sam@example.com">
 
         {% elif kind == 'date' %}
-            <input type="date" id="f-{{ name }}" name="{{ name }}" value="{{ item.get(name, '') }}" {{ 'required' if required }}>
+            <input type="date" id="f-{{ name }}" name="{{ name }}" value="{{ item.get(name, '') }}"
+                   min="{{ date_min }}" max="{{ date_max }}" {{ 'required' if required }}>
 
         {% elif kind == 'textarea' %}
             <textarea id="f-{{ name }}" name="{{ name }}">{{ item.get(name, '') }}</textarea>


### PR DESCRIPTION
The People page showed "1048 years old" for a hosted family: the age maths was right, but the stored birth years were 0978, 0105 and 0017, because a browser's date input accepts any year from 0001 and the form saved whatever parsed as a date. The settings form now refuses a date of birth before 1900 or after today and names the year it received, and the date input carries the same bounds as `min`/`max` so the browser blocks the mistake first. New tests in `tests/test_settings.py` cover both bounds, a baby born today, a two-digit year, the input attributes, and editing a person whose stored year is already wrong. `web/CLAUDE.md` records that the `date` field kind means a date of birth and is bounded. The three affected rows in the hosted database still need their years re-entered by hand; the form refuses to save those people until that is done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
