### PR TITLE
Fill in a name for a new calendar

### DIFF
--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -768,6 +768,55 @@ class TestCalendarLinkFeedback:
         assert "Copy a fresh iCal / ICS sharing link" not in page
 
 
+class TestANewCalendarComesWithAName:
+    """The name is for the settings list, not the board, so it is filled in.
+
+    Somebody arriving with a link should be able to paste it and save. The
+    suggestion is "Family" unless a calendar already has that name, and then a
+    numbered one — two feeds sharing a name are filed together.
+    """
+
+    def test_the_first_calendar_is_called_family(self, client):
+        page = client.get("/settings/calendars/new").get_data(as_text=True)
+        assert 'name="label" value="Family"' in page
+        assert "<h1" in page and "New calendar" in page
+
+    def test_pasting_a_link_and_saving_is_enough(self, client, config_path):
+        client.post("/settings/calendars/new", data={
+            "label": "Family", "url": "https://calendar.example/private-xxxx/basic.ics",
+            "enabled": "on"})
+        [saved] = config_module.load_config(config_path)["calendars"]
+        assert saved["label"] == "Family"
+
+    def test_a_second_calendar_gets_a_number_rather_than_the_same_name(self, tmp_path):
+        path = tmp_path / "config.yaml"
+        path.write_text('calendars:\n  - id: fam12345\n    label: "Family"\n'
+                        '    url: "https://calendar.example/private-xxxx/basic.ics"\n'
+                        '    enabled: true\n')
+        page = client_for(create_app(FileStore(path))).get(
+            "/settings/calendars/new").get_data(as_text=True)
+        assert 'name="label" value="Calendar 2"' in page
+
+    def test_the_number_skips_names_already_taken(self, tmp_path):
+        path = tmp_path / "config.yaml"
+        path.write_text('calendars:\n  - id: fam12345\n    label: "family"\n'
+                        '    url: "https://a.example/private-xxxx/a.ics"\n'
+                        '  - id: two12345\n    label: "Calendar 2"\n'
+                        '    url: "https://b.example/private-xxxx/b.ics"\n')
+        page = client_for(create_app(FileStore(path))).get(
+            "/settings/calendars/new").get_data(as_text=True)
+        assert 'name="label" value="Calendar 3"' in page
+
+    def test_an_existing_calendar_keeps_its_own_name_in_the_heading(self, tmp_path):
+        path = tmp_path / "config.yaml"
+        path.write_text('calendars:\n  - id: sch12345\n    label: "School"\n'
+                        '    url: "https://a.example/private-xxxx/a.ics"\n')
+        page = client_for(create_app(FileStore(path))).get(
+            "/settings/calendars/sch12345").get_data(as_text=True)
+        assert "New calendar" not in page
+        assert 'name="label" value="School"' in page
+
+
 class TestSavingACalendarForgetsWhatItFetched:
     """A guest list added after a fetch was never applied to what is stored.
 

--- a/web/routes/settings.py
+++ b/web/routes/settings.py
@@ -434,7 +434,9 @@ def section_edit(section_name, item_id):
 
     is_new = item_id == "new"
     if is_new:
-        item = {"enabled": True} if section_name == "calendars" else {}
+        item = {}
+        if section_name == "calendars":
+            item = {"enabled": True, "label": suggested_calendar_label(config)}
         index = None
     else:
         index, item = config_module.find_item(items, item_id)
@@ -490,6 +492,27 @@ def section_edit(section_name, item_id):
         emoji=EMOJI_SUGGESTIONS.get(section_name, []),
         colors=config_module.AVATAR_COLORS, people=config_module.people_names(config),
     )
+
+
+def suggested_calendar_label(config):
+    """A name for a new calendar, filled in so it need not be typed.
+
+    The name never reaches the board — it is how the settings list and the
+    feed status refer to the calendar — so making somebody invent one before
+    they can paste the link they came with is friction for nothing. "Family"
+    for the first; after that a numbered one, because two feeds with one name
+    are filed together (`calendars.feed_label`) and the second would silently
+    inherit the first's events when it failed. Whatever is filled in can be
+    typed over.
+    """
+    taken = {feed_label(c).strip().lower() for c in config.get("calendars") or []
+             if isinstance(c, dict)}
+    if "family" not in taken:
+        return "Family"
+    number = 2
+    while f"calendar {number}" in taken:
+        number += 1
+    return f"Calendar {number}"
 
 
 def follow_a_rename(config, old, new):

--- a/web/templates/settings/edit.html
+++ b/web/templates/settings/edit.html
@@ -1,10 +1,10 @@
 {% extends "settings/base.html" %}
 {% import "settings/_icons.html" as icons %}
-{% block title %}{{ item.name or item.title or item.label or section.singular }}{% endblock %}
+{% block title %}{{ ("New " ~ section.singular) if is_new else (item.name or item.title or item.label or section.singular) }}{% endblock %}
 
 {% block appbar %}
 <a class="action muted" href="{{ url_for('settings.section_list', section_name=section_name) }}">Cancel</a>
-<h1 style="text-align:center;">{{ item.name or item.title or item.label or ("New " ~ section.singular) }}</h1>
+<h1 style="text-align:center;">{{ ("New " ~ section.singular) if is_new else (item.name or item.title or item.label or section.singular) }}</h1>
 <button class="action" type="submit" form="edit-form" name="action" value="save">Save</button>
 {% endblock %}
 


### PR DESCRIPTION
A new calendar now opens with its name already filled in, so somebody arriving with a link can paste it and save. The suggestion is "Family" for the first calendar and "Calendar 2", "Calendar 3" once that name is taken, skipping any name already in use, because two feeds sharing a name are filed together. The edit page's heading reads "New calendar" for a new one rather than the suggested name, and keeps the calendar's own name when editing an existing one. Covered by five new settings tests, and the full suite passes with and without Postgres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
