### PR TITLE
Add a growth page: signups and activations by week, behind an admin list

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -109,6 +109,15 @@ envs:
   - key: SENDGRID_API_KEY
     scope: RUN_TIME
     type: SECRET
+  # Who may open /admin, the operator's page (DIN-37): a comma-separated list
+  # of account addresses. Not a credential — but an address is personal data
+  # and this file is public, the same reason the logs record a domain and
+  # never an address — so it is merged in from `.env` like the secrets above.
+  # **Put it in `.env` before the next apply**, or the merge snippet in the
+  # header fails on the missing key. Unset means nobody can open the page.
+  - key: DINKYDASH_ADMIN_EMAILS
+    scope: RUN_TIME
+    type: SECRET
 
   # The spend breaker (DIN-43), in model calls a day. Written out at their
   # defaults rather than left implicit, because a ceiling nobody can see is a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,6 +154,12 @@ mode is a different product on the same code.
   anywhere. When a route does one day take a family id — the admin view is the likely first — the
   check goes in `family.py`, before the store is built, and **a mismatch is a 404 and never a 403**:
   "forbidden" confirms the row exists, which tells one family that another one does.
+- **The operator's page is behind a list of addresses, and a miss is a 404.** `/admin` (DIN-37)
+  shows signups and activations by week, and only to a signed-in account whose address is in
+  `DINKYDASH_ADMIN_EMAILS`. Anybody else gets the same answer as a URL that does not exist, and an
+  unset list means nobody. It reads `growth_by_day` — a date and two counts, kept by a trigger on
+  `families` and surviving deletion the way `global_model_spend` does — and one bare `count(*)`, so
+  no family row is read and no id passes through it. `tests/test_admin.py` asserts each of those.
 - **`web/__init__.py` falls back to a hardcoded `app.secret_key`.** Harmless with no auth; in cloud
   mode the session *is* the authentication, so cloud mode must refuse to start without a real
   `DINKYDASH_SECRET_KEY`.
@@ -305,6 +311,7 @@ dinkydash/
 ├── screens.py         the token that puts a board on a wall (cloud only)
 ├── budget.py          what a family may spend on the model, and what everybody may
 │                     (`accounts.delete_family` is the hard delete; see phase 5)
+├── growth.py          signups and activations per day, with no family in the row (cloud only)
 └── runner.py          the two halves of the day, reading and writing through a store
 
 web/
@@ -316,7 +323,8 @@ web/
 ├── routes/settings.py the settings UI (one table drives every list section)
 ├── routes/auth.py     /login, /login/link, /logout — cloud mode only
 ├── routes/screen.py   /s/<token> — the board with no session, cloud mode only
-└── templates/         board.html, preview.html, auth/*.html, settings/*.html
+├── routes/admin.py    /admin — signups and activations by week, for DINKYDASH_ADMIN_EMAILS only
+└── templates/         board.html, preview.html, auth/*.html, settings/*.html, admin/growth.html
 ```
 
 ### The storage seam

--- a/PLAN.md
+++ b/PLAN.md
@@ -232,7 +232,8 @@ in `calendars.py`. Keep business calculations independent of clocks and files.
 | `.do/app.yaml`, `.python-version`, `requirements-cloud.txt` | Hosted components, Python build and dependencies |
 | `tests/`, `.github/workflows/test.yml` | Both-mode validation and CI |
 
-Billing and admin functionality are future work; there is no planned ORM/model layer
+Billing is future work, and admin functionality so far is the growth page at `/admin`
+([DIN-37](https://linear.app/keepthescore/issue/DIN-37)); there is no planned ORM/model layer
 or duplicate self-hosted config loader.
 
 ### URL map
@@ -244,6 +245,7 @@ or duplicate self-hosted config loader.
 | `/settings/…` | Local settings | Settings scoped to the session's family |
 | `/s/<token>` | Not used | Bearer-token board |
 | `/preview` | Three sizes of the local board | Authenticated preview of the tokenised board |
+| `/admin` | Not used | Signups and activations by week, for addresses in `DINKYDASH_ADMIN_EMAILS` only |
 | `/healthz` | Process health | Process health, not worker/database health |
 
 Stripe routes are not implemented; their contract belongs to [DIN-53](https://linear.app/keepthescore/issue/DIN-53).
@@ -254,7 +256,7 @@ The SQL files in [migrations/](migrations/) are authoritative. The current table
 
 | Table | Stored data / current use |
 |---|---|
-| `families` | Config, screen token, account status, trial deadline and lapse timestamp |
+| `families` | Config, screen token, account status, trial deadline, lapse and activation timestamps |
 | `users` | Family membership and login address |
 | `login_tokens` | Hashed single-use token, expiry, and either user or signup email |
 | `agendas` | One overwritten calendar window and fetch status per family |
@@ -262,6 +264,7 @@ The SQL files in [migrations/](migrations/) are authoritative. The current table
 | `content_history` | Recent generated copy, trimmed to the configured history length (at least 30) |
 | `model_spend` | Daily per-family calls and reported tokens |
 | `global_model_spend` | Daily call totals without family identifiers; survives deletion |
+| `growth_by_day` | Daily signups and activations without family identifiers, kept by a trigger; survives deletion |
 | `calendar_health` | Schema exists; recurring-failure tracking is not yet wired up |
 | `schema_migrations` | Applied migration versions |
 
@@ -404,7 +407,7 @@ alone does not close the phase.
 - [ ] Worker heartbeat and external health alerts, verified by a controlled failure ([DIN-54](https://linear.app/keepthescore/issue/DIN-54)).
 - [ ] Repeatable restore into an isolated database, with a successful drill recorded ([DIN-56](https://linear.app/keepthescore/issue/DIN-56)).
 - [x] Preserve explicit preview database overrides ([DIN-48](https://linear.app/keepthescore/issue/DIN-48)).
-- [ ] Dedicated admin/registration analytics dashboard ([DIN-37](https://linear.app/keepthescore/issue/DIN-37); Backlog).
+- [ ] Admin dashboard ([DIN-37](https://linear.app/keepthescore/issue/DIN-37)): signups and activations by week exist at `/admin`, behind `DINKYDASH_ADMIN_EMAILS` (migration 006, `dinkydash/growth.py`). Spend, trial status and calendar health, per the issue's triage, remain Backlog.
 
 **Done when:** an operator can detect stopped/failed work, inspect useful metadata and
 recover the application. A healthy `/healthz` response alone is insufficient.
@@ -434,9 +437,9 @@ already exist and are not exclusions. Manual rewrites also already exist.
 Weather ([DIN-24](https://linear.app/keepthescore/issue/DIN-24)) and photo/screensaver mode ([DIN-11](https://linear.app/keepthescore/issue/DIN-11)) remain deferred scope decisions.
 Their issues must agree with the plan before either is promoted into the MVP.
 
-Additional edge rules, Sentry instrumentation, an admin analytics dashboard,
-persisted retry backoff/parent notifications, a feedback widget and public launch
-promotion are also Backlog. Existing redacted logs, bounded retries and support email
+Additional edge rules, Sentry instrumentation, the rest of the admin dashboard (spend,
+trial status, calendar health), persisted retry backoff/parent notifications, a feedback
+widget and public launch promotion are also Backlog. Existing redacted logs, bounded retries and support email
 cover those needs for the MVP alongside the remaining liveness and recovery work.
 
 ## Open questions

--- a/dinkydash/CLAUDE.md
+++ b/dinkydash/CLAUDE.md
@@ -68,19 +68,25 @@ thirty-day session can outlive the account it names, and that should sign the ho
 500. Catching the bare parent would swallow `KeyError` and `IndexError` too, which is to say every
 real bug, and send it to the login page.
 
-Three things are unscoped, all deliberately outside the store rather than weakening it, and each
-because there is no family to scope *to* yet:
+Four things are unscoped, all deliberately outside the store rather than weakening it, and each
+because there is no family to scope *to*:
 
 - **`worker.family_ids`**, whose whole job is to walk every family;
 - **`dinkydash/accounts.py`**, which resolves an email address to a user before there is a family.
   A magic link has to find exactly one person without being told which family they belong to, which
   is why `users.email` is globally unique;
 - **`dinkydash/screens.py`**, which resolves a screen token to a family. A wall panel has no session
-  to scope to and never will — that is what the token is for.
+  to scope to and never will — that is what the token is for;
+- **`dinkydash/growth.py`**, which reads the signup and activation counter for the operator's page
+  (DIN-37). The narrowest of the four: `growth_by_day` is a date and two counts with no family
+  identifier to scope by, kept by a trigger on `families` (migration 006) so that it survives
+  deletion the way `global_model_spend` does, and `families_now` is a bare `count(*)`.
 
-Each of the three hands its result to a `PostgresStore` built for exactly one family, so the rule
-that matters is untouched. `web/family.py` is where the last two arrive, and it has both doors in
-one file on purpose: if a third is ever added it should be as obvious as those two are.
+Each of the first three hands its result to a `PostgresStore` built for exactly one family, and the
+fourth reads no row about any family at all, so the rule that matters is untouched. `web/family.py`
+is where the second and third arrive, and it has both doors in one file on purpose — `is_admin`,
+the gate on the operator's page, sits beside them for the same reason: if another is ever added it
+should be as obvious as those are.
 
 ## Signing somebody in, and signing somebody up
 

--- a/dinkydash/growth.py
+++ b/dinkydash/growth.py
@@ -1,0 +1,78 @@
+"""Signups and activations over time, for whoever runs the service. Cloud only.
+
+    history(pool)                -> every day with a signup or an activation
+    families_now(pool)           -> how many families exist right now
+    by_week(rows, weeks, today)  -> the last `weeks` weeks, gaps filled (pure)
+    totals(rows)                 -> all-time signups and activations (pure)
+
+A **signup** is a family created — the click on the emailed link, never the
+address being submitted (DIN-41). An **activation** is the first time that
+family's settings carry a calendar link, which `config.starter_config` calls
+the parent's first real act. Both are counted per UTC day by a trigger on
+`families` (migration 006) into `growth_by_day`, a table with a date and two
+counts in it and nothing else.
+
+**This is the fourth deliberately unscoped read in the product**, after
+`worker.family_ids`, `accounts.py` and `screens.py`, and it is the narrowest
+of them: the table it reads carries no family identifiers, so there is nothing
+here that *could* be scoped. `families_now` is a bare `count(*)`. No row about
+any one family is read, and no id passes through this module in either
+direction — which is the property an operator's page in a public repo should
+have, so that a bug in it cannot leak a family.
+
+Like `accounts.py`, this imports no driver: it is handed a pool and asks it for
+connections.
+"""
+
+from collections import namedtuple
+from datetime import timedelta
+
+# One week on the chart. `start` is the Monday, as a date.
+Week = namedtuple("Week", "start signups activations")
+Totals = namedtuple("Totals", "signups activations")
+
+
+def history(pool):
+    """Every day on which somebody signed up or activated, oldest first.
+
+    One row per day with something in it — a year of a small product is a few
+    hundred rows — so the roll-up below can be a pure function over the lot.
+    """
+    with pool.connection() as conn, conn.cursor() as cur:
+        cur.execute("SELECT day, signups, activations FROM growth_by_day ORDER BY day")
+        return cur.fetchall()
+
+
+def families_now(pool):
+    """How many families exist at this moment. A count, and only a count."""
+    with pool.connection() as conn, conn.cursor() as cur:
+        cur.execute("SELECT count(*) FROM families")
+        return cur.fetchone()[0]
+
+
+def week_of(day):
+    """The Monday of the week that day is in."""
+    return day - timedelta(days=day.weekday())
+
+
+def by_week(rows, weeks, today):
+    """The last `weeks` weeks up to and including today's, oldest first.
+
+    Every week in the span is present, so a quiet fortnight reads as two empty
+    columns rather than a gap the eye closes over. `today` is passed in rather
+    than read from a clock, like everything else in this package.
+    """
+    weeks = max(1, int(weeks))
+    first = week_of(today) - timedelta(weeks=weeks - 1)
+    counts = {first + timedelta(weeks=i): [0, 0] for i in range(weeks)}
+    for day, signups, activations in rows:
+        bucket = counts.get(week_of(day))
+        if bucket is not None:
+            bucket[0] += signups
+            bucket[1] += activations
+    return [Week(start, *pair) for start, pair in sorted(counts.items())]
+
+
+def totals(rows):
+    """All-time signups and activations, whatever span the chart shows."""
+    return Totals(sum(row[1] for row in rows), sum(row[2] for row in rows))

--- a/doc/operations.md
+++ b/doc/operations.md
@@ -511,3 +511,19 @@ never a guarantee. The old
 `0 6 * * * generate.py` line still works and does both halves at once; use one or the other, not
 both. A failed run leaves the previous board in place rather than blanking the screen, the board
 labels itself stale, and the next tick tries again.
+
+
+## The operator's page, 10 September 2026 (DIN-37)
+
+`/admin` on `app.dinkydash.co` shows signups and activations by week, to accounts whose address is
+in `DINKYDASH_ADMIN_EMAILS` and to nobody else. **The variable is not set anywhere yet.** It is in
+`.do/app.yaml` as a `type: SECRET` entry with no value, so the next `doctl apps update` needs it in
+`.env` first or the merge snippet in the spec's header fails on the missing key — and until that
+apply happens the page answers 404 to everyone, including the owner. `deploy_on_push` does not
+apply the spec (see above), so merging alone does not open the page.
+
+Migration 006 (`growth_by_day`, `families.activated_at`) applies itself through the pre-deploy job
+on the next deploy. Its backfill stamps every family that already has a calendar with the time of
+its last settings save, which is the latest the calendar could have been added and the only stamp
+there is: approximate for the families that exist today, exact for every family after. Counts are
+per UTC day and are never subtracted from, so a deleted account still shows as a signup.

--- a/migrations/006_growth.sql
+++ b/migrations/006_growth.sql
@@ -1,0 +1,101 @@
+-- Signups and activations, counted per day and kept without a family (DIN-37).
+--
+-- Two moments in a family's life are worth counting over time: the click on
+-- the emailed link that creates the family (a **signup**), and the first time
+-- its settings carry a calendar link (an **activation**) — "the parent's first
+-- real act in the settings UI", as `config.starter_config` puts it. The first
+-- has always been `families.created_at`. The second had no record at all.
+--
+-- **Why a daily aggregate rather than a query over `families`.** Deleting an
+-- account is a hard delete, so a chart drawn from `created_at` forgets a signup
+-- the moment that family leaves. A week in which five families signed up and
+-- all five deleted their accounts would then show as a week in which nothing
+-- happened — which is the one week worth looking at. `global_model_spend` (004)
+-- already made this trade for the spend breaker: a date and a count survive
+-- deletion, and nothing in the row leads back to a family.
+--
+-- **Why a trigger.** Every path that writes a config runs through it — the
+-- settings UI, a hand-run UPDATE, whatever imports a config one day — so the
+-- count cannot drift from the truth by way of a caller that forgot to call
+-- something. The same reasoning as `count_global_model_calls` and
+-- `stamp_family_lapse`.
+--
+-- `families.activated_at` is what makes an activation count **once**: a
+-- calendar removed and added again is not a second activation. It is also the
+-- per-family answer to "when did they get going", which the aggregate cannot
+-- give. It is a real column because it is something the platform writes,
+-- not something the parent typed (001, on what earns a column).
+--
+-- **UTC days**, like `model_spend`: a total summed over a dozen local dates is
+-- not a day, and there is no family clock to use here anyway.
+
+-- The pre-deploy job runs while the old web code is still creating families and
+-- saving settings. Block writes until the backfill and the trigger are both in
+-- place, so a signup landing between the two is counted exactly once. Reads
+-- carry on; the board is not affected.
+LOCK TABLE families IN SHARE ROW EXCLUSIVE MODE;
+
+ALTER TABLE families ADD COLUMN activated_at TIMESTAMPTZ;
+
+CREATE TABLE growth_by_day (
+    day         DATE PRIMARY KEY,
+    signups     INTEGER NOT NULL DEFAULT 0 CHECK (signups >= 0),
+    activations INTEGER NOT NULL DEFAULT 0 CHECK (activations >= 0)
+);
+
+-- Does this config connect a calendar: a `calendars` entry with a link in it?
+-- Written as a CASE so the array function is never reached for a document
+-- whose `calendars` is not an array. A trigger that raised on an odd document
+-- would turn one family's settings save into a 500.
+CREATE FUNCTION config_has_a_calendar(config JSONB) RETURNS boolean
+LANGUAGE sql IMMUTABLE AS $$
+    SELECT CASE
+        WHEN jsonb_typeof(config -> 'calendars') = 'array' THEN EXISTS (
+            SELECT 1 FROM jsonb_array_elements(config -> 'calendars') AS entry
+            WHERE jsonb_typeof(entry) = 'object'
+              AND coalesce(entry ->> 'url', '') <> '')
+        ELSE false
+    END
+$$;
+
+-- Backfill. A family that already has a calendar was activated at some point
+-- before now; the last settings save is the latest that could have been, and
+-- it is the only stamp there is. Approximate for the families that predate
+-- this migration, exact for every family after it.
+UPDATE families SET activated_at = updated_at WHERE config_has_a_calendar(config);
+
+INSERT INTO growth_by_day (day, signups, activations)
+SELECT day, sum(signups), sum(activations)
+FROM (
+    SELECT (created_at AT TIME ZONE 'UTC')::date AS day, 1 AS signups, 0 AS activations
+    FROM families
+    UNION ALL
+    SELECT (activated_at AT TIME ZONE 'UTC')::date, 0, 1
+    FROM families WHERE activated_at IS NOT NULL
+) AS moments
+GROUP BY day;
+
+CREATE FUNCTION count_family_growth() RETURNS trigger
+LANGUAGE plpgsql AS $$
+BEGIN
+    IF TG_OP = 'INSERT' THEN
+        INSERT INTO growth_by_day (day, signups)
+        VALUES ((NEW.created_at AT TIME ZONE 'UTC')::date, 1)
+        ON CONFLICT (day) DO UPDATE SET signups = growth_by_day.signups + 1;
+    END IF;
+    IF NEW.activated_at IS NULL AND config_has_a_calendar(NEW.config) THEN
+        NEW.activated_at := now();
+        INSERT INTO growth_by_day (day, activations)
+        VALUES ((now() AT TIME ZONE 'UTC')::date, 1)
+        ON CONFLICT (day) DO UPDATE SET activations = growth_by_day.activations + 1;
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+-- BEFORE, not AFTER, because it writes `NEW.activated_at`. A family inserted
+-- with a calendar already in its config counts as both on the same day.
+-- Deletion is deliberately not a trigger: nothing is ever subtracted.
+CREATE TRIGGER count_family_growth
+BEFORE INSERT OR UPDATE OF config ON families
+FOR EACH ROW EXECUTE FUNCTION count_family_growth();

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,11 +66,14 @@ def forget_unowned_rows(pool):
 
     The global model-call aggregate also has no family foreign key. Clear it
     explicitly here so one test's calls cannot exhaust another test's budget.
+    The signup and activation counter (migration 006) survives deletion for
+    the same reason and is cleared for the same one.
     """
     with pool.connection() as conn, conn.transaction():
         with conn.cursor() as cur:
             cur.execute("DELETE FROM login_tokens WHERE user_id IS NULL")
             cur.execute("DELETE FROM global_model_spend")
+            cur.execute("DELETE FROM growth_by_day")
 
 
 @pytest.fixture

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,0 +1,232 @@
+"""The operator's page at /admin: who may open it, and what it shows (DIN-37).
+
+* **single mode has no such page.** One family, nothing to count, and no
+  session to check — a 404 with no database at all;
+* **cloud mode puts it behind the login, then behind a list.** Signed out is a
+  redirect to `/login` like every other page a person signs into; signed in
+  and not on `DINKYDASH_ADMIN_EMAILS` is a 404, never a 403;
+* **an empty list is nobody**, including the person who would obviously be
+  on it. A new deployment is closed until somebody opens it;
+* **the page is counts.** It reads the counter and the number of families,
+  and it takes no id from the request, the session or the URL.
+
+The chart's arithmetic is tested with no database. The rest skips without
+`DINKYDASH_TEST_DATABASE_URL`.
+"""
+
+import re
+from datetime import date, timedelta
+
+import pytest
+
+from dinkydash import growth
+from dinkydash.store import FileStore
+from tests.conftest import client_for
+from web import create_app
+from web.routes import admin
+
+ADDRESS = "owner@example.com"
+
+
+def test_single_mode_has_no_admin_page(tmp_path, monkeypatch):
+    monkeypatch.delenv("DINKYDASH_MODE", raising=False)
+    monkeypatch.setenv("DINKYDASH_ADMIN_EMAILS", ADDRESS)
+    (tmp_path / "config.yaml").write_text('family_name: "The Wilsons"\n')
+    client = client_for(create_app(FileStore(tmp_path / "config.yaml")))
+    assert client.get("/admin").status_code == 404
+
+
+# -- the drawing, with no database ------------------------------------------
+
+class TestTheChart:
+    @pytest.mark.parametrize("highest,expected", [
+        (0, (1, 1)), (1, (1, 1)), (4, (4, 1)), (5, (5, 1)), (6, (6, 2)), (7, (8, 2)),
+        (11, (15, 5)), (23, (25, 5)), (26, (30, 10)), (51, (60, 20)), (999, (1000, 200)),
+    ])
+    def test_the_axis_ends_on_a_clean_number_with_at_most_five_lines(self, highest, expected):
+        ceiling, step = admin.scale(highest)
+        assert (ceiling, step) == expected
+        assert ceiling // step <= admin.MOST_GRIDLINES
+
+    def weeks(self, n, values=()):
+        values = dict(values)
+        return [growth.Week(date(2026, 1, 5) + timedelta(weeks=i), *values.get(i, (0, 0)))
+                for i in range(n)]
+
+    def test_one_column_pair_per_week_and_nothing_drawn_for_a_zero(self):
+        drawn = admin.chart(self.weeks(3, {1: (2, 1)}))
+        assert len(drawn["columns"]) == 3
+        assert [bar["path"] for bar in drawn["columns"][0]["bars"]] == ["", ""]
+        assert all(bar["path"].startswith("M") for bar in drawn["columns"][1]["bars"])
+
+    def test_columns_stay_thin_and_two_always_fit_in_their_week(self):
+        for n in (1, 4, 12, 26, admin.MOST_WEEKS):
+            drawn = admin.chart(self.weeks(n, {0: (3, 1)}))
+            assert drawn["thickness"] <= admin.THICKEST
+            slot = drawn["columns"][0]["slot_w"]
+            assert 2 * drawn["thickness"] + admin.GAP <= slot + 0.01, n
+
+    def test_the_tallest_column_reaches_no_higher_than_the_top_gridline(self):
+        drawn = admin.chart(self.weeks(2, {1: (7, 3)}))
+        top = min(line["y"] for line in drawn["gridlines"])
+        tallest = min(bar["y"] for column in drawn["columns"] for bar in column["bars"])
+        assert tallest >= top
+        assert drawn["gridlines"][0]["y"] == drawn["baseline"]
+
+    def test_only_the_latest_week_is_marked_for_direct_labels(self):
+        drawn = admin.chart(self.weeks(5, {0: (4, 2), 4: (1, 0)}))
+        assert [column["last"] for column in drawn["columns"]] == [False] * 4 + [True]
+
+    def test_week_labels_thin_out_but_the_latest_week_always_has_one(self):
+        for n in (1, 12, 26, admin.MOST_WEEKS):
+            drawn = admin.chart(self.weeks(n))
+            labelled = [column for column in drawn["columns"] if column["label"]]
+            assert 1 <= len(labelled) <= admin.MOST_WEEK_LABELS + 1, n
+            assert drawn["columns"][-1]["label"], n
+
+    def test_a_column_is_rounded_on_top_and_square_at_the_foot(self):
+        path = admin.column_path(10, 100, 20, 50)
+        assert path.startswith("M10.00,150.00 V104.00 Q10.00,100.00 14.00,100.00")
+        assert path.endswith("V150.00 Z")
+        assert admin.column_path(10, 100, 20, 0) == ""
+
+    @pytest.mark.parametrize("raw,weeks", [
+        (None, 12), ("", 12), ("abc", 12), ("12", 12), ("26", 26),
+        ("0", 1), ("-4", 1), ("52", 52), ("9999", 52), ("3.5", 12),
+    ])
+    def test_the_span_is_bounded(self, raw, weeks):
+        assert admin.span(raw) == weeks
+
+
+# -- who gets in, in Postgres ------------------------------------------------
+
+@pytest.fixture
+def user(pg_pool, pg_family):
+    with pg_pool.connection() as conn, conn.transaction(), conn.cursor() as cur:
+        cur.execute("INSERT INTO users (family_id, email) VALUES (%s, %s) RETURNING id",
+                    (pg_family, ADDRESS))
+        return pg_family, cur.fetchone()[0]
+
+
+@pytest.fixture
+def cloud(pg_pool, monkeypatch):
+    monkeypatch.setenv("DINKYDASH_MODE", "cloud")
+    monkeypatch.setenv("DINKYDASH_SECRET_KEY", "a-real-one")
+    monkeypatch.delenv("DINKYDASH_ADMIN_EMAILS", raising=False)
+    return create_app(pool=pg_pool)
+
+
+def signed_in(app, user):
+    family_id, user_id = user
+    client = client_for(app)
+    with client.session_transaction() as stored:
+        stored["user_id"] = user_id
+        stored["family_id"] = str(family_id)
+    return client
+
+
+class TestWhoMayLook:
+    def test_signed_out_is_sent_to_the_login_like_any_other_page(self, cloud, monkeypatch):
+        monkeypatch.setenv("DINKYDASH_ADMIN_EMAILS", ADDRESS)
+        response = client_for(cloud).get("/admin")
+        assert response.status_code == 302
+        assert response.headers["Location"].endswith("/login")
+
+    def test_with_no_list_nobody_is_an_admin(self, cloud, user):
+        assert signed_in(cloud, user).get("/admin").status_code == 404
+
+    def test_with_an_empty_list_nobody_is_an_admin(self, cloud, user, monkeypatch):
+        monkeypatch.setenv("DINKYDASH_ADMIN_EMAILS", " , ,")
+        assert signed_in(cloud, user).get("/admin").status_code == 404
+
+    def test_somebody_else_on_the_list_is_a_404_and_never_a_403(self, cloud, user, monkeypatch):
+        monkeypatch.setenv("DINKYDASH_ADMIN_EMAILS", "somebody@example.com")
+        assert signed_in(cloud, user).get("/admin").status_code == 404
+
+    def test_the_address_on_the_list_gets_in_however_it_is_written(self, cloud, user, monkeypatch):
+        monkeypatch.setenv("DINKYDASH_ADMIN_EMAILS", "other@example.com,  Owner@Example.COM ")
+        response = signed_in(cloud, user).get("/admin")
+        assert response.status_code == 200
+        assert response.headers["Cache-Control"] == "no-store"
+        assert "Growth" in response.get_data(as_text=True)
+
+    def test_a_session_naming_a_user_that_is_gone_is_a_404(self, cloud, user, monkeypatch):
+        monkeypatch.setenv("DINKYDASH_ADMIN_EMAILS", ADDRESS)
+        client = signed_in(cloud, user)
+        with pg_pool_of(cloud).connection() as conn, conn.transaction(), conn.cursor() as cur:
+            cur.execute("DELETE FROM users WHERE id = %s", (user[1],))
+        assert client.get("/admin").status_code == 404
+
+
+def pg_pool_of(app):
+    return app.config["POOL"]
+
+
+# -- what it shows -----------------------------------------------------------
+
+@pytest.fixture
+def admin_client(cloud, user, monkeypatch):
+    monkeypatch.setenv("DINKYDASH_ADMIN_EMAILS", ADDRESS)
+    return signed_in(cloud, user)
+
+
+def rows_in_the_table(html):
+    body = re.search(r"<tbody>(.*?)</tbody>", html, re.S).group(1)
+    return re.findall(r"<tr>\s*<td>(.*?)</td>\s*<td[^>]*>(\d+)</td>\s*<td[^>]*>(\d+)</td>", body, re.S)
+
+
+class TestWhatItShows:
+    def test_the_numbers_come_from_the_counter(self, admin_client, monkeypatch):
+        from datetime import datetime, timezone
+        this_monday = growth.week_of(datetime.now(timezone.utc).date())
+        monkeypatch.setattr(growth, "history", lambda pool: [
+            (date(2025, 1, 6), 5, 2),          # long ago: in the totals, off the chart
+            (this_monday, 3, 1),               # this week
+        ])
+        monkeypatch.setattr(growth, "families_now", lambda pool: 6)
+        html = admin_client.get("/admin").get_data(as_text=True)
+        # The tiles: 8 signups, 3 activations (38%), 6 families, 2 deleted.
+        tiles = re.findall(r'<div class="value">(\d+)</div>', html)
+        assert tiles == ["8", "3", "6"]
+        assert "38% of signups" in html
+        assert "2 deleted" in html
+        assert "3 this week" in html
+        # The table: twelve weeks, latest first, this week's row on top.
+        rows = rows_in_the_table(html)
+        assert len(rows) == 12
+        assert rows[0][1:] == ("3", "1")
+        assert rows[0][0] == this_monday.strftime("%-d %b %Y")
+        assert all(row[1:] == ("0", "0") for row in rows[1:])
+
+    def test_a_real_signup_appears(self, admin_client, pg_pool):
+        # The fixture's own family was created moments ago, so this week has
+        # at least one signup in it and the page says so.
+        html = admin_client.get("/admin").get_data(as_text=True)
+        rows = rows_in_the_table(html)
+        assert int(rows[0][1]) >= 1
+        assert int(re.findall(r'<div class="value">(\d+)</div>', html)[2]) >= 1
+
+    def test_the_span_is_read_from_the_query_string_and_bounded(self, admin_client):
+        for query, expected in (("", 12), ("?weeks=26", 26), ("?weeks=9999", 52),
+                                ("?weeks=abc", 12), ("?weeks=0", 1)):
+            html = admin_client.get("/admin" + query).get_data(as_text=True)
+            assert len(rows_in_the_table(html)) == expected, query
+
+    def test_a_deleted_account_is_still_counted(self, admin_client, pg_pool):
+        from dinkydash import accounts
+        from dinkydash import config as config_module
+
+        with pg_pool.connection() as conn, conn.transaction(), conn.cursor() as cur:
+            cur.execute("INSERT INTO families (screen_token, config) VALUES (%s, %s::jsonb) "
+                        "RETURNING id", (config_module.new_screen_token(),
+                                         '{"calendars": [{"url": "https://example.com/x.ics"}]}'))
+            other = cur.fetchone()[0]
+        before = rows_in_the_table(admin_client.get("/admin").get_data(as_text=True))[0]
+        assert accounts.delete_family(pg_pool, other)
+        after = rows_in_the_table(admin_client.get("/admin").get_data(as_text=True))[0]
+        assert after == before
+
+    def test_the_page_makes_no_third_party_request(self, admin_client):
+        html = admin_client.get("/admin").get_data(as_text=True)
+        assert not re.search(r'(src|href)="https?://', html.replace("https://dinkydash.co", ""))
+        assert "<script" not in html

--- a/tests/test_growth.py
+++ b/tests/test_growth.py
@@ -1,0 +1,274 @@
+"""Signups and activations: counted once each, and kept after deletion (DIN-37).
+
+Four claims:
+
+* **a signup is a family created**, counted by the row appearing, whatever
+  made it — the click on the emailed link in production, plain SQL here;
+* **an activation is the first calendar link saved**, and it counts once.
+  Removing the calendar and adding it back is not a second activation, and a
+  calendar with no link in it is not one at all;
+* **deleting the family leaves both counts where they were**, the way the
+  spend total does (DIN-49), and the row that survives has no family in it;
+* **the migration backfills** what can be known about the families that
+  predate it, and a family created while the old code is still running is
+  counted exactly once.
+
+The roll-up is pure and is tested with no database. The rest skips without
+`DINKYDASH_TEST_DATABASE_URL`, like the rest of the Postgres half.
+"""
+
+from datetime import date
+
+import pytest
+
+from dinkydash import growth
+
+A_CALENDAR = {"id": "cal12345", "label": "School",
+              "url": "https://example.com/private-xxxx/basic.ics", "enabled": True}
+
+
+# -- the roll-up, with no database in sight ---------------------------------
+
+class TestByWeek:
+    TODAY = date(2026, 9, 10)  # a Thursday; its week starts Monday the 7th
+
+    def test_every_week_in_the_span_is_present_even_when_empty(self):
+        weeks = growth.by_week([], 4, self.TODAY)
+        assert [w.start for w in weeks] == [date(2026, 8, 17), date(2026, 8, 24),
+                                            date(2026, 8, 31), date(2026, 9, 7)]
+        assert all((w.signups, w.activations) == (0, 0) for w in weeks)
+
+    def test_a_day_lands_in_the_week_of_its_monday(self):
+        rows = [(date(2026, 9, 6), 2, 1),   # a Sunday: the week of 31 August
+                (date(2026, 9, 7), 3, 0)]   # a Monday: this week
+        by_start = {w.start: w for w in growth.by_week(rows, 4, self.TODAY)}
+        assert by_start[date(2026, 8, 31)][1:] == (2, 1)
+        assert by_start[date(2026, 9, 7)][1:] == (3, 0)
+
+    def test_days_in_one_week_add_up(self):
+        rows = [(date(2026, 9, 7), 1, 0), (date(2026, 9, 8), 2, 1), (date(2026, 9, 10), 0, 1)]
+        latest = growth.by_week(rows, 1, self.TODAY)[-1]
+        assert (latest.signups, latest.activations) == (3, 2)
+
+    def test_a_day_before_the_span_is_left_out(self):
+        rows = [(date(2026, 8, 16), 9, 9)]  # the Sunday before a 4-week span
+        assert all(w.signups == 0 for w in growth.by_week(rows, 4, self.TODAY))
+
+    def test_a_day_after_today_is_left_out_too(self):
+        # A clock skew or a hand-edited row must not invent a future column.
+        rows = [(date(2026, 9, 14), 5, 5)]
+        weeks = growth.by_week(rows, 2, self.TODAY)
+        assert weeks[-1].start == date(2026, 9, 7)
+        assert all(w.signups == 0 for w in weeks)
+
+    def test_oldest_first_and_the_latest_week_is_last(self):
+        weeks = growth.by_week([], 12, self.TODAY)
+        assert len(weeks) == 12
+        assert weeks == sorted(weeks)
+        assert weeks[-1].start == date(2026, 9, 7)
+
+    def test_totals_count_everything_whatever_the_span(self):
+        rows = [(date(2025, 1, 1), 4, 1), (date(2026, 9, 10), 1, 1)]
+        assert growth.totals(rows) == (5, 2)
+        assert growth.totals([]) == (0, 0)
+
+
+# -- the counter, in Postgres ------------------------------------------------
+
+def counts(pool):
+    """`{day: (signups, activations)}`, straight from the table."""
+    with pool.connection() as conn, conn.cursor() as cur:
+        cur.execute("SELECT day, signups, activations FROM growth_by_day")
+        return {day: (s, a) for day, s, a in cur.fetchall()}
+
+
+def today(pool):
+    """The database's UTC date, which is the one the trigger stamps with."""
+    with pool.connection() as conn, conn.cursor() as cur:
+        cur.execute("SELECT (now() AT TIME ZONE 'UTC')::date")
+        return cur.fetchone()[0]
+
+
+def activated_at(pool, family_id):
+    with pool.connection() as conn, conn.cursor() as cur:
+        cur.execute("SELECT activated_at FROM families WHERE id = %s", (family_id,))
+        return cur.fetchone()[0]
+
+
+def a_family(pool, config="{}"):
+    from dinkydash import config as config_module
+    with pool.connection() as conn, conn.transaction(), conn.cursor() as cur:
+        cur.execute("INSERT INTO families (screen_token, config) VALUES (%s, %s::jsonb) "
+                    "RETURNING id", (config_module.new_screen_token(), config))
+        return cur.fetchone()[0]
+
+
+def forget(pool, family_id):
+    with pool.connection() as conn, conn.transaction(), conn.cursor() as cur:
+        cur.execute("DELETE FROM families WHERE id = %s", (family_id,))
+
+
+@pytest.fixture
+def store(pg_pool, pg_family):
+    from dinkydash.pgstore import PostgresStore
+    return PostgresStore(pg_pool, pg_family)
+
+
+class TestTheCounter:
+    def test_a_new_family_is_a_signup_today_and_nothing_else(self, pg_pool):
+        day = today(pg_pool)
+        before = counts(pg_pool).get(day, (0, 0))
+        family_id = a_family(pg_pool)
+        try:
+            assert counts(pg_pool)[day] == (before[0] + 1, before[1])
+            assert activated_at(pg_pool, family_id) is None
+        finally:
+            forget(pg_pool, family_id)
+
+    def test_saving_a_calendar_is_an_activation(self, pg_pool, pg_family, store):
+        day = today(pg_pool)
+        before = counts(pg_pool).get(day, (0, 0))
+        config = store.load_config()
+        config["calendars"] = [dict(A_CALENDAR)]
+        store.save_config(config)
+        assert counts(pg_pool)[day] == (before[0], before[1] + 1)
+        assert activated_at(pg_pool, pg_family) is not None
+
+    def test_an_activation_counts_once(self, pg_pool, pg_family, store):
+        config = store.load_config()
+        config["calendars"] = [dict(A_CALENDAR)]
+        store.save_config(config)
+        first = activated_at(pg_pool, pg_family)
+        after_one = counts(pg_pool)
+
+        # A second calendar, then none at all, then one again.
+        config["calendars"].append(dict(A_CALENDAR, id="cal67890", label="Swimming"))
+        store.save_config(config)
+        config["calendars"] = []
+        store.save_config(config)
+        config["calendars"] = [dict(A_CALENDAR)]
+        store.save_config(config)
+
+        assert counts(pg_pool) == after_one
+        assert activated_at(pg_pool, pg_family) == first
+
+    def test_a_calendar_with_no_link_is_not_an_activation(self, pg_pool, pg_family, store):
+        before = counts(pg_pool)
+        config = store.load_config()
+        config["calendars"] = [{"id": "cal12345", "label": "School", "url": "", "enabled": True}]
+        store.save_config(config)
+        assert counts(pg_pool) == before
+        assert activated_at(pg_pool, pg_family) is None
+
+    def test_an_odd_document_does_not_break_the_save(self, pg_pool, pg_family):
+        """A trigger that raised here would be a 500 on somebody's settings page."""
+        before = counts(pg_pool)
+        with pg_pool.connection() as conn, conn.transaction(), conn.cursor() as cur:
+            for odd in ('{"calendars": "nonsense"}', '{"calendars": {"url": "x"}}',
+                        '{"calendars": [1, "two", null]}', '{"calendars": null}', '{}'):
+                cur.execute("UPDATE families SET config = %s::jsonb WHERE id = %s",
+                            (odd, pg_family))
+        assert counts(pg_pool) == before
+        assert activated_at(pg_pool, pg_family) is None
+
+    def test_a_family_born_with_a_calendar_is_both_at_once(self, pg_pool):
+        day = today(pg_pool)
+        before = counts(pg_pool).get(day, (0, 0))
+        family_id = a_family(pg_pool, '{"calendars": [{"url": "https://example.com/x.ics"}]}')
+        try:
+            assert counts(pg_pool)[day] == (before[0] + 1, before[1] + 1)
+            assert activated_at(pg_pool, family_id) is not None
+        finally:
+            forget(pg_pool, family_id)
+
+    def test_deleting_the_family_changes_nothing(self, pg_pool):
+        family_id = a_family(pg_pool, '{"calendars": [{"url": "https://example.com/x.ics"}]}')
+        after = counts(pg_pool)
+        forget(pg_pool, family_id)
+        assert counts(pg_pool) == after
+
+    def test_the_hard_delete_changes_nothing_either(self, pg_pool, pg_family, store):
+        """`accounts.delete_family` is what the account page calls."""
+        from dinkydash import accounts
+
+        config = store.load_config()
+        config["calendars"] = [dict(A_CALENDAR)]
+        store.save_config(config)
+        after = counts(pg_pool)
+        assert accounts.delete_family(pg_pool, pg_family)
+        assert counts(pg_pool) == after
+
+    def test_the_table_holds_a_date_and_two_counts_and_nothing_else(self, pg_pool):
+        with pg_pool.connection() as conn, conn.cursor() as cur:
+            cur.execute("SELECT * FROM growth_by_day LIMIT 0")
+            assert [c.name for c in cur.description] == ["day", "signups", "activations"]
+
+    def test_history_is_the_table_oldest_first(self, pg_pool):
+        with pg_pool.connection() as conn, conn.transaction(), conn.cursor() as cur:
+            cur.execute("DELETE FROM growth_by_day")
+            cur.executemany("INSERT INTO growth_by_day VALUES (%s, %s, %s)",
+                            [(date(2026, 9, 9), 2, 1), (date(2026, 9, 1), 1, 0)])
+        assert growth.history(pg_pool) == [(date(2026, 9, 1), 1, 0), (date(2026, 9, 9), 2, 1)]
+
+    def test_families_now_is_a_count_of_rows(self, pg_pool):
+        before = growth.families_now(pg_pool)
+        family_id = a_family(pg_pool)
+        try:
+            assert growth.families_now(pg_pool) == before + 1
+        finally:
+            forget(pg_pool, family_id)
+        assert growth.families_now(pg_pool) == before
+
+
+# -- the migration, over a schema that predates it --------------------------
+
+def test_the_migration_backfills_and_then_counts_exactly_once(pg_pool):
+    from dinkydash import db
+
+    # An isolated copy of the previous schema, removed by transaction rollback,
+    # the way tests/test_spend_migration.py does it.
+    with pg_pool.connection() as conn, conn.transaction(force_rollback=True):
+        with conn.cursor() as cur:
+            cur.execute("CREATE SCHEMA growth_migration_test")
+            cur.execute("SET LOCAL search_path TO growth_migration_test, public")
+            upgrade = db.MIGRATIONS_DIR / "006_growth.sql"
+            for path in db.migrations():
+                if path == upgrade:
+                    break
+                cur.execute(path.read_text())
+
+            # Three families from before the counter existed: one never set up,
+            # one with a calendar saved on the 5th, one with a link-less entry.
+            cur.executemany(
+                """INSERT INTO families (screen_token, config, created_at, updated_at)
+                   VALUES (%s, %s::jsonb, %s, %s)""",
+                [("growth-test-one", '{}', "2026-09-01 10:00+00", "2026-09-01 10:00+00"),
+                 ("growth-test-two",
+                  '{"calendars": [{"label": "School", "url": "https://example.com/a.ics"}]}',
+                  "2026-09-02 10:00+00", "2026-09-05 10:00+00"),
+                 ("growth-test-thr", '{"calendars": [{"label": "Empty", "url": ""}]}',
+                  "2026-09-02 11:00+00", "2026-09-02 11:00+00")])
+            cur.execute(upgrade.read_text())
+
+            cur.execute("SELECT day, signups, activations FROM growth_by_day ORDER BY day")
+            assert cur.fetchall() == [(date(2026, 9, 1), 1, 0), (date(2026, 9, 2), 2, 0),
+                                      (date(2026, 9, 5), 0, 1)]
+            cur.execute("SELECT screen_token, activated_at = updated_at FROM families "
+                        "WHERE activated_at IS NOT NULL")
+            assert cur.fetchall() == [("growth-test-two", True)]
+
+            # From here on the trigger is in charge: the link-less family pastes
+            # a real link, and a fourth family signs up.
+            cur.execute("SELECT (now() AT TIME ZONE 'UTC')::date")
+            day = cur.fetchone()[0]
+            cur.execute("""UPDATE families
+                           SET config = '{"calendars": [{"url": "https://example.com/b.ics"}]}'
+                           WHERE screen_token = 'growth-test-thr'""")
+            cur.execute("INSERT INTO families (screen_token) VALUES ('growth-test-fou')")
+            cur.execute("SELECT signups, activations FROM growth_by_day WHERE day = %s", (day,))
+            assert cur.fetchone() == (1, 1)
+
+            # And nothing is ever subtracted.
+            cur.execute("DELETE FROM families")
+            cur.execute("SELECT sum(signups), sum(activations) FROM growth_by_day")
+            assert cur.fetchone() == (4, 2)

--- a/web/CLAUDE.md
+++ b/web/CLAUDE.md
@@ -55,6 +55,18 @@ iframes — uses `web.urls.board_path()`. Build absolute credential URLs with
 request host as a development fallback. The login-link CLI shares the origin policy and accepts
 an explicit local `--base-url`. QR codes are generated only on `/settings/screen`.
 
+**`web/routes/admin.py` is the third blueprint only cloud mode registers, and its gate is a list.**
+`/admin` (DIN-37) shows signups and activations by week to the operator and to nobody else:
+`guard()` first, so a signed-out visitor is sent to `/login` like everywhere else, then
+`family.is_admin()`, which compares the signed-in account's address with `DINKYDASH_ADMIN_EMAILS`
+and answers a miss with a 404 — never a 403, and an unset list is nobody. The page reads no family:
+its numbers come from `dinkydash/growth.py`, and the chart is inline SVG drawn from numbers the
+route works out (`admin.chart`), because arithmetic in a template is arithmetic nobody tests. Its
+two series colours are the shell's own `--accent` and `--purple`, checked as a pair on the card's
+white with the dataviz palette validator (CVD ΔE 24.7, both above 3:1); a third series means
+running it again, not picking a colour. `tests/test_admin.py` covers the gate, the bounds on
+`?weeks=` and the drawing.
+
 **Every form that writes needs one hidden field.** `<input type="hidden" name="csrf_token"
 value="{{ csrf_token() }}">`, right inside the `<form>`. `csrf_token()` is a Jinja global set up by
 `web/session.py`, so no route has to remember to pass anything — but a form without the field is a

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -65,6 +65,9 @@ def create_app(store=None, *, pool=None):
         from .routes.screen import bp as screen_bp
         app.register_blueprint(screen_bp)
 
+        from .routes.admin import bp as admin_bp
+        app.register_blueprint(admin_bp)
+
         from dinkydash.pgstore import NoSuchFamily
 
         @app.errorhandler(NoSuchFamily)

--- a/web/family.py
+++ b/web/family.py
@@ -3,13 +3,20 @@
 Cloud requests use the signed session or a verified screen token. Stores are
 cached on Flask's g and share the app's pool. Single mode uses a fixed store.
 See web/CLAUDE.md for route authentication requirements.
+
+`is_admin` is the third door, and the only one that is not a family: whether
+the signed-in person may open the operator's page (`web/routes/admin.py`).
 """
 
+import os
 import uuid
 
 from flask import abort, current_app, g, session
 
-from .session import FAMILY_ID
+from .session import FAMILY_ID, USER_ID
+
+# Who may open /admin: a comma-separated list of addresses. Unset means nobody.
+ADMIN_EMAILS = "DINKYDASH_ADMIN_EMAILS"
 
 
 def current_store():
@@ -51,6 +58,38 @@ def current_screen_token():
     from dinkydash import screens
 
     return screens.token_for(_the_pool(), _family_on_the_session())
+
+
+def is_admin():
+    """Is the person on the session on the `DINKYDASH_ADMIN_EMAILS` list?
+
+    Decided from the account's *address* rather than a flag on the row, so
+    that who may see the operator's page is set where the other operator
+    settings are — the app spec — and needs no SQL to change. The address is
+    only ever compared, never used to look anything up: the session says who
+    is signed in, and the list says whether that person may look. An empty or
+    missing list means nobody may, which is the safe way for a new deployment
+    to be wrong.
+
+    Cloud mode only. Callers answer `False` with a 404 and never a 403 —
+    "forbidden" would say the page exists (`web/routes/admin.py`).
+    """
+    from dinkydash import accounts
+
+    allowed = admin_addresses()
+    user_id = session.get(USER_ID)
+    if not allowed or not user_id:
+        return False
+    address = accounts.address_for(_the_pool(), user_id)
+    return accounts.normalise(address) in allowed
+
+
+def admin_addresses():
+    """The operator addresses, normalised the way `accounts` compares them."""
+    from dinkydash import accounts
+
+    raw = os.environ.get(ADMIN_EMAILS, "")
+    return {accounts.normalise(part) for part in raw.split(",") if part.strip()}
 
 
 def store_for_token(token):

--- a/web/routes/admin.py
+++ b/web/routes/admin.py
@@ -1,0 +1,189 @@
+"""The operator's page: signups and activations by week. Cloud mode only.
+
+    GET /admin             the last twelve weeks
+    GET /admin?weeks=52    further back, up to a year
+
+Registered only in cloud mode, like `auth` and `screen` — a self-hoster is one
+family, and there is nothing to count.
+
+**Two checks, and the second answers 404.** `guard()` sends a signed-out
+visitor to `/login`, like every other page a person signs into. Then the
+address on the signed-in account is compared with `DINKYDASH_ADMIN_EMAILS`
+(`web.family.is_admin`), and anybody not on that list gets the same answer as
+a URL that does not exist. A 403 would say the page is there, which is nothing
+a stranger needs to know, and 404-on-a-mismatch is the rule every other
+authorisation miss in this app follows. An empty or missing list means nobody,
+which is the safe way for a new deployment to be wrong.
+
+**No family is read here.** The page is built from `dinkydash/growth.py`,
+which reads a table with no family identifiers in it plus one `count(*)`.
+Nothing in this file takes an id from the request, the session or the URL, so
+there is no id to check and nothing for a bug here to leak.
+
+The chart is inline SVG drawn from numbers worked out below, with no script
+and no third-party request — the settings shell's own rules. Its two colours
+are the shell's accent and purple tokens, checked as a pair on the card's
+white: adjacent CVD ΔE 24.7, both above 3:1 against the surface.
+"""
+
+import math
+from datetime import datetime, timezone
+
+from flask import (Blueprint, abort, current_app, make_response, render_template,
+                   request)
+
+from dinkydash import growth
+from web.family import is_admin
+from web.session import guard
+
+bp = Blueprint("admin", __name__)
+
+DEFAULT_WEEKS = 12
+MOST_WEEKS = 52
+SPANS = (12, 26, 52)
+
+# The chart, in SVG user units. The page scales the drawing to the shell's
+# width, so these are proportions rather than pixels. Room on the left for the
+# axis figures, on top for the direct labels, and below for the week labels.
+WIDTH, HEIGHT = 420, 190
+LEFT, RIGHT, TOP, BOTTOM = 28, 8, 20, 28
+PLOT_W = WIDTH - LEFT - RIGHT
+PLOT_H = HEIGHT - TOP - BOTTOM
+
+# A column is thin: at most this thick, and a 2-unit gap of surface between
+# the two in a week separates them without a stroke. Data-ends are rounded,
+# the baseline end square.
+THICKEST = 20
+GAP = 2
+RADIUS = 4
+
+# Axis steps that read as clean numbers, chosen so there are at most five
+# gridlines above the baseline.
+STEPS = (1, 2, 5, 10, 20, 50, 100, 200, 500, 1000, 2000, 5000)
+MOST_GRIDLINES = 5
+MOST_WEEK_LABELS = 6
+
+
+@bp.before_request
+def _admins_only():
+    bounce = guard()
+    if bounce is not None:
+        return bounce
+    if not is_admin():
+        abort(404)
+    return None
+
+
+@bp.route("/admin")
+def growth_page():
+    weeks = span(request.args.get("weeks"))
+    pool = current_app.config["POOL"]
+    rows = growth.history(pool)
+    # UTC, because the counter is in UTC days and there is no family clock.
+    today = datetime.now(timezone.utc).date()
+    weekly = growth.by_week(rows, weeks, today)
+    total = growth.totals(rows)
+    families = growth.families_now(pool)
+    response = make_response(render_template(
+        "admin/growth.html",
+        weekly=weekly, latest=weekly[-1], span=weeks, spans=SPANS,
+        totals=total, families_now=families,
+        # Every signup since the counter began is either a family that still
+        # exists or one that was deleted. Clamped, in case a family predates
+        # the counter in a way the backfill could not see.
+        deleted=max(0, total.signups - families),
+        chart=chart(weekly),
+    ))
+    # Counts, not anybody's data — but it is the business's own page, and a
+    # shared cache has no business holding it.
+    response.headers["Cache-Control"] = "no-store"
+    return response
+
+
+def span(raw):
+    """How many weeks to show: the query string, bounded, or the default."""
+    try:
+        weeks = int(raw)
+    except (TypeError, ValueError):
+        return DEFAULT_WEEKS
+    return min(MOST_WEEKS, max(1, weeks))
+
+
+# -- the drawing ------------------------------------------------------------
+
+def scale(highest):
+    """The axis ceiling and its step: clean numbers, at most five gridlines.
+
+    `highest` is the tallest value on the chart. The ceiling is the next
+    multiple of the step at or above it, so the tallest column reaches the top
+    gridline only when it happens to land on one.
+    """
+    highest = max(1, int(highest))
+    for step in STEPS:
+        if highest <= step * MOST_GRIDLINES:
+            break
+    return step * math.ceil(highest / step), step
+
+
+def chart(weekly):
+    """Everything the template needs to draw the columns, as plain numbers.
+
+    Worked out here rather than in Jinja because it is arithmetic, and
+    arithmetic in a template is arithmetic nobody tests.
+    """
+    ceiling, step = scale(max(max(w.signups, w.activations) for w in weekly))
+    count = len(weekly)
+    slot = PLOT_W / count
+    thickness = min(THICKEST, max(1.5, (slot - GAP) / 2 * 0.72))
+    pair = 2 * thickness + GAP
+    label_every = max(1, math.ceil(count / MOST_WEEK_LABELS))
+
+    def y_of(value):
+        return TOP + PLOT_H * (1 - value / ceiling)
+
+    columns = []
+    for i, week in enumerate(weekly):
+        slot_x = LEFT + i * slot
+        x = slot_x + (slot - pair) / 2
+        bars = []
+        for series, value in (("signups", week.signups),
+                              ("activations", week.activations)):
+            y = y_of(value)
+            bars.append({"series": series, "value": value, "x": round(x, 2),
+                         "y": round(y, 2),
+                         "path": column_path(x, y, thickness, TOP + PLOT_H - y)})
+            x += thickness + GAP
+        columns.append({
+            "week": week,
+            "slot_x": round(slot_x, 2), "slot_w": round(slot, 2),
+            "bars": bars,
+            "last": i == count - 1,
+            # Counted from the right, so the latest week is always labelled.
+            "label": (week.start.strftime("%-d %b")
+                      if (count - 1 - i) % label_every == 0 else ""),
+        })
+
+    return {
+        "width": WIDTH, "height": HEIGHT,
+        "left": LEFT, "right": WIDTH - RIGHT, "top": TOP, "plot_h": PLOT_H,
+        "baseline": TOP + PLOT_H, "thickness": round(thickness, 2),
+        "gridlines": [{"value": v, "y": round(y_of(v), 2)}
+                      for v in range(0, ceiling + 1, step)],
+        "columns": columns,
+    }
+
+
+def column_path(x, y, width, height):
+    """A column with a rounded top and a square foot, or "" for nothing.
+
+    A zero draws nothing rather than a hairline: the week is still there, in
+    its label, its hover text and the table, and an empty week should look
+    empty.
+    """
+    if height <= 0:
+        return ""
+    r = min(RADIUS, width / 2, height)
+    foot = y + height
+    return (f"M{x:.2f},{foot:.2f} V{y + r:.2f} Q{x:.2f},{y:.2f} {x + r:.2f},{y:.2f} "
+            f"H{x + width - r:.2f} Q{x + width:.2f},{y:.2f} {x + width:.2f},{y + r:.2f} "
+            f"V{foot:.2f} Z")

--- a/web/routes/settings.py
+++ b/web/routes/settings.py
@@ -751,7 +751,7 @@ def _family_facts():
     """The platform's own bookkeeping about a family, for the export."""
     with current_app.config["POOL"].connection() as conn, conn.cursor() as cur:
         cur.execute(
-            """SELECT plan, status, trial_ends_at, created_at, lapsed_at
+            """SELECT plan, status, trial_ends_at, created_at, lapsed_at, activated_at
                FROM families WHERE id = %s""",
             (current_family_id(),),
         )
@@ -762,7 +762,8 @@ def _family_facts():
     # to somebody, saved to a downloads folder and forgotten; a live credential
     # should not ride along in one. It is on the screen page, where it can be
     # rotated in the same breath as being read.
-    return dict(zip(("plan", "status", "trial_ends_at", "created_at", "lapsed_at"), row))
+    return dict(zip(("plan", "status", "trial_ends_at", "created_at", "lapsed_at",
+                     "activated_at"), row))
 
 
 def delete_account():

--- a/web/templates/admin/growth.html
+++ b/web/templates/admin/growth.html
@@ -1,0 +1,164 @@
+{# The operator's page: signups and activations by week (DIN-37). Cloud mode
+   only, and only for the addresses in DINKYDASH_ADMIN_EMAILS — everyone else
+   gets a 404 before this renders. Nothing here belongs to any one family:
+   the numbers are counts, and the page takes no id from anywhere. #}
+{% extends "settings/base.html" %}
+{% import "settings/_icons.html" as icons %}
+{% block title %}Growth{% endblock %}
+
+{% block head %}
+<style>
+    /* The two series wear the shell's own tokens, checked as a pair on the
+       card's white (CVD ΔE 24.7, both above 3:1). Text never wears them: the
+       swatch beside a label carries identity, the label stays in ink. */
+    .growth { --signups: var(--accent); --activations: var(--purple); }
+
+    .tiles { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 0.625rem; }
+    .tile { padding: 0.75rem 0.8125rem; display: flex; flex-direction: column; gap: 0.125rem; min-width: 0; }
+    .tile .name { font-size: 0.6875rem; font-weight: 800; letter-spacing: 0.06em; text-transform: uppercase; color: var(--text-muted); }
+    .tile .value { font-size: 1.75rem; font-weight: 800; line-height: 1.15; letter-spacing: -0.02em; }
+    .tile .sub { font-size: 0.75rem; color: var(--text-muted); }
+
+    .spans { display: flex; align-items: center; gap: 0.375rem; flex-wrap: wrap; }
+    .spans .label { padding: 0 0.25rem 0 0; }
+
+    .legend { display: flex; gap: 0.875rem; font-size: 0.75rem; font-weight: 700; color: var(--text-mid); }
+    .legend .key { display: inline-flex; align-items: center; gap: 0.375rem; }
+    .legend .swatch { width: 0.75rem; height: 0.75rem; border-radius: 0.1875rem; }
+    .legend .swatch.signups { background: var(--signups); }
+    .legend .swatch.activations { background: var(--activations); }
+
+    /* The drawing scales with the card; its own numbers are SVG user units,
+       not screen pixels, which is why the font sizes below are attributes on
+       the elements rather than lengths in this sheet. */
+    .chart { display: block; width: 100%; height: auto; overflow: visible; }
+    .chart .grid { stroke: var(--border); stroke-width: 1; }
+    .chart .baseline { stroke: var(--border-strong); stroke-width: 1; }
+    .chart .tick { fill: var(--text-muted); }
+    .chart .direct { fill: var(--text); }
+    .chart .hit { fill: transparent; pointer-events: all; }
+    .chart .bar.signups { fill: var(--signups); }
+    .chart .bar.activations { fill: var(--activations); }
+    .chart .week:hover .bar { opacity: 0.72; }
+
+    .numbers { width: 100%; border-collapse: collapse; font-size: 0.875rem; }
+    .numbers th, .numbers td { padding: 0.625rem 0.875rem; text-align: right; }
+    .numbers th:first-child, .numbers td:first-child { text-align: left; }
+    .numbers th { font-size: 0.6875rem; font-weight: 800; letter-spacing: 0.06em; text-transform: uppercase; color: var(--text-muted); }
+    .numbers tbody tr { border-top: 1px solid var(--border); }
+    .numbers td + td { font-variant-numeric: tabular-nums; font-weight: 700; }
+    .numbers td.zero { color: var(--faint); font-weight: 600; }
+</style>
+{% endblock %}
+
+{% block appbar %}
+<a class="back" href="{{ url_for('settings.home') }}">{{ icons.back() }}</a>
+<h1>Growth</h1>
+{% endblock %}
+
+{% block content %}
+<div class="growth" style="display:flex;flex-direction:column;gap:1rem;">
+
+<div class="tiles">
+    <div class="card tile">
+        <div class="name">Signups</div>
+        <div class="value">{{ totals.signups }}</div>
+        <div class="sub">{{ latest.signups }} this week</div>
+    </div>
+    <div class="card tile">
+        <div class="name">Activations</div>
+        <div class="value">{{ totals.activations }}</div>
+        <div class="sub">
+            {%- if totals.signups -%}
+                {{ (100 * totals.activations / totals.signups) | round | int }}% of signups
+            {%- else -%}
+                {{ latest.activations }} this week
+            {%- endif -%}
+        </div>
+    </div>
+    <div class="card tile">
+        <div class="name">Families now</div>
+        <div class="value">{{ families_now }}</div>
+        <div class="sub">{{ deleted }} deleted</div>
+    </div>
+</div>
+
+{# One row of range choices, above everything it scopes. #}
+<div class="spans">
+    <span class="label">Last</span>
+    {% for n in spans %}
+    <a class="pill {{ 'warm' if n == span else 'muted' }}"
+       href="{{ url_for('admin.growth_page', weeks=n) }}">{{ n }} weeks</a>
+    {% endfor %}
+</div>
+
+<div class="card pad" style="display:flex;flex-direction:column;gap:0.75rem;">
+    <div style="display:flex;justify-content:space-between;align-items:baseline;gap:0.5rem;flex-wrap:wrap;">
+        <div style="font-size:0.9375rem;font-weight:800;">By week</div>
+        <div class="legend">
+            <span class="key"><span class="swatch signups"></span>Signups</span>
+            <span class="key"><span class="swatch activations"></span>Activations</span>
+        </div>
+    </div>
+
+    <svg class="chart" viewBox="0 0 {{ chart.width }} {{ chart.height }}" role="img"
+         aria-labelledby="growth-chart-title">
+        <title id="growth-chart-title">Signups and activations over the last {{ span }} weeks</title>
+        {% for line in chart.gridlines %}
+        <line class="{{ 'baseline' if line.value == 0 else 'grid' }}"
+              x1="{{ chart.left }}" x2="{{ chart.right }}" y1="{{ line.y }}" y2="{{ line.y }}"/>
+        <text class="tick" x="{{ chart.left - 6 }}" y="{{ line.y }}" text-anchor="end"
+              dominant-baseline="middle" font-size="12">{{ line.value }}</text>
+        {% endfor %}
+        {% for column in chart.columns %}
+        {% set week = column.week %}
+        <g class="week">
+            {# The whole week's slot is the hover target, not the painted pixels. #}
+            <title>Week of {{ week.start.strftime('%-d %B') }}: {{ week.signups }} signup{{ '' if week.signups == 1 else 's' }}, {{ week.activations }} activation{{ '' if week.activations == 1 else 's' }}</title>
+            <rect class="hit" x="{{ column.slot_x }}" y="{{ chart.top }}"
+                  width="{{ column.slot_w }}" height="{{ chart.plot_h }}"/>
+            {% for bar in column.bars %}
+            {% if bar.path %}<path class="bar {{ bar.series }}" d="{{ bar.path }}"/>{% endif %}
+            {# Direct labels on the latest week only; the axis and the table carry the rest. #}
+            {% if column.last and bar.value %}
+            <text class="direct" x="{{ bar.x + chart.thickness / 2 }}" y="{{ bar.y - 4 }}"
+                  text-anchor="middle" font-size="13" font-weight="800">{{ bar.value }}</text>
+            {% endif %}
+            {% endfor %}
+            {% if column.label %}
+            <text class="tick" x="{{ column.slot_x + column.slot_w / 2 }}" y="{{ chart.height - 8 }}"
+                  text-anchor="middle" font-size="12">{{ column.label }}</text>
+            {% endif %}
+        </g>
+        {% endfor %}
+    </svg>
+
+    <div class="hint">
+        A signup is a family created by opening its emailed link. An activation is the
+        first time a family saves a calendar link. Days are UTC, weeks start on Monday,
+        and both counts stay when an account is deleted.
+    </div>
+</div>
+
+<div>
+    <div class="label">The numbers</div>
+    <div class="card">
+        <table class="numbers">
+            <thead>
+                <tr><th>Week of</th><th>Signups</th><th>Activations</th></tr>
+            </thead>
+            <tbody>
+                {% for week in weekly | reverse %}
+                <tr>
+                    <td>{{ week.start.strftime('%-d %b %Y') }}</td>
+                    <td class="{{ 'zero' if not week.signups }}">{{ week.signups }}</td>
+                    <td class="{{ 'zero' if not week.activations }}">{{ week.activations }}</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+</div>
+
+</div>
+{% endblock %}

--- a/website/content/privacy.md
+++ b/website/content/privacy.md
@@ -5,7 +5,7 @@ template: page.html
 description: What DinkyDash stores, who it is sent to, how long it is kept, and how to get it back or delete it.
 ---
 
-*Last updated: 9 September 2026.*
+*Last updated: 10 September 2026.*
 
 DinkyDash puts a family's day on a screen. That means the things it holds are a
 household's names, dates of birth and movements — which is about as personal as
@@ -33,6 +33,7 @@ either something you typed or something the software produced.
 | **The written line** | Written by Claude each morning | The board's headline and note |
 | **Sign-in links** | Generated when you ask for one | Hashed, never stored as a working link |
 | **Counts of model calls** | Recorded when the board is written | So one account cannot run up an unbounded bill |
+| **Counts of sign-ups and first calendar connections** | Recorded when a family is created, and the first time it saves a calendar link | So we can see whether the product is being used, without looking at anyone's account |
 
 **We do not use cookies for tracking.** The hosted app sets one cookie, and it
 is the session that keeps you signed in. There is no analytics on
@@ -97,6 +98,9 @@ We would rather hold less, so most of this expires on its own.
 - **Daily totals of model calls across the service**: kept without an account
   identifier, including after account deletion, so deleting an account does not
   reset the service's spending limit. These totals contain only a date and count.
+- **Daily counts of sign-ups and of families that first connected a calendar**:
+  kept without an account identifier, including after account deletion. Like the
+  model-call totals, these hold a date and a count and nothing else.
 
 After your trial or subscription ends, the screen shows the last saved board
 with an ended-access message for 30 days, then only the message. This changes


### PR DESCRIPTION
Adds `/admin` in cloud mode: signups (a family created) and activations (the first calendar link saved) per week, as an inline-SVG chart, three tiles and a table, visible only to addresses in `DINKYDASH_ADMIN_EMAILS` and a 404 to everyone else (DIN-37). Migration 006 adds `growth_by_day`, a date-and-two-counts table kept by a trigger on `families` so the numbers survive account deletion like `global_model_spend`, plus `families.activated_at` so an activation counts once; `dinkydash/growth.py` is the fourth deliberately unscoped read and touches no family row. The privacy policy, PLAN.md, the instruction files, the app spec and the operations log are updated to match, and the account export now carries `activated_at`. Before the page works in production, `DINKYDASH_ADMIN_EMAILS` has to go into `.env` and the spec applied with `doctl apps update`; until then the page is a 404 for everyone, and the migration applies itself through the pre-deploy job. 58 new tests; the suite passes with Postgres (1032 passed) and as a self-hoster (700 passed, 332 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
