### PR TITLE
Let /admin/ reach the admin page instead of a 404

### DIFF
--- a/doc/operations.md
+++ b/doc/operations.md
@@ -558,6 +558,18 @@ variables are set at exactly their code defaults, so nothing changed there. It d
 workspace's `.env`, so the operator's page above is still closed to everyone. The next apply needs
 the key in `.env` first.
 
+**The key was set later the same evening**, without another full apply: the live spec was fetched
+with `doctl apps spec get`, the one entry added, and the result applied back with `doctl apps update`
+— existing secrets round-trip as `EV[...]` ciphertext that App Platform accepts unchanged, so nothing
+else in the running app moved and no plaintext secret was needed from `.env`. Deployment `af1c9fa9`
+active at 2026-09-10 20:10:55 UTC. The address is also in `.env` in the main checkout, so the next
+merge-from-`.env` apply carries it too. Which address it is stays out of this file on purpose.
+
+**The first visit was to `/admin/`, and it was a 404.** The route was registered as `/admin` only,
+and Flask adds the slash-tolerant redirect to rules that end in a slash, not to ones that do not, so
+the typed URL never reached the admin check — and a 404 is exactly what not being on the list looks
+like. Fixed by making the rule accept both; `tests/test_admin.py` asserts it.
+
 **How to read it next time.** After a restart, `doctl apps logs <id> site --type run` holds only the
 new container; the one that died is under `--type run_restarted`. The health probe arrives every
 10 s on a ~2 ms cadence, so a probe that lands late is the cheap sign that a request was CPU-bound

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -34,6 +34,7 @@ def test_single_mode_has_no_admin_page(tmp_path, monkeypatch):
     (tmp_path / "config.yaml").write_text('family_name: "The Wilsons"\n')
     client = client_for(create_app(FileStore(tmp_path / "config.yaml")))
     assert client.get("/admin").status_code == 404
+    assert client.get("/admin/").status_code == 404
 
 
 # -- the drawing, with no database ------------------------------------------
@@ -149,6 +150,21 @@ class TestWhoMayLook:
         assert response.status_code == 200
         assert response.headers["Cache-Control"] == "no-store"
         assert "Growth" in response.get_data(as_text=True)
+
+    def test_a_trailing_slash_is_the_same_page(self, cloud, user, monkeypatch):
+        """The first real visit was to `/admin/`, and it was a 404 — before the
+        admin check ran, so it looked exactly like not being on the list."""
+        monkeypatch.setenv("DINKYDASH_ADMIN_EMAILS", ADDRESS)
+        response = signed_in(cloud, user).get("/admin/")
+        assert response.status_code == 200
+        assert "Growth" in response.get_data(as_text=True)
+
+    def test_a_trailing_slash_opens_nothing_for_anybody_else(self, cloud, user, monkeypatch):
+        monkeypatch.setenv("DINKYDASH_ADMIN_EMAILS", "somebody@example.com")
+        assert signed_in(cloud, user).get("/admin/").status_code == 404
+        signed_out = client_for(cloud).get("/admin/")
+        assert signed_out.status_code == 302
+        assert signed_out.headers["Location"].endswith("/login")
 
     def test_a_session_naming_a_user_that_is_gone_is_a_404(self, cloud, user, monkeypatch):
         monkeypatch.setenv("DINKYDASH_ADMIN_EMAILS", ADDRESS)

--- a/web/routes/admin.py
+++ b/web/routes/admin.py
@@ -1,6 +1,7 @@
 """The operator's page: signups and activations by week. Cloud mode only.
 
     GET /admin             the last twelve weeks
+    GET /admin/            the same; a typed URL often ends in a slash
     GET /admin?weeks=52    further back, up to a year
 
 Registered only in cloud mode, like `auth` and `screen` — a self-hoster is one
@@ -74,7 +75,11 @@ def _admins_only():
     return None
 
 
-@bp.route("/admin")
+# `strict_slashes=False`, so `/admin/` is the page and not a 404. Flask only
+# adds the slash-tolerant redirect to rules that *end* in one, and the first
+# person to open this typed the slash — a 404 that arrives before the admin
+# check runs looks exactly like not being on the list.
+@bp.route("/admin", strict_slashes=False)
 def growth_page():
     weeks = span(request.args.get("weeks"))
     pool = current_app.config["POOL"]


### PR DESCRIPTION
`/admin/` with a trailing slash was a 404 because the route was registered as `/admin` only, and Flask adds the slash-tolerant redirect to rules that end in a slash rather than to ones that do not, so the typed URL never reached the admin check and the failure looked exactly like not being on the list. The rule now accepts both forms, with tests for an admin, somebody else, a signed-out visitor and single mode. The operations log also records that `DINKYDASH_ADMIN_EMAILS` was set on the live app by round-tripping the running spec (deployment `af1c9fa9`, 20:10 UTC), so nothing else changed and no plaintext secret was needed, and it records this failure. Until this merges, `https://app.dinkydash.co/admin` without the slash already works for the listed address.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
