### PR TITLE
Clarify calendar setup and failed link feedback

### DIFF
--- a/dinkydash/calendars.py
+++ b/dinkydash/calendars.py
@@ -47,6 +47,13 @@ class FeedError(Exception):
     it must never carry the URL or the feed's contents — see `_why`.
     """
 
+    def __init__(self, message, *, status_code=None, invalid_data=False):
+        super().__init__(message)
+        # Let the UI offer a repair without parsing the diagnostic or exposing
+        # the original Requests exception, which can contain the private URL.
+        self.status_code = status_code
+        self.invalid_data = invalid_data
+
 
 class FeedRefused(FeedError):
     """The URL was refused before any request was made.
@@ -159,7 +166,8 @@ def _occurrences(ical_text, start, end):
     except Exception as exc:
         # Not `{exc}`: a parser error quotes the line it choked on, which is
         # somebody's appointment.
-        raise FeedError(f"could not read the calendar data ({type(exc).__name__})") from exc
+        raise FeedError(f"could not read the calendar data ({type(exc).__name__})",
+                        invalid_data=True) from exc
     return list(recurring_events_of(cal).between(start, end + timedelta(days=1)))
 
 
@@ -311,7 +319,9 @@ def fetch_text(url, timeout=DEFAULT_TIMEOUT):
     except FeedError:
         raise
     except Exception as exc:
-        raise FeedError(f"could not fetch the calendar: {_why(exc)}") from exc
+        response = getattr(exc, "response", None)
+        raise FeedError(f"could not fetch the calendar: {_why(exc)}",
+                        status_code=getattr(response, "status_code", None)) from exc
 
     raise FeedError("could not fetch the calendar: too many redirects")
 

--- a/doc/running-it.md
+++ b/doc/running-it.md
@@ -77,7 +77,7 @@ full screen with no browser around it.
 
 ## Adding a calendar
 
-Settings → Calendars → Add a calendar. Paste an iCal link and press **Check this link** — it will
+Settings → Calendars → Add a calendar. Paste an iCal link and press **Test calendar link** — it will
 tell you how many events it found and what the next one is, rather than silently accepting a URL
 that returns nothing.
 
@@ -99,7 +99,7 @@ skipped rather than emptying the board.
 A personal calendar with work and private appointments in it can still go on the board. Fill in
 **Only show events shared with** on that calendar with the other parent's email address — the one
 on the invitations — and only the events they are a guest at, or organised, get through. The rest
-is dropped as the feed is read, so it is never stored and never sent to Claude. **Check this link**
+is dropped as the feed is read, so it is never stored and never sent to Claude. **Test calendar link**
 says how many events get through out of how many, and warns you if none do. Saving a calendar
 clears what was fetched from it before, and the next tick fetches it afresh — or press **Refresh
 calendars**. In `config.yaml` the setting is `shared_with`, a list of addresses under that calendar.

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -494,6 +494,50 @@ class TestTheGuestList:
         assert "24 events over the next 14 days. Next up: Swimming, 2026-09-04 at all day." in page
 
 
+class TestCalendarLinkFeedback:
+    @pytest.mark.parametrize("status, body, message", [
+        (401, b"", "isn't allowing DinkyDash"),
+        (403, b"", "isn't allowing DinkyDash"),
+        (404, b"", "It may be private, out of date, or copied incorrectly."),
+        (410, b"", "It may be private, out of date, or copied incorrectly."),
+        (200, b"<html>Sign in to your calendar</html>", "didn't return readable calendar data"),
+    ])
+    def test_unusable_links_explain_how_to_retry_without_saving(
+            self, client, config_path, monkeypatch, status, body, message):
+        from html import unescape
+        from test_feed_safety import FakeResponse, resolves_to, serves
+
+        resolves_to(monkeypatch, "1.1.1.1")
+        serves(monkeypatch, FakeResponse(status=status, body=body))
+        # A link can be tested before choosing a name. Testing must neither
+        # create a calendar nor lose the pasted link and guest filter.
+        link = "https://calendar.example/not-a-feed"
+        response = client.post("/settings/calendars/new", data={
+            "action": "check", "label": "", "url": link,
+            "shared_with": "sam@example.com", "enabled": "on",
+        })
+        assert response.status_code == 200
+        page = unescape(response.get_data(as_text=True))
+        assert message in page
+        assert "Copy a fresh iCal / ICS sharing link" in page
+        assert '<details class="note-box calendar-help" open>' in page
+        assert "This works for private calendars too" in page
+        assert f'value="{link}"' in page
+        assert 'value="sam@example.com"' in page
+        assert not config_module.load_config(config_path).get("calendars")
+
+    def test_server_failure_does_not_blame_calendar_sharing(self, client, monkeypatch):
+        from test_feed_safety import FakeResponse, resolves_to, serves
+
+        resolves_to(monkeypatch, "1.1.1.1")
+        serves(monkeypatch, FakeResponse(status=503))
+        page = client.post("/settings/calendars/new", data={
+            "action": "check", "url": "https://calendar.example/feed.ics",
+        }).get_data(as_text=True)
+        assert "503" in page
+        assert "Copy a fresh iCal / ICS sharing link" not in page
+
+
 class TestSavingACalendarForgetsWhatItFetched:
     """A guest list added after a fetch was never applied to what is stored.
 

--- a/web/routes/settings.py
+++ b/web/routes/settings.py
@@ -115,17 +115,11 @@ SECTIONS = {
                  "sent to Anthropic each morning so Claude can write the day's line; an event "
                  "kept off the board by a guest list is never stored and never sent.",
         "fields": [
-            # "Name", like People and Pets, rather than an instruction. The
-            # heading above already says what is being named, and this string
-            # never reaches the board — it is how the settings list and the
-            # feed status refer to this calendar, so the hint says so.
-            ("label", "Name", "text", True,
-             "Only you see this — try “Family” or “School”."),
-            ("url", "iCal link", "url", True,
-             "Google → Settings and sharing → Integrate calendar → Secret address in iCal format. "
-             "iCloud → share the calendar → Public Calendar → Copy Link (a webcal:// link is "
-             "fine, it is converted for you). Outlook → Settings → Calendar → Shared calendars → "
-             "Publish a calendar, then the ICS link. Links must be https."),
+            ("label", "Calendar name", "text", True,
+             "A name to help you recognise this calendar in settings, such as “Family” or “School”. "
+             "It won't appear on the board."),
+            ("url", "Calendar link (iCal / ICS)", "url", True,
+             "Paste the calendar's sharing link here. HTTPS and webcal:// links work."),
             ("shared_with", "Only show events shared with", "emails", False,
              "Email addresses, with commas between them. Only events with one of these people "
              "on the guest list, or organised by them, go on the board — the rest of this "
@@ -444,7 +438,22 @@ def check_feed(item, config):
             days_ahead=int(config.get("calendar_days_ahead") or 14),
             shared_with=wanted,
         )
-    except (FeedError, GenerationError) as exc:
+    except FeedError as exc:
+        if exc.status_code in (401, 403, 404, 410) or exc.invalid_data:
+            if exc.status_code in (401, 403):
+                message = "This calendar isn't allowing DinkyDash to read it."
+            elif exc.status_code in (404, 410):
+                message = ("We couldn't find a calendar at this link. It may be private, "
+                           "out of date, or copied incorrectly.")
+            else:
+                message = ("This link didn't return readable calendar data. It may open "
+                           "a calendar webpage or a sign-in page instead.")
+            return {"ok": False, "link_help": True, "message": message,
+                    "recovery": "Copy a fresh iCal / ICS sharing link from your calendar's "
+                                "settings, paste it above, then test again. See the provider "
+                                "instructions above for the right link."}
+        return {"ok": False, "message": str(exc)}
+    except GenerationError as exc:
         return {"ok": False, "message": str(exc)}
     days = found["days_ahead"]
     if not found["total"]:

--- a/web/templates/settings/_calendar_help.html
+++ b/web/templates/settings/_calendar_help.html
@@ -1,0 +1,14 @@
+<p class="hint">Open your provider to copy the link (opens in a new tab):</p>
+<div class="calendar-providers">
+    <a class="btn outline" href="https://calendar.google.com/calendar/u/0/r/settings" target="_blank" rel="noopener noreferrer">Google Calendar ↗</a>
+    <a class="btn outline" href="https://www.icloud.com/calendar/" target="_blank" rel="noopener noreferrer">Apple Calendar (iCloud) ↗</a>
+    <a class="btn outline" href="https://outlook.live.com/calendar/" target="_blank" rel="noopener noreferrer">Outlook ↗</a>
+</div>
+<details class="note-box calendar-help" {{ 'open' if checked and checked.link_help }}>
+    <summary>Where do I find my calendar link?</summary>
+    <ol>
+        <li><strong>Google Calendar:</strong> On a computer, open Settings, choose your calendar, then Integrate calendar. Copy the “Secret address in iCal format”. This works for private calendars too. The public iCal address only works if your calendar is public.</li>
+        <li><strong>Apple Calendar (iCloud):</strong> Open the calendar's sharing options, turn on Public Calendar, then copy the link. On iPhone, tap Calendars, the info button, then Share Link.</li>
+        <li><strong>Outlook:</strong> Open Settings → Calendar → Shared calendars. Under Publish a calendar, choose your calendar and a permission level that includes event details, then Publish and copy the ICS link.</li>
+    </ol>
+</details>

--- a/web/templates/settings/base.html
+++ b/web/templates/settings/base.html
@@ -71,6 +71,7 @@
         }
         .appbar .action { font-size: 0.9375rem; font-weight: 800; color: var(--accent); padding: 0 0.375rem; }
         .appbar .action.muted { color: var(--text-muted); font-weight: 700; }
+        .appbar button.action { border: none; background: transparent; font-family: inherit; cursor: pointer; }
 
         .content { padding: 1rem; display: flex; flex-direction: column; gap: 1rem; }
 
@@ -150,7 +151,17 @@
 
         .checkline { display: flex; align-items: center; gap: 0.6875rem; padding: 0.375rem 0.125rem; }
         .checkline input { width: 1.375rem; height: 1.375rem; accent-color: var(--accent); }
-        .checkline span { font-size: 0.9375rem; font-weight: 700; }
+        .checkline span, .checkline label { font-size: 0.9375rem; font-weight: 700; }
+
+        .calendar-intro { font-size: 0.875rem; color: var(--text-mid); }
+        .calendar-providers { display: flex; flex-wrap: wrap; gap: 0.5rem; }
+        .calendar-providers .btn { flex: 1 1 auto; min-height: 2.75rem; height: auto; padding: 0.625rem; font-size: 0.8125rem; }
+        .calendar-help { margin-top: 0.375rem; }
+        .calendar-help summary { cursor: pointer; font-weight: 800; padding: 0.25rem 0; }
+        .calendar-help ol { padding-left: 1.125rem; margin-top: 0.5rem; }
+        .calendar-help li + li { margin-top: 0.625rem; }
+        .calendar-test { display: flex; flex-direction: column; gap: 0.5rem; border-top: 1px solid var(--border); padding-top: 1rem; }
+        .calendar-test-next { margin-top: 0.5rem; }
 
         .note-box { background: var(--warm); border-radius: 0.875rem; padding: 0.8125rem 0.9375rem; font-size: 0.8125rem; color: var(--text-mid); line-height: 1.55; }
         .flash { border-radius: 0.875rem; padding: 0.8125rem 0.9375rem; font-size: 0.875rem; font-weight: 700; }

--- a/web/templates/settings/edit.html
+++ b/web/templates/settings/edit.html
@@ -13,8 +13,8 @@
 <div class="problems"><ul>{% for problem in problems %}<li>{{ problem }}</li>{% endfor %}</ul></div>
 {% endif %}
 
-{% if checked %}
-<div class="flash {{ 'ok' if checked.ok else 'error' }}">{{ checked.message }}</div>
+{% if section_name == 'calendars' %}
+<p class="calendar-intro">Bring events onto your board. Name the calendar, then copy its sharing link from your calendar provider.</p>
 {% endif %}
 
 <form id="edit-form" method="post" class="card pad" style="display:flex;flex-direction:column;gap:1rem;">
@@ -24,10 +24,12 @@
         {% if kind != 'checkbox' %}<label for="f-{{ name }}">{{ label }}</label>{% endif %}
 
         {% if kind == 'text' %}
-            <input type="text" id="f-{{ name }}" name="{{ name }}" value="{{ item.get(name, '') }}" {{ 'required' if required }}>
+            <input type="text" id="f-{{ name }}" name="{{ name }}" value="{{ item.get(name, '') }}" {{ 'required' if required }}
+                   {% if section_name == 'calendars' and name == 'label' %}placeholder="e.g. Family or School" aria-describedby="hint-{{ name }}"{% endif %}>
 
         {% elif kind == 'url' %}
-            <input type="url" id="f-{{ name }}" name="{{ name }}" value="{{ item.get(name, '') }}" {{ 'required' if required }} placeholder="https://calendar.google.com/…/basic.ics">
+            <input type="url" id="f-{{ name }}" name="{{ name }}" value="{{ item.get(name, '') }}" {{ 'required' if required }}
+                   placeholder="https://…" autocapitalize="none" autocorrect="off" spellcheck="false" aria-describedby="hint-{{ name }}">
 
         {% elif kind == 'emails' %}
             {# Stored as a list, typed as one line. A hand-edited file may hold a string; show it as it is. #}
@@ -46,7 +48,7 @@
         {% elif kind == 'checkbox' %}
             <div class="checkline">
                 <input type="checkbox" id="f-{{ name }}" name="{{ name }}" {{ 'checked' if item.get(name) }}>
-                <span>{{ label }}</span>
+                <label for="f-{{ name }}">{{ label }}</label>
             </div>
 
         {% elif kind == 'monthday' %}
@@ -101,14 +103,36 @@
             {% endif %}
         {% endif %}
 
-        {% if help %}<div class="hint">{{ help }}</div>{% endif %}
+        {% if help %}<div class="hint" id="hint-{{ name }}">{{ help }}</div>{% endif %}
+        {% if section_name == 'calendars' and name == 'url' %}
+            {% include "settings/_calendar_help.html" %}
+        {% endif %}
     </div>
     {% endfor %}
 
     {% if section_name == 'calendars' %}
-    <button class="btn outline" type="submit" name="action" value="check">Check this link</button>
+    <div class="calendar-test">
+        <button class="btn outline" type="submit" name="action" value="check" formnovalidate aria-describedby="calendar-test-hint">Test calendar link</button>
+        <p class="hint" id="calendar-test-hint">Optional: fetch upcoming events to confirm the link works and see what passes your guest filter. Testing doesn't save your changes.</p>
+        {% if checked %}
+        <div class="flash {{ 'ok' if checked.ok else 'error' }}" role="status" id="calendar-test-result" tabindex="-1">
+            <strong>Calendar test result</strong>
+            <p>{{ checked.message }}</p>
+            {% if checked.recovery %}<p class="calendar-test-next">{{ checked.recovery }}</p>{% endif %}
+            {% if checked.link_help %}<p class="calendar-test-next"><a href="#f-url">Replace calendar link ↑</a></p>{% endif %}
+            {% if checked.ok %}<p class="calendar-test-next">Ready to keep it? Save the calendar below.</p>{% endif %}
+        </div>
+        {% endif %}
+    </div>
+    <button class="btn" type="submit" name="action" value="save">Save calendar</button>
     {% endif %}
 </form>
+
+{% if checked %}
+<script>
+    document.getElementById('calendar-test-result').focus();
+</script>
+{% endif %}
 
 {% if not is_new %}
 <form method="post" action="{{ url_for('settings.section_delete', section_name=section_name, item_id=item_id) }}"

--- a/website/content/cozi-calendar-display.md
+++ b/website/content/cozi-calendar-display.md
@@ -69,8 +69,8 @@ does not work on, and [the Echo Show page](/echo-show-calendar-display/) says wh
 Point it at Cozi:
 
 1. Open **Settings → Calendars → Add a calendar**.
-2. Give it a name — "Cozi" or the child's name — and paste the URL into **iCal link**.
-3. Press **Check this link**. It reports how many events it found and what the next one is,
+2. Give it a name — "Cozi" or the child's name — and paste the URL into **Calendar link (iCal / ICS)**.
+3. Press **Test calendar link**. It reports how many events it found and what the next one is,
    so you know it works before you save.
 4. Repeat for each family member's feed you shared.
 

--- a/website/content/getting-started.md
+++ b/website/content/getting-started.md
@@ -69,7 +69,7 @@ Each family member is a separate feed, so share each one you want and add them a
 
 ### Then paste it in
 
-Put the link in `config.yaml` under `calendars:` (step 2 below), or add it later from the settings page: **Settings → Calendars → Add a calendar**, then press **Check this link** to confirm it works before you save.
+Put the link in `config.yaml` under `calendars:` (step 2 below), or add it later from the settings page: **Settings → Calendars → Add a calendar**, then press **Test calendar link** to confirm it works before you save.
 
 Whichever provider it came from, treat the link like a password. Anyone who has it can read that calendar, for as long as it exists, and there is no way to see who has.
 
@@ -80,7 +80,7 @@ You do not need a separate family calendar. If your own calendar also holds work
 Two things to get right:
 
 - **Use the address on the invitation.** Google, Apple and Outlook all record guests by email address, so it has to be the one you actually invite them with. If they have two, list both with a comma between them.
-- **Press Check this link before you save.** With a guest list filled in, it says how many events get through out of how many, and warns you if none do. That usually means the address is not the one on the invitations, or that nothing in the next fortnight has been shared yet.
+- **Press Test calendar link before you save.** With a guest list filled in, it says how many events get through out of how many, and warns you if none do. That usually means the address is not the one on the invitations, or that nothing in the next fortnight has been shared yet.
 
 Each calendar has its own list, so the school calendar, which has no guests, is left alone. Saving a calendar clears whatever was fetched from it before, so nothing from before the guest list lingers; the board picks it up again at the next refresh, or straight away if you press **Refresh calendars**. In `config.yaml` the same setting is `shared_with`, a list of addresses under that calendar.
 
@@ -219,7 +219,7 @@ The settings page adds a short `id` to each person, pet, chore, date and calenda
 Everything on the board is editable at `/settings`. Two things worth knowing:
 
 - **A saved board is from this morning.** Editing a chore or a person shows up on the next page load, but the headline and daily line are only rewritten each morning. Press **Rewrite now** on the settings home page to get fresh copy immediately. Each press is one API call.
-- **Adding a calendar checks the link.** Paste an iCal address and press **Check this link**. It tells you how many events it found and what the next one is, so you are not left guessing whether the URL works.
+- **Adding a calendar checks the link.** Paste an iCal address and press **Test calendar link**. It tells you how many events it found and what the next one is, so you are not left guessing whether the URL works.
 - **A personal calendar can keep its private side.** Fill in **Only show events shared with** on that calendar, and only the events the other parent is on reach the board. See [a personal calendar with work in it](#personal-calendar) above.
 
 The board can be in one of three states: the normal board, a first-run "waiting" screen before anything is generated, or a stale state after a failed or missing run. When stale, the times, turns and countdowns are still today's — only the written line is old, and the board says so.
@@ -464,7 +464,7 @@ The old `lcd_rotate` and `display_rotate` lines in `config.txt` no longer apply 
 
 **Times are off by an hour.** The timezone under Settings → Family & system is what the engine uses, not the machine clock. Set it even if the clock is already local.
 
-**A calendar shows nothing.** Check it under Settings → Calendars — a failed feed says so. Apple regenerates iCloud links when a calendar stops being shared, so a link that worked last month may need replacing. If the calendar has **Only show events shared with** filled in, open it and press **Check this link**: a working link with no events getting through means the address is not the one on the invitations.
+**A calendar shows nothing.** Check it under Settings → Calendars — a failed feed says so. Apple regenerates iCloud links when a calendar stops being shared, so a link that worked last month may need replacing. If the calendar has **Only show events shared with** filled in, open it and press **Test calendar link**: a working link with no events getting through means the address is not the one on the invitations.
 
 **A GNOME keyring password box appears.** The `--password-store=basic` flag in `run.sh` prevents this. Make sure it is present.
 

--- a/website/content/google-calendar-ical-link.md
+++ b/website/content/google-calendar-ical-link.md
@@ -99,8 +99,8 @@ connection, and it can only read.
 To add it:
 
 1. Open **Settings → Calendars → Add a calendar**.
-2. Give it a name and paste the address into **iCal link**.
-3. Press **Check this link**. It says how many events it found and what the next one is, so
+2. Give it a name and paste the address into **Calendar link (iCal / ICS)**.
+3. Press **Test calendar link**. It says how many events it found and what the next one is, so
    you know it works before you save.
 
 ![Adding a calendar in DinkyDash's settings: a name, the iCal link, and a Check this link button](/images/settings-add-calendar.webp)

--- a/website/content/icloud-calendar-link.md
+++ b/website/content/icloud-calendar-link.md
@@ -109,8 +109,8 @@ anywhere in it — the link is the entire connection, and it can only read.
 To add it:
 
 1. Open **Settings → Calendars → Add a calendar**.
-2. Give it a name and paste the address into **iCal link**. A `webcal://` link is fine.
-3. Press **Check this link**. It reports how many events it found and what the next one is,
+2. Give it a name and paste the address into **Calendar link (iCal / ICS)**. A `webcal://` link is fine.
+3. Press **Test calendar link**. It reports how many events it found and what the next one is,
    so you know before you save.
 
 ![Adding a calendar in DinkyDash's settings: a name, the iCal link, and a Check this link button](/images/settings-add-calendar.webp)

--- a/website/content/outlook-calendar-ics-link.md
+++ b/website/content/outlook-calendar-ics-link.md
@@ -109,8 +109,8 @@ it — the published link is the whole connection, and it can only read.
 To add it:
 
 1. Open **Settings → Calendars → Add a calendar**.
-2. Give it a name and paste the ICS address into **iCal link**.
-3. Press **Check this link**. It says how many events came back and what the next one is,
+2. Give it a name and paste the ICS address into **Calendar link (iCal / ICS)**.
+3. Press **Test calendar link**. It says how many events came back and what the next one is,
    before you save.
 
 ![Adding a calendar in DinkyDash's settings: a name, the iCal link, and a Check this link button](/images/settings-add-calendar.webp)


### PR DESCRIPTION
Calendar setup now explains the calendar name, offers Google Calendar, Apple/iCloud and Outlook shortcuts with sharing instructions, and separates the optional “Test calendar link” action from saving.
Inaccessible, missing or unreadable feeds now show actionable recovery guidance, expand provider instructions and focus the result while preserving unsaved fields.
The change also improves form labels and button styling, updates the setup guides, and adds regression coverage for failed links without treating server outages as sharing problems.

Validation: 671 tests passed (309 environment-dependent skips); browser checks covered phone and desktop layouts, failed-test recovery, webcal links and save validation.
