### PR TITLE
Add the newest accounts to the admin page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,11 +155,15 @@ mode is a different product on the same code.
   check goes in `family.py`, before the store is built, and **a mismatch is a 404 and never a 403**:
   "forbidden" confirms the row exists, which tells one family that another one does.
 - **The operator's page is behind a list of addresses, and a miss is a 404.** `/admin` (DIN-37)
-  shows signups and activations by week, and only to a signed-in account whose address is in
-  `DINKYDASH_ADMIN_EMAILS`. Anybody else gets the same answer as a URL that does not exist, and an
-  unset list means nobody. It reads `growth_by_day` — a date and two counts, kept by a trigger on
-  `families` and surviving deletion the way `global_model_spend` does — and one bare `count(*)`, so
-  no family row is read and no id passes through it. `tests/test_admin.py` asserts each of those.
+  shows signups and activations by week and the newest accounts, and only to a signed-in account
+  whose address is in `DINKYDASH_ADMIN_EMAILS`. Anybody else gets the same answer as a URL that does
+  not exist, and an unset list means nobody. The counts read `growth_by_day` — a date and two
+  counts, kept by a trigger on `families` and surviving deletion the way `global_model_spend` does —
+  and one bare `count(*)`. The roster reads each family's address and the platform's bookkeeping
+  (created, activated, status, deadlines, last sign-in) and **never the config**: no name, no
+  calendar, no child's date of birth. No family id is rendered or taken from anywhere, so nothing
+  on the page reaches one family. `tests/test_admin.py` asserts each of those, including that a
+  family's name and calendar label do not appear.
 - **`web/__init__.py` falls back to a hardcoded `app.secret_key`.** Harmless with no auth; in cloud
   mode the session *is* the authentication, so cloud mode must refuse to start without a real
   `DINKYDASH_SECRET_KEY`.

--- a/PLAN.md
+++ b/PLAN.md
@@ -254,7 +254,7 @@ or duplicate self-hosted config loader.
 | `/settings/…` | Local settings | Settings scoped to the session's family |
 | `/s/<token>` | Not used | Bearer-token board |
 | `/preview` | Three sizes of the local board | Authenticated preview of the tokenised board |
-| `/admin` | Not used | Signups and activations by week, for addresses in `DINKYDASH_ADMIN_EMAILS` only |
+| `/admin` | Not used | Signups and activations by week and the newest accounts, for addresses in `DINKYDASH_ADMIN_EMAILS` only |
 | `/healthz` | Process health | Process health, not worker/database health |
 
 Stripe routes are not implemented; their contract belongs to [DIN-53](https://linear.app/keepthescore/issue/DIN-53).
@@ -416,7 +416,7 @@ alone does not close the phase.
 - [ ] Worker heartbeat and external health alerts, verified by a controlled failure ([DIN-54](https://linear.app/keepthescore/issue/DIN-54)).
 - [ ] Repeatable restore into an isolated database, with a successful drill recorded ([DIN-56](https://linear.app/keepthescore/issue/DIN-56)).
 - [x] Preserve explicit preview database overrides ([DIN-48](https://linear.app/keepthescore/issue/DIN-48)).
-- [ ] Admin dashboard ([DIN-37](https://linear.app/keepthescore/issue/DIN-37)): signups and activations by week exist at `/admin`, behind `DINKYDASH_ADMIN_EMAILS` (migration 006, `dinkydash/growth.py`). Spend, trial status and calendar health, per the issue's triage, remain Backlog.
+- [ ] Admin dashboard ([DIN-37](https://linear.app/keepthescore/issue/DIN-37)): signups and activations by week and a roster of the newest accounts (address, created, activated, status, trial deadline, last sign-in) exist at `/admin`, behind `DINKYDASH_ADMIN_EMAILS` (migration 006, `dinkydash/growth.py`). Country of origin is not shown: App Platform forwards `do-connecting-ip` only, and `CF-IPCountry` would need the hostname proxied through our own Cloudflare zone, which App Platform's certificates rule out (DIN-29). Spend and calendar health, per the issue's triage, remain Backlog.
 
 **Done when:** an operator can detect stopped/failed work, inspect useful metadata and
 recover the application. A healthy `/healthz` response alone is insufficient.

--- a/dinkydash/CLAUDE.md
+++ b/dinkydash/CLAUDE.md
@@ -77,13 +77,15 @@ because there is no family to scope *to*:
   is why `users.email` is globally unique;
 - **`dinkydash/screens.py`**, which resolves a screen token to a family. A wall panel has no session
   to scope to and never will — that is what the token is for;
-- **`dinkydash/growth.py`**, which reads the signup and activation counter for the operator's page
-  (DIN-37). The narrowest of the four: `growth_by_day` is a date and two counts with no family
-  identifier to scope by, kept by a trigger on `families` (migration 006) so that it survives
-  deletion the way `global_model_spend` does, and `families_now` is a bare `count(*)`.
+- **`dinkydash/growth.py`**, which feeds the operator's page (DIN-37). Its counts are the narrowest
+  read there is: `growth_by_day` is a date and two counts with no family identifier to scope by,
+  kept by a trigger on `families` (migration 006) so that it survives deletion the way
+  `global_model_spend` does, and `families_now` is a bare `count(*)`. Its `roster` is wider, and
+  deliberately only so wide — the address and the platform's bookkeeping columns on the newest
+  families, never `config`, and no id in or out.
 
 Each of the first three hands its result to a `PostgresStore` built for exactly one family, and the
-fourth reads no row about any family at all, so the rule that matters is untouched. `web/family.py`
+fourth never reaches one family at all, so the rule that matters is untouched. `web/family.py`
 is where the second and third arrive, and it has both doors in one file on purpose — `is_admin`,
 the gate on the operator's page, sits beside them for the same reason: if another is ever added it
 should be as obvious as those are.

--- a/dinkydash/growth.py
+++ b/dinkydash/growth.py
@@ -1,7 +1,9 @@
-"""Signups and activations over time, for whoever runs the service. Cloud only.
+"""Signups, activations and the newest accounts, for whoever runs the service.
+Cloud only.
 
     history(pool)                -> every day with a signup or an activation
     families_now(pool)           -> how many families exist right now
+    roster(pool, most)           -> the newest families: address and bookkeeping
     by_week(rows, weeks, today)  -> the last `weeks` weeks, gaps filled (pure)
     totals(rows)                 -> all-time signups and activations (pure)
 
@@ -13,12 +15,17 @@ the parent's first real act. Both are counted per UTC day by a trigger on
 counts in it and nothing else.
 
 **This is the fourth deliberately unscoped read in the product**, after
-`worker.family_ids`, `accounts.py` and `screens.py`, and it is the narrowest
-of them: the table it reads carries no family identifiers, so there is nothing
-here that *could* be scoped. `families_now` is a bare `count(*)`. No row about
-any one family is read, and no id passes through this module in either
-direction — which is the property an operator's page in a public repo should
-have, so that a bug in it cannot leak a family.
+`worker.family_ids`, `accounts.py` and `screens.py`. The counts are the
+narrowest read there is — `growth_by_day` carries no family identifier, and
+`families_now` is a bare `count(*)`. The roster is wider, and deliberately
+only so wide: the address on each account and the platform's own bookkeeping
+about it (when it was created, when it activated, its status and deadlines,
+when it last signed in). **Never the config.** Names, dates of birth and
+calendars are the family's content, and no operator page needs them. No
+family id leaves this module in either direction, because nothing on the page
+links to one family — so a bug in the page can show an operator an address,
+which the operator can already see in the mailbox that sent it, and nothing
+else.
 
 Like `accounts.py`, this imports no driver: it is handed a pool and asks it for
 connections.
@@ -30,6 +37,15 @@ from datetime import timedelta
 # One week on the chart. `start` is the Monday, as a date.
 Week = namedtuple("Week", "start signups activations")
 Totals = namedtuple("Totals", "signups activations")
+
+# One account on the roster: the address and the bookkeeping, nothing of the config.
+Account = namedtuple("Account", "email created_at activated_at status trial_ends_at "
+                                "lapsed_at last_login_at")
+
+# How many the roster shows. A page listing every address there has ever been
+# is a leak amplifier as well as a slow page; the newest are the ones an
+# operator is looking for, and the counts above the list are about everyone.
+MOST_IN_ROSTER = 100
 
 
 def history(pool):
@@ -48,6 +64,26 @@ def families_now(pool):
     with pool.connection() as conn, conn.cursor() as cur:
         cur.execute("SELECT count(*) FROM families")
         return cur.fetchone()[0]
+
+
+def roster(pool, most=MOST_IN_ROSTER):
+    """The newest `most` families, newest first, with the address on each.
+
+    A LEFT JOIN, because a family made by hand has no parent row yet and should
+    still be on the list rather than silently missing from it. One parent per
+    family at MVP; a second would be a second line, which is the right answer.
+    """
+    with pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            """SELECT u.email, f.created_at, f.activated_at, f.status,
+                      f.trial_ends_at, f.lapsed_at, u.last_login_at
+               FROM families AS f
+               LEFT JOIN users AS u ON u.family_id = f.id
+               ORDER BY f.created_at DESC, u.id
+               LIMIT %s""",
+            (max(1, int(most)),),
+        )
+        return [Account(*row) for row in cur.fetchall()]
 
 
 def week_of(day):

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -7,8 +7,10 @@
   and not on `DINKYDASH_ADMIN_EMAILS` is a 404, never a 403;
 * **an empty list is nobody**, including the person who would obviously be
   on it. A new deployment is closed until somebody opens it;
-* **the page is counts.** It reads the counter and the number of families,
-  and it takes no id from the request, the session or the URL.
+* **the page is counts, and a bounded roster.** The counts read no family
+  row at all. The roster reads the address and the platform's bookkeeping on
+  the newest families and never the config — no name, no calendar, no child's
+  date of birth — and no family id is rendered or taken from anywhere.
 
 The chart's arithmetic is tested with no database. The rest skips without
 `DINKYDASH_TEST_DATABASE_URL`.
@@ -97,6 +99,62 @@ class TestTheChart:
     ])
     def test_the_span_is_bounded(self, raw, weeks):
         assert admin.span(raw) == weeks
+
+
+# -- the words on the roster, with no database -------------------------------
+
+def an_account(**over):
+    from datetime import datetime, timezone
+    fields = dict(email="parent@example.com",
+                  created_at=datetime(2026, 9, 1, 8, tzinfo=timezone.utc),
+                  activated_at=None, status="trialing",
+                  trial_ends_at=datetime(2026, 9, 15, 8, tzinfo=timezone.utc),
+                  lapsed_at=None, last_login_at=None)
+    fields.update(over)
+    return growth.Account(**fields)
+
+
+class TestDescribingAnAccount:
+    TODAY = date(2026, 9, 10)
+
+    def test_a_fresh_trial(self):
+        shown = admin.describe(an_account(), self.TODAY)
+        assert shown["status"] == "Trial to 15 Sep 2026"
+        assert shown["tone"] == "warm"
+        assert shown["detail"] == "Signed up 1 Sep 2026 · not activated yet · never signed in"
+
+    def test_an_activated_family_that_signs_in(self):
+        from datetime import datetime, timezone
+        shown = admin.describe(an_account(
+            activated_at=datetime(2026, 9, 2, 9, tzinfo=timezone.utc),
+            last_login_at=datetime(2026, 9, 9, 21, tzinfo=timezone.utc)), self.TODAY)
+        assert shown["detail"] == ("Signed up 1 Sep 2026 · activated 2 Sep 2026 · "
+                                   "last sign-in 9 Sep 2026")
+
+    def test_a_trial_past_its_deadline_reads_as_ended_before_the_sweep(self):
+        from datetime import datetime, timezone
+        shown = admin.describe(an_account(
+            trial_ends_at=datetime(2026, 9, 9, 8, tzinfo=timezone.utc)), self.TODAY)
+        assert shown["status"] == "Trial ended 9 Sep 2026"
+        assert shown["tone"] == "muted"
+
+    def test_the_other_statuses(self):
+        from datetime import datetime, timezone
+        assert admin.describe(an_account(status="active"), self.TODAY)["status"] == "Active"
+        assert admin.describe(an_account(status="active"), self.TODAY)["tone"] == "good"
+        assert admin.describe(an_account(status="past_due"), self.TODAY)["status"] == "Past due"
+        assert admin.describe(an_account(status="canceled"), self.TODAY)["status"] == "Cancelled"
+        lapsed = admin.describe(an_account(
+            status="lapsed", lapsed_at=datetime(2026, 9, 3, 8, tzinfo=timezone.utc)), self.TODAY)
+        assert lapsed["status"] == "Lapsed 3 Sep 2026"
+        assert lapsed["tone"] == "muted"
+
+    def test_dates_are_utc_days(self):
+        from datetime import datetime, timezone, timedelta
+        # 23:30 in UTC-2 is 01:30 the next day in UTC; the page writes UTC.
+        late = datetime(2026, 9, 1, 23, 30, tzinfo=timezone(timedelta(hours=-2)))
+        assert admin.describe(an_account(created_at=late), self.TODAY)["detail"].startswith(
+            "Signed up 2 Sep 2026")
 
 
 # -- who gets in, in Postgres ------------------------------------------------
@@ -246,3 +304,81 @@ class TestWhatItShows:
         html = admin_client.get("/admin").get_data(as_text=True)
         assert not re.search(r'(src|href)="https?://', html.replace("https://dinkydash.co", ""))
         assert "<script" not in html
+
+
+# -- the roster ----------------------------------------------------------------
+
+A_FAMILY_CONFIG = {
+    "family_name": "The Zebedees",
+    "people": [{"id": "zeb12345", "name": "Zebedee", "date_of_birth": "2015-04-01"}],
+    "calendars": [{"id": "cal12345", "label": "Zebra school",
+                   "url": "https://example.com/private-zzzz/basic.ics", "enabled": True}],
+}
+
+
+@pytest.fixture
+def another_family(pg_pool):
+    """A second family with a parent, a name, a child and a calendar — none of
+    which but the address may appear on the operator's page."""
+    from dinkydash import config as config_module
+    from dinkydash.pgstore import PostgresStore
+
+    with pg_pool.connection() as conn, conn.transaction(), conn.cursor() as cur:
+        cur.execute("INSERT INTO families (screen_token) VALUES (%s) RETURNING id",
+                    (config_module.new_screen_token(),))
+        family_id = cur.fetchone()[0]
+        cur.execute("INSERT INTO users (family_id, email, last_login_at) "
+                    "VALUES (%s, %s, now()) RETURNING id", (family_id, "zebedee@example.org"))
+    PostgresStore(pg_pool, family_id).save_config(dict(A_FAMILY_CONFIG))
+    yield family_id
+    with pg_pool.connection() as conn, conn.transaction(), conn.cursor() as cur:
+        cur.execute("DELETE FROM families WHERE id = %s", (family_id,))
+
+
+class TestTheRoster:
+    def test_the_newest_families_are_listed_with_their_address(
+            self, admin_client, another_family, pg_family):
+        html = admin_client.get("/admin").get_data(as_text=True)
+        assert "zebedee@example.org" in html
+        assert ADDRESS in html
+        # Newest first: the second family was made after the fixture's.
+        assert html.index("zebedee@example.org") < html.index(ADDRESS)
+        assert "activated" in html and "Trial to" in html
+
+    def test_nothing_from_the_config_is_on_the_page(self, admin_client, another_family):
+        html = admin_client.get("/admin").get_data(as_text=True)
+        for private in ("Zebedee", "Zebra school", "private-zzzz", "2015-04-01", "The Zebedees"):
+            assert private not in html, private
+
+    def test_no_family_id_is_rendered(self, admin_client, another_family, pg_family):
+        html = admin_client.get("/admin").get_data(as_text=True)
+        assert str(pg_family) not in html
+        assert str(another_family) not in html
+        assert not re.search(r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}", html)
+
+    def test_a_family_with_no_parent_row_is_still_listed(self, admin_client, pg_pool):
+        # The signed-in fixture family has a parent; make one by hand without.
+        from dinkydash import config as config_module
+        with pg_pool.connection() as conn, conn.transaction(), conn.cursor() as cur:
+            cur.execute("INSERT INTO families (screen_token) VALUES (%s) RETURNING id",
+                        (config_module.new_screen_token(),))
+            orphan = cur.fetchone()[0]
+        try:
+            html = admin_client.get("/admin").get_data(as_text=True)
+            assert "No address on file" in html
+        finally:
+            with pg_pool.connection() as conn, conn.transaction(), conn.cursor() as cur:
+                cur.execute("DELETE FROM families WHERE id = %s", (orphan,))
+
+    def test_a_deleted_family_leaves_the_list(self, admin_client, another_family, pg_pool):
+        from dinkydash import accounts
+        assert "zebedee@example.org" in admin_client.get("/admin").get_data(as_text=True)
+        assert accounts.delete_family(pg_pool, another_family)
+        assert "zebedee@example.org" not in admin_client.get("/admin").get_data(as_text=True)
+
+    def test_the_list_is_capped_and_says_so(self, admin_client, monkeypatch):
+        monkeypatch.setattr(growth, "MOST_IN_ROSTER", 1)
+        monkeypatch.setattr(growth, "families_now", lambda pool: 3)
+        html = admin_client.get("/admin").get_data(as_text=True)
+        assert "newest 1 of 3" in html
+        assert html.count('class="row account"') == 1

--- a/tests/test_growth.py
+++ b/tests/test_growth.py
@@ -210,6 +210,26 @@ class TestTheCounter:
                             [(date(2026, 9, 9), 2, 1), (date(2026, 9, 1), 1, 0)])
         assert growth.history(pg_pool) == [(date(2026, 9, 1), 1, 0), (date(2026, 9, 9), 2, 1)]
 
+    def test_the_roster_is_newest_first_and_carries_no_config(self, pg_pool, pg_family, store):
+        config = store.load_config()
+        config["family_name"] = "The Quiet Ones"
+        config["calendars"] = [dict(A_CALENDAR)]
+        store.save_config(config)
+        with pg_pool.connection() as conn, conn.transaction(), conn.cursor() as cur:
+            cur.execute("INSERT INTO users (family_id, email) VALUES (%s, %s)",
+                        (pg_family, "quiet@example.com"))
+        newer = a_family(pg_pool)
+        try:
+            listed = growth.roster(pg_pool)
+            assert [a.email for a in listed[:2]] == [None, "quiet@example.com"]
+            mine = listed[1]
+            assert mine.activated_at is not None and mine.status == "trialing"
+            assert mine._fields == ("email", "created_at", "activated_at", "status",
+                                    "trial_ends_at", "lapsed_at", "last_login_at")
+            assert growth.roster(pg_pool, most=1) == listed[:1]
+        finally:
+            forget(pg_pool, newer)
+
     def test_families_now_is_a_count_of_rows(self, pg_pool):
         before = growth.families_now(pg_pool)
         family_id = a_family(pg_pool)

--- a/web/CLAUDE.md
+++ b/web/CLAUDE.md
@@ -63,12 +63,15 @@ an explicit local `--base-url`. QR codes are drawn by `settings/_screen_link.htm
 `/settings/screen` and by the last step of the set-up checklist, and nowhere else.
 
 **`web/routes/admin.py` is the third blueprint only cloud mode registers, and its gate is a list.**
-`/admin` (DIN-37) shows signups and activations by week to the operator and to nobody else:
-`guard()` first, so a signed-out visitor is sent to `/login` like everywhere else, then
-`family.is_admin()`, which compares the signed-in account's address with `DINKYDASH_ADMIN_EMAILS`
-and answers a miss with a 404 — never a 403, and an unset list is nobody. The page reads no family:
-its numbers come from `dinkydash/growth.py`, and the chart is inline SVG drawn from numbers the
-route works out (`admin.chart`), because arithmetic in a template is arithmetic nobody tests. Its
+`/admin` (DIN-37) shows signups and activations by week and the newest accounts to the operator and
+to nobody else: `guard()` first, so a signed-out visitor is sent to `/login` like everywhere else,
+then `family.is_admin()`, which compares the signed-in account's address with
+`DINKYDASH_ADMIN_EMAILS` and answers a miss with a 404 — never a 403, and an unset list is nobody.
+Everything on it comes from `dinkydash/growth.py`: counts that read no family row, and a roster
+that reads the address and bookkeeping columns and never the config — `tests/test_admin.py` puts a
+named child and a labelled calendar on a family and asserts neither reaches the page. The chart is
+inline SVG drawn from numbers the route works out (`admin.chart`), because arithmetic in a
+template is arithmetic nobody tests. Its
 two series colours are the shell's own `--accent` and `--purple`, checked as a pair on the card's
 white with the dataviz palette validator (CVD ΔE 24.7, both above 3:1); a third series means
 running it again, not picking a colour. `tests/test_admin.py` covers the gate, the bounds on

--- a/web/routes/admin.py
+++ b/web/routes/admin.py
@@ -1,4 +1,4 @@
-"""The operator's page: signups and activations by week. Cloud mode only.
+"""The operator's page: signups, activations and the newest accounts. Cloud only.
 
     GET /admin             the last twelve weeks
     GET /admin/            the same; a typed URL often ends in a slash
@@ -16,10 +16,13 @@ a stranger needs to know, and 404-on-a-mismatch is the rule every other
 authorisation miss in this app follows. An empty or missing list means nobody,
 which is the safe way for a new deployment to be wrong.
 
-**No family is read here.** The page is built from `dinkydash/growth.py`,
-which reads a table with no family identifiers in it plus one `count(*)`.
-Nothing in this file takes an id from the request, the session or the URL, so
-there is no id to check and nothing for a bug here to leak.
+**What the page reads is bounded, and the bound is written down.** The counts
+come from a table with no family identifiers in it plus one `count(*)`. The
+roster below them is the one read that touches a family's row, and it takes
+the address and the platform's bookkeeping — created, activated, status,
+deadlines, last sign-in — and never the config (`growth.roster`). Nothing in
+this file takes an id from the request, the session or the URL, and none is
+rendered, so there is no id to check and no way to reach one family from here.
 
 The chart is inline SVG drawn from numbers worked out below, with no script
 and no third-party request — the settings shell's own rules. Its two colours
@@ -98,6 +101,8 @@ def growth_page():
         # the counter in a way the backfill could not see.
         deleted=max(0, total.signups - families),
         chart=chart(weekly),
+        roster=[describe(account, today) for account in growth.roster(pool)],
+        most_in_roster=growth.MOST_IN_ROSTER,
     ))
     # Counts, not anybody's data — but it is the business's own page, and a
     # shared cache has no business holding it.
@@ -112,6 +117,50 @@ def span(raw):
     except (TypeError, ValueError):
         return DEFAULT_WEEKS
     return min(MOST_WEEKS, max(1, weeks))
+
+
+# -- the roster -------------------------------------------------------------
+
+# What the status pill says, and which of the shell's pill styles it wears.
+STATUS_WORDS = {"active": "Active", "past_due": "Past due", "canceled": "Cancelled"}
+
+
+def describe(account, today):
+    """One account as the page shows it: the address, a status pill, one line.
+
+    Pure, so the words are testable without a database. `today` is the UTC
+    date the rest of the page uses, and it decides one thing: a trial whose
+    deadline has passed but which the worker has not swept yet is shown as
+    ended, because that is what `lifecycle.access_for` already enforces.
+    """
+    status, tone = _status(account, today)
+    facts = [f"Signed up {_day(account.created_at)}"]
+    facts.append(f"activated {_day(account.activated_at)}" if account.activated_at
+                 else "not activated yet")
+    facts.append(f"last sign-in {_day(account.last_login_at)}" if account.last_login_at
+                 else "never signed in")
+    return {"email": account.email, "status": status, "tone": tone,
+            "detail": " · ".join(facts)}
+
+
+def _status(account, today):
+    if account.status == "trialing":
+        ends = account.trial_ends_at
+        if ends is None:
+            return "Trial", "warm"
+        if ends.astimezone(timezone.utc).date() < today:
+            return f"Trial ended {_day(ends)}", "muted"
+        return f"Trial to {_day(ends)}", "warm"
+    if account.status == "lapsed":
+        return (f"Lapsed {_day(account.lapsed_at)}" if account.lapsed_at else "Lapsed"), "muted"
+    if account.status == "active":
+        return "Active", "good"
+    return STATUS_WORDS.get(account.status, str(account.status).capitalize()), "muted"
+
+
+def _day(stamp):
+    """A timestamp as a UTC date the way the page writes them: `7 Sep 2026`."""
+    return stamp.astimezone(timezone.utc).strftime("%-d %b %Y")
 
 
 # -- the drawing ------------------------------------------------------------

--- a/web/templates/admin/growth.html
+++ b/web/templates/admin/growth.html
@@ -51,6 +51,11 @@
     .numbers tbody tr { border-top: 1px solid var(--border); }
     .numbers td + td { font-variant-numeric: tabular-nums; font-weight: 700; }
     .numbers td.zero { color: var(--faint); font-weight: 600; }
+
+    /* The roster. An address can be long and has no spaces to break at. */
+    .account .row-title { word-break: break-all; }
+    .account .row-sub { white-space: normal; }
+    .pill.good { background: rgba(22, 163, 74, 0.12); color: #15803d; }
 </style>
 {% endblock %}
 
@@ -160,6 +165,28 @@
                 {% endfor %}
             </tbody>
         </table>
+    </div>
+</div>
+
+{# The newest accounts: the address and the platform's bookkeeping, and never
+   anything from the family's config. Nothing here links to one family, so no
+   id is rendered. #}
+<div>
+    <div class="label">
+        Families{% if families_now > most_in_roster %} · newest {{ most_in_roster }} of {{ families_now }}{% endif %}
+    </div>
+    <div class="card">
+        {% for account in roster %}
+        <div class="row account">
+            <div class="row-main">
+                <div class="row-title">{{ account.email or "No address on file" }}</div>
+                <div class="row-sub">{{ account.detail }}</div>
+            </div>
+            <span class="pill {{ account.tone }}">{{ account.status }}</span>
+        </div>
+        {% else %}
+        <div class="row"><div class="row-sub">No families yet.</div></div>
+        {% endfor %}
     </div>
 </div>
 


### PR DESCRIPTION
Adds a roster of the newest families under the counts on `/admin`: the address, when the family was created, when it activated, its status with the trial deadline or lapse date, and the last sign-in, capped at the newest hundred with the page saying so. `growth.roster` reads exactly the address and the platform's bookkeeping columns and never the config, no family id is rendered or taken from anywhere, and a test puts a named child and a labelled calendar on a family and asserts that neither reaches the page. No country column: App Platform forwards `do-connecting-ip` only, and `CF-IPCountry` would need `app.dinkydash.co` proxied through our own Cloudflare zone, which App Platform's certificates rule out (DIN-29), so PLAN.md records that against DIN-37. The instruction files are updated to say what the page now reads and what it must not. 24 new tests; the suite passes with Postgres (1135 passed) and as a self-hoster (793 passed, 342 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
