### PR TITLE
Add waiting screen for calendar link tests

### DIFF
--- a/web/templates/settings/_calendar_wait.html
+++ b/web/templates/settings/_calendar_wait.html
@@ -1,0 +1,30 @@
+<dialog class="calendar-wait card" id="calendar-wait" aria-labelledby="calendar-wait-title" aria-describedby="calendar-wait-description">
+    <span class="calendar-wait-spinner" aria-hidden="true"></span>
+    <h2 id="calendar-wait-title" tabindex="-1" autofocus>Checking your calendar…</h2>
+    <p id="calendar-wait-description">We're fetching your upcoming events. This may take a little while.</p>
+    <p class="calendar-wait-hint">Keep this page open. Your result will appear here.</p>
+</dialog>
+<script>
+    (() => {
+        const form = document.getElementById('edit-form');
+        const waiting = document.getElementById('calendar-wait');
+        // Keep the ordinary form submission, including its action and CSRF token.
+        // Older browsers still submit normally without the waiting screen.
+        if (typeof waiting.showModal !== 'function') return;
+
+        form.addEventListener('submit', (event) => {
+            if (waiting.open) {
+                event.preventDefault();
+                return;
+            }
+            if (event.defaultPrevented || event.submitter?.value !== 'check') return;
+            waiting.showModal();
+        });
+        // Closing the dialog would not cancel the request already in flight.
+        waiting.addEventListener('cancel', (event) => event.preventDefault());
+        // A browser may restore this exact page when the user goes back.
+        window.addEventListener('pageshow', () => {
+            if (waiting.open) waiting.close();
+        });
+    })();
+</script>

--- a/web/templates/settings/base.html
+++ b/web/templates/settings/base.html
@@ -195,6 +195,24 @@
         .calendar-help li + li { margin-top: 0.625rem; }
         .calendar-test { display: flex; flex-direction: column; gap: 0.5rem; border-top: 1px solid var(--border); padding-top: 1rem; }
         .calendar-test-next { margin-top: 0.5rem; }
+        .calendar-wait {
+            margin: auto; width: calc(100% - 2rem); max-width: 24rem;
+            padding: 2rem 1.5rem; color: var(--text); text-align: center;
+        }
+        .calendar-wait[open] { display: flex; flex-direction: column; align-items: center; gap: 0.875rem; }
+        .calendar-wait::backdrop { background: var(--bg); opacity: 0.95; }
+        .calendar-wait h2 { font-size: 1.25rem; font-weight: 800; outline: none; }
+        .calendar-wait p { font-size: 0.875rem; color: var(--text-mid); }
+        .calendar-wait .calendar-wait-hint { font-size: 0.75rem; }
+        .calendar-wait-spinner {
+            width: 2.5rem; height: 2.5rem; margin-bottom: 0.375rem;
+            border: 3px solid var(--border); border-top-color: var(--accent);
+            border-radius: 50%; animation: calendar-wait-spin 0.9s linear infinite;
+        }
+        @keyframes calendar-wait-spin { to { transform: rotate(360deg); } }
+        @media (prefers-reduced-motion: reduce) {
+            .calendar-wait-spinner { animation: none; }
+        }
 
         .note-box { background: var(--warm); border-radius: 0.875rem; padding: 0.8125rem 0.9375rem; font-size: 0.8125rem; color: var(--text-mid); line-height: 1.55; }
         .flash { border-radius: 0.875rem; padding: 0.8125rem 0.9375rem; font-size: 0.875rem; font-weight: 700; }

--- a/web/templates/settings/edit.html
+++ b/web/templates/settings/edit.html
@@ -129,6 +129,10 @@
     {% endif %}
 </form>
 
+{% if section_name == 'calendars' %}
+{% include "settings/_calendar_wait.html" %}
+{% endif %}
+
 {% if checked %}
 <script>
     document.getElementById('calendar-test-result').focus();


### PR DESCRIPTION
Testing a calendar link previously left the form unchanged while the provider responded; it now immediately shows a centred “Checking your calendar…” dialog with a spinner and reassuring copy.
The dialog prevents repeat submissions, resets on back navigation, supports reduced motion, and preserves the existing form submission and result handling with a no-JavaScript fallback.

Validation: 146 tests passed and 66 skipped across settings, authentication, and static assets; browser checks covered mobile and desktop layouts, focus, duplicate prevention, submitted fields, success and failure results, back navigation, reduced motion, saving, and the no-JavaScript fallback.
