### PR TITLE
Trim calendar feeds to the window before parsing, and give the site 1 GB

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -188,7 +188,13 @@ services:
         scope: RUN_TIME
         value: ${_self.COMMIT_HASH}
 
-    instance_size_slug: apps-s-1vcpu-0.5gb
+    # 1 GB, not 0.5. Two gunicorn workers each kept ~250 MB after parsing an
+    # 8 MB personal calendar, and on 10 September 2026 that took the container
+    # past 512 MB and killed it — the site down for a minute, nothing in the log
+    # but the exit. `calendars._trim` now keeps the parse to a fortnight, so the
+    # headroom is for the next feed shape nobody has measured. $10 a month
+    # rather than $5; still the basic tier, still no autoscaling.
+    instance_size_slug: apps-s-1vcpu-1gb-fixed
     instance_count: 1
     http_port: 8080
 

--- a/dinkydash/CLAUDE.md
+++ b/dinkydash/CLAUDE.md
@@ -305,6 +305,16 @@ nothing: switching a calendar off means switching it off. The failure is recorde
 `calendar_statuses` and shown on the settings page, and the stamp is written either way, so a broken
 feed is retried on the configured cadence rather than every tick.
 
+**A feed is trimmed to the window before it is parsed.** `calendars._trim` drops, as text, every
+VEVENT that cannot fall inside `[start, end]`, and keeps whatever the parser needs to decide that for
+itself: recurring events and their exceptions, extra dates, VTIMEZONE blocks, and any event whose
+dates it cannot read. The reason is memory, not speed: `icalendar` builds an object for every
+property of every event, a decade-long personal calendar is 8 MB and 14,000 of them, and parsing one
+cost ~200 MB with ~250 MB kept by the process afterwards — which is how two gunicorn workers took the
+hosted site past its 512 MB on 10 September 2026. The rule is that over-keeping is always safe and
+under-keeping is a hidden appointment, so every doubt resolves to keep, and `tests/test_feed_trim.py`
+asserts that the trimmed parse gives exactly what the untrimmed one gave.
+
 **A tick takes an exclusive `flock` on `.tick.lock` and skips itself if another holds it**
 (`generate.only_one_tick`). Its job is money, not consistency — the storage split is what stops two
 writers clobbering each other, and this stops a second tick paying Anthropic for a brief the first

--- a/dinkydash/calendars.py
+++ b/dinkydash/calendars.py
@@ -162,13 +162,87 @@ def parse_feed(ical_text, start, end, tzinfo, label=None, shared_with=None):
 def _occurrences(ical_text, start, end):
     """Every event in the window, with recurrences expanded."""
     try:
-        cal = Calendar.from_ical(ical_text)
+        cal = Calendar.from_ical(_trim(ical_text, start, end))
     except Exception as exc:
         # Not `{exc}`: a parser error quotes the line it choked on, which is
         # somebody's appointment.
         raise FeedError(f"could not read the calendar data ({type(exc).__name__})",
                         invalid_data=True) from exc
     return list(recurring_events_of(cal).between(start, end + timedelta(days=1)))
+
+
+# A personal Google calendar is a decade of appointments in one file — the
+# owner's is 8 MB and 14,000 events — and `icalendar` builds an object for every
+# property of every one of them. Measured on that feed: ~200 MB to parse and
+# ~250 MB kept by the process afterwards, because Python does not hand arenas
+# back. Two gunicorn workers each holding that is how the hosted site went past
+# its 512 MB and was killed on 10 September 2026, with nothing in the log but
+# the exit. The board only ever wants a fortnight, so `_trim` drops, as text and
+# before the parser sees them, the events that cannot fall in the window.
+#
+# Whatever the parser needs to get the window right is kept regardless of its
+# date: recurring events (their EXDATEs ride on them), extra dates, the
+# exceptions that move one occurrence, VTIMEZONE blocks, and any event whose
+# dates this cannot read. Over-keeping is always safe — the parsed result is
+# windowed again by `recurring_ical_events` — so every doubt resolves to keep.
+_TRIM_MARGIN = timedelta(days=2)   # a timezone moves a date by a day at most; be generous
+_RECURRENCE_LINE = re.compile(r"^(RRULE|RDATE|RECURRENCE-ID)[;:]", re.IGNORECASE)
+_DATE_LINE = re.compile(r"^(DTSTART|DTEND)(?:;[^:]*)?:(\d{4})(\d{2})(\d{2})", re.IGNORECASE)
+_DURATION_LINE = re.compile(r"^DURATION(?:;[^:]*)?:-?P(?:(\d+)W)?(?:(\d+)D)?", re.IGNORECASE)
+
+
+def _trim(ical_text, start, end):
+    """The feed as text, minus every VEVENT that cannot touch [start, end]."""
+    lo, hi = start - _TRIM_MARGIN, end + _TRIM_MARGIN
+    kept, block = [], None
+    for line in ical_text.splitlines(keepends=True):
+        if block is None:
+            if line.rstrip("\r\n").upper() == "BEGIN:VEVENT":
+                block = [line]
+            else:
+                kept.append(line)
+            continue
+        block.append(line)
+        if line.rstrip("\r\n").upper() == "END:VEVENT":
+            if _may_touch(block, lo, hi):
+                kept.extend(block)
+            block = None
+    if block is not None:
+        kept.extend(block)   # unterminated: the parser's complaint to make
+    return "".join(kept)
+
+
+def _may_touch(block, lo, hi):
+    """Whether an event, as its raw lines, could have an occurrence in [lo, hi].
+
+    Reads DTSTART, DTEND and DURATION only, and only their date digits. A line
+    it cannot read — a folded value, a parameter with a colon in it — means
+    keep: the parser decides, exactly as it did before the trim existed.
+    """
+    first = last = None
+    duration_days = 0
+    for line in block:
+        if _RECURRENCE_LINE.match(line):
+            return True
+        found = _DATE_LINE.match(line)
+        if found:
+            try:
+                day = date(int(found[2]), int(found[3]), int(found[4]))
+            except ValueError:
+                return True
+            if found[1].upper() == "DTSTART":
+                first = day
+            else:
+                last = day
+            continue
+        found = _DURATION_LINE.match(line)
+        if found:
+            duration_days = int(found[1] or 0) * 7 + int(found[2] or 0)
+    if first is None:
+        return True
+    if last is None:
+        last = first + timedelta(days=duration_days + 1)
+    return first <= hi and max(first, last) >= lo
 
 
 def _events(occurrences, tzinfo, label, shared_with):

--- a/doc/operations.md
+++ b/doc/operations.md
@@ -527,3 +527,39 @@ on the next deploy. Its backfill stamps every family that already has a calendar
 its last settings save, which is the latest the calendar could have been added and the only stamp
 there is: approximate for the families that exist today, exact for every family after. Counts are
 per UTC day and are never subtracted from, so a deleted account still shows as a signup.
+
+
+## The site ran out of memory, 10 September 2026
+
+**What happened.** At 19:15:26 UTC the `site` container died with `exited with code: 128`, ten
+seconds after the owner pressed **Check** on a calendar link for the second time, and was serving
+again at 19:16. Nothing in the log but the exit line: no traceback, no 500, the `worker` untouched,
+no other app in the account restarted. Any request in that minute got the platform's error page.
+
+**Why.** Measured afterwards on the same feed, locally, with the link handed over through a file in
+`/tmp` and never pasted anywhere: 8.4 MB, ~13,900 events, 286 recurrence rules, 15,600 attendee
+lines. One Check adds ~200 MB at its peak and the process keeps ~250 MB afterwards — a plateau over
+four parses, not a leak; Python does not hand arenas back. `--workers 2` on a 512 MB instance means
+the second worker to parse it puts the container over the limit. DigitalOcean labelled the exit 128
+rather than the 137 it documents for out-of-memory; treat 128 the same way.
+
+**Two fixes.** `calendars._trim` drops, as text, every VEVENT that cannot fall in the fetched window
+before `icalendar` sees it — the same shape of feed now parses in 0.4 s at ~100 MB peak rather than
+3.5 s at ~240 MB, and `tests/test_feed_trim.py` pins that the trimmed parse equals the untrimmed
+one. And `site` is `apps-s-1vcpu-1gb-fixed` rather than `apps-s-1vcpu-0.5gb`: applied 19:51 UTC
+with the merge-from-`.env` dance in the spec's header, deployment `bdb642ca` active at 19:52:56,
+`doctl apps propose` pricing the app at $20 a month rather than $15. The `worker` component stays at
+0.5 GB: it is one process, and with the trim its refresh of the same feed is small.
+
+**What that apply also carried**, because the spec is the whole app: the dead `DINKYDASH_FAMILY_ID`
+is gone, `GIT_SHA` is bound and `/healthz` reports a commit at last, and the three spend-breaker
+variables are set at exactly their code defaults, so nothing changed there. It did **not** carry
+`DINKYDASH_ADMIN_EMAILS`: the spec it was built from predates DIN-37 and the key is not in this
+workspace's `.env`, so the operator's page above is still closed to everyone. The next apply needs
+the key in `.env` first.
+
+**How to read it next time.** After a restart, `doctl apps logs <id> site --type run` holds only the
+new container; the one that died is under `--type run_restarted`. The health probe arrives every
+10 s on a ~2 ms cadence, so a probe that lands late is the cheap sign that a request was CPU-bound
+just then. There is still no memory graph outside the dashboard's Insights tab, and no alert on
+restarts.

--- a/doc/operations.md
+++ b/doc/operations.md
@@ -551,8 +551,8 @@ with the merge-from-`.env` dance in the spec's header, deployment `bdb642ca` act
 `doctl apps propose` pricing the app at $20 a month rather than $15. The `worker` component stays at
 0.5 GB: it is one process, and with the trim its refresh of the same feed is small.
 
-**What that apply also carried**, because the spec is the whole app: the dead `DINKYDASH_FAMILY_ID`
-is gone, `GIT_SHA` is bound and `/healthz` reports a commit at last, and the three spend-breaker
+**What that apply also carried**, because the spec is the whole app: the dead single-family variable
+from before DIN-39 is gone, `GIT_SHA` is bound and `/healthz` reports a commit at last, and the three spend-breaker
 variables are set at exactly their code defaults, so nothing changed there. It did **not** carry
 `DINKYDASH_ADMIN_EMAILS`: the spec it was built from predates DIN-37 and the key is not in this
 workspace's `.env`, so the operator's page above is still closed to everyone. The next apply needs

--- a/tests/test_feed_trim.py
+++ b/tests/test_feed_trim.py
@@ -1,0 +1,165 @@
+"""A decade-long feed is parsed a fortnight at a time.
+
+`icalendar` builds an object for every property of every event, and a personal
+Google calendar is ten years of them: the owner's is 8 MB and 14,000 events,
+measured at ~200 MB to parse and ~250 MB kept afterwards, which is how two
+gunicorn workers took the hosted site past 512 MB on 10 September 2026.
+`calendars._trim` drops, as text, every VEVENT that cannot touch the window
+before the parser sees it. These tests pin what must survive the trim: the
+trimmed parse has to give exactly what the untrimmed one gave.
+"""
+
+from datetime import date, timedelta
+
+from icalendar import Calendar
+from recurring_ical_events import of as recurring_events_of
+
+from dinkydash import calendars
+from dinkydash.calendars import parse_feed, sort_key
+from tests.test_calendars import BERLIN, all_day, ical, timed
+
+START = date(2026, 9, 10)
+END = START + timedelta(days=14)
+
+
+def weekly(uid, first, summary, until=None):
+    rule = "RRULE:FREQ=WEEKLY" + (f";UNTIL={until}" if until else "")
+    return (f"BEGIN:VEVENT\r\nUID:{uid}\r\nDTSTART;TZID=Europe/Berlin:{first}\r\n"
+            f"{rule}\r\nSUMMARY:{summary}\r\nEND:VEVENT\r\n")
+
+
+def moved(uid, original, new_start, summary):
+    """One occurrence of `uid` rescheduled — the exception a RECURRENCE-ID carries."""
+    return (f"BEGIN:VEVENT\r\nUID:{uid}\r\nRECURRENCE-ID;TZID=Europe/Berlin:{original}\r\n"
+            f"DTSTART;TZID=Europe/Berlin:{new_start}\r\nSUMMARY:{summary}\r\nEND:VEVENT\r\n")
+
+
+def extra_date(uid, first, extra, summary):
+    return (f"BEGIN:VEVENT\r\nUID:{uid}\r\nDTSTART;VALUE=DATE:{first}\r\n"
+            f"RDATE;VALUE=DATE:{extra}\r\nSUMMARY:{summary}\r\nEND:VEVENT\r\n")
+
+
+def spanning(uid, first_day, last_day, summary):
+    return (f"BEGIN:VEVENT\r\nUID:{uid}\r\nDTSTART;VALUE=DATE:{first_day}\r\n"
+            f"DTEND;VALUE=DATE:{last_day}\r\nSUMMARY:{summary}\r\nEND:VEVENT\r\n")
+
+
+def lasting(uid, start, duration, summary):
+    return (f"BEGIN:VEVENT\r\nUID:{uid}\r\nDTSTART;TZID=Europe/Berlin:{start}\r\n"
+            f"DURATION:{duration}\r\nSUMMARY:{summary}\r\nEND:VEVENT\r\n")
+
+
+def with_alarm(uid, start, summary):
+    return (f"BEGIN:VEVENT\r\nUID:{uid}\r\nDTSTART;TZID=Europe/Berlin:{start}\r\n"
+            f"SUMMARY:{summary}\r\nBEGIN:VALARM\r\nACTION:DISPLAY\r\nTRIGGER:-PT10M\r\n"
+            f"DESCRIPTION:{summary}\r\nEND:VALARM\r\nEND:VEVENT\r\n")
+
+
+TIMEZONE_BLOCK = ("BEGIN:VTIMEZONE\r\nTZID:Europe/Berlin\r\nBEGIN:STANDARD\r\n"
+                  "DTSTART:19701025T030000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\n"
+                  "RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\n")
+
+
+def untrimmed(feed):
+    """What the parser gave before the trim existed."""
+    occurrences = recurring_events_of(Calendar.from_ical(feed)).between(START, END + timedelta(days=1))
+    return sorted(calendars._events(list(occurrences), BERLIN, None, None), key=sort_key)
+
+
+def trimmed(feed):
+    return sorted(parse_feed(feed, START, END, BERLIN), key=sort_key)
+
+
+def titles(feed):
+    return [e["title"] for e in trimmed(feed)]
+
+
+def test_events_outside_the_window_are_dropped_as_text():
+    feed = ical(timed("old", "20250910T090000", "Last year"),
+                timed("now", "20260915T090000", "This fortnight"),
+                timed("later", "20270910T090000", "Next year"))
+    kept = calendars._trim(feed, START, END)
+    assert "UID:now" in kept
+    assert "UID:old" not in kept and "UID:later" not in kept
+    assert titles(feed) == ["This fortnight"]
+
+
+def test_the_window_edges_are_kept():
+    feed = ical(all_day("first", START.strftime("%Y%m%d"), "Day one"),
+                all_day("last", END.strftime("%Y%m%d"), "Day fourteen"),
+                all_day("before", (START - timedelta(days=30)).strftime("%Y%m%d"), "A month ago"))
+    assert titles(feed) == ["Day one", "Day fourteen"]
+
+
+def test_recurring_events_are_kept_whatever_their_start():
+    feed = ical(weekly("standup", "20200910T100000", "Weekly since 2020"),
+                weekly("gone", "20190101T100000", "Ended in 2021", until="20210101T000000Z"))
+    assert "UID:standup" in calendars._trim(feed, START, END)
+    assert titles(feed) == ["Weekly since 2020"] * 3
+    assert trimmed(feed) == untrimmed(feed)
+
+
+def test_a_moved_occurrence_is_honoured():
+    # 17 September falls in the window; the exception moves it to October. If the
+    # trim dropped that exception, the parser would put the original back.
+    feed = ical(weekly("standup", "20200910T100000", "Weekly"),
+                moved("standup", "20260917T100000", "20261001T100000", "Weekly"),
+                moved("standup", "20261008T100000", "20260918T110000", "Weekly, pulled forward"))
+    assert [e["date"] for e in trimmed(feed)] == ["2026-09-10", "2026-09-18", "2026-09-24"]
+    assert trimmed(feed) == untrimmed(feed)
+
+
+def test_an_extra_date_on_an_old_event_is_kept():
+    feed = ical(extra_date("party", "20190601", "20260915", "Reunion"))
+    assert [e["date"] for e in trimmed(feed)] == ["2026-09-15"]
+    assert trimmed(feed) == untrimmed(feed)
+
+
+def test_an_event_that_started_before_the_window_and_runs_into_it_is_kept():
+    feed = ical(spanning("holiday", "20260901", "20260912", "Holiday"),
+                lasting("retreat", "20260830T090000", "P3W", "Retreat"),
+                spanning("finished", "20260801", "20260805", "Over before it began"))
+    kept = calendars._trim(feed, START, END)
+    assert "UID:holiday" in kept and "UID:retreat" in kept
+    assert "UID:finished" not in kept
+    assert trimmed(feed) == untrimmed(feed)
+
+
+def test_a_date_the_trim_cannot_read_means_keep():
+    folded = ("BEGIN:VEVENT\r\nUID:folded\r\nDTSTART;TZID=Europe/Berlin:2026091\r\n 5T090000\r\n"
+              "SUMMARY:Folded mid-value\r\nEND:VEVENT\r\n")
+    quoted = ("BEGIN:VEVENT\r\nUID:quoted\r\nDTSTART;X-NOTE=\"a:b\":20260916T090000\r\n"
+              "SUMMARY:Colon in a parameter\r\nEND:VEVENT\r\n")
+    feed = ical(folded, quoted)
+    kept = calendars._trim(feed, START, END)
+    assert "UID:folded" in kept and "UID:quoted" in kept
+    assert titles(feed) == ["Folded mid-value", "Colon in a parameter"]
+
+
+def test_timezones_and_alarms_survive_and_dropped_events_take_their_alarms_with_them():
+    feed = ("BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//test//EN\r\n" + TIMEZONE_BLOCK
+            + with_alarm("now", "20260915T090000", "Dentist")
+            + with_alarm("old", "20200915T090000", "Old dentist")
+            + "END:VCALENDAR\r\n")
+    kept = calendars._trim(feed, START, END)
+    assert "BEGIN:VTIMEZONE" in kept
+    assert kept.count("BEGIN:VALARM") == 1
+    assert "Old dentist" not in kept
+    assert titles(feed) == ["Dentist"]
+    assert trimmed(feed) == untrimmed(feed)
+
+
+def test_a_decade_of_appointments_shrinks_to_the_fortnight():
+    old = [timed(f"old-{i}", (date(2016, 1, 1) + timedelta(days=i % 3600)).strftime("%Y%m%dT090000"),
+                 f"Event {i}") for i in range(10_000)]
+    current = [timed("a", "20260911T090000", "A"), timed("b", "20260920T090000", "B")]
+    feed = ical(*old, *current)
+    kept = calendars._trim(feed, START, END)
+    assert kept.count("BEGIN:VEVENT") == 2
+    assert titles(feed) == ["A", "B"]
+    assert trimmed(feed) == untrimmed(feed)
+
+
+def test_trim_leaves_a_small_feed_alone():
+    feed = ical(timed("a", "20260911T090000", "A"), all_day("b", "20260920", "B"))
+    assert calendars._trim(feed, START, END) == feed


### PR DESCRIPTION
On 10 September the hosted site container died ten seconds after a calendar check: an 8 MB personal feed costs ~200 MB to parse and each gunicorn worker keeps ~250 MB afterwards, so two workers on the 0.5 GB instance went over the limit with nothing in the log but the exit. `calendars._trim` now drops, as text, every VEVENT that cannot fall in the fetched window before `icalendar` sees it, keeping recurring events, their exceptions, extra dates, VTIMEZONE blocks and anything it cannot read, and `tests/test_feed_trim.py` asserts the trimmed parse equals the untrimmed one (0.4 s and ~100 MB peak instead of 3.5 s and ~240 MB on a feed of that shape). The `site` component moves to `apps-s-1vcpu-1gb-fixed` in `.do/app.yaml`, already applied and live since 19:52 UTC. The incident, the measurements and the apply are written up in `doc/operations.md`, with a note in `dinkydash/CLAUDE.md` on why the trim exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)