### PR TITLE
Watch the worker and each deploy from outside, and refuse to start without the database (DIN-54)

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -201,6 +201,14 @@ services:
     # The check arrives on the .ondigitalocean.app hostname, which is in no
     # `domains` block above — so wsgi.py sends unknown hosts to the marketing
     # site, which answers /healthz. A 404 here would roll every deploy back.
+    #
+    # **`/healthz/worker` is deliberately not this path.** It reads the
+    # database and answers 503 when the worker has missed three passes, which
+    # is what `.github/workflows/monitor.yml` wants and what a probe must never
+    # do: three quiet probes restart this container, and a dead worker would be
+    # answered with a rolled-back deploy. `tests/test_deploy_spec.py` holds the
+    # line. What this probe cannot see — a wrong DATABASE_URL — `db.ready`
+    # catches at start-up by refusing to start.
     health_check:
       http_path: /healthz
       initial_delay_seconds: 15
@@ -214,6 +222,12 @@ workers:
   # component rather than a thread in `site` because there is no lock on the
   # tick in cloud mode: two processes would both refresh and both pay Anthropic
   # for the same brief. One worker, however many web instances.
+  #
+  # Every completed pass writes one row to `worker_heartbeat` (DIN-54), which
+  # `/healthz/worker` on the site serves to the monitor workflow. The allowance
+  # before that answer turns 503 is `DINKYDASH_WORKER_STALE_AFTER`, defaulting
+  # in code to 900 s — three missed passes at the default interval. Change
+  # `DINKYDASH_WORKER_INTERVAL` here and set that alongside it.
   - name: worker
     github:
       repo: caspii/dinkydash

--- a/.github/workflows/monitor.yml
+++ b/.github/workflows/monitor.yml
@@ -1,0 +1,68 @@
+# Is the hosted service up, on the commit it should be, with a worker that is
+# still ticking? One script, `monitor.py`, and a failed run is the alert
+# (DIN-54): GitHub emails whoever last touched this file's schedule when a
+# scheduled run fails, and the Actions tab shows a red X either way.
+#
+# * every fifteen minutes: the marketing site, the app, and `/healthz/worker`,
+#   which answers 503 once the worker has missed three passes;
+# * after every push to `main`: the same, but first wait for App Platform to
+#   finish building and for both hostnames to report that commit. A push that
+#   never goes live, or goes live broken, fails here within fifteen minutes —
+#   which the platform's own health check cannot tell you, because it never
+#   reads the database and never opens a page;
+# * by hand, with the two addresses as inputs. Point `app` somewhere that
+#   cannot answer and the run fails within a minute, which is how to see the
+#   alert arrive without stopping anything real (doc/operations.md).
+#
+# No secrets: everything it reads is public, and nothing it reads is anybody's
+# data. Scheduled workflows are best effort — GitHub runs them late under load
+# and switches them off after sixty days without a push — so the cadence is a
+# floor on how quickly a dead worker is noticed, not a promise.
+name: Monitor
+
+on:
+  schedule:
+    - cron: "*/15 * * * *"
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      site:
+        description: "The marketing site"
+        default: "https://dinkydash.co"
+      app:
+        description: "The app"
+        default: "https://app.dinkydash.co"
+
+permissions:
+  contents: read
+
+jobs:
+  live:
+    name: live service
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.11"
+
+      # `monitor.py` is standard library only, so there is nothing to install.
+      - name: Wait for this commit to be live, then check the service
+        if: github.event_name == 'push'
+        run: python monitor.py --commit "$GITHUB_SHA" --wait 900
+
+      - name: Check the live service
+        if: github.event_name == 'schedule'
+        run: python monitor.py
+
+      # Inputs reach the shell through the environment, never by interpolation
+      # into the command line.
+      - name: Check the addresses given
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          SITE: ${{ inputs.site }}
+          APP: ${{ inputs.app }}
+        run: python monitor.py --site "$SITE" --app "$APP"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -229,6 +229,19 @@ committed `docs/`; with the site rendered on request there is one copy of it, in
 **Allowlisting is for values that are public by design.** A real secret that reached a commit is
 fixed by rotating it.
 
+**What decides whether a deploy goes live, and what watches it afterwards** (DIN-54). App
+Platform probes `/healthz` on the platform's own hostname, so it is the marketing app that answers
+it; the probe reads nothing on purpose, because three failed probes restart the container and a
+probe that depended on the database would turn a slow query into a rolled-back deploy. So it only
+proves that the process came up — which is why `create_app` now calls `db.ready` and refuses to
+start when the pooled database does not answer within ten seconds, turning a wrong `DATABASE_URL`
+into a deploy that never goes live rather than one that 500s every board. What the probe cannot
+see, `.github/workflows/monitor.yml` checks from outside with `monitor.py` — every fifteen minutes,
+and after each push to `main` once both hostnames report that commit: the pages that rank, the
+login page, and `/healthz/worker`, which serves the worker's last completed pass and answers 503
+once it is older than `DINKYDASH_WORKER_STALE_AFTER` (three missed passes). A failed run is the
+alert. **That path must never become the probe**, and `tests/test_deploy_spec.py` fails if it does.
+
 Two things the net does not catch, both worth knowing before trusting it:
 
 - **The defaults have no rule for a calendar URL**, which is why we wrote our own. Anything else
@@ -312,6 +325,7 @@ dinkydash/
 ├── budget.py          what a family may spend on the model, and what everybody may
 │                     (`accounts.delete_family` is the hard delete; see phase 5)
 ├── growth.py          signups and activations per day, with no family in the row (cloud only)
+├── heartbeat.py       the worker's pulse: one row, written after each completed pass (cloud only)
 └── runner.py          the two halves of the day, reading and writing through a store
 
 web/
@@ -326,6 +340,7 @@ web/
 ├── routes/auth.py     /login, /login/link, /logout — cloud mode only
 ├── routes/screen.py   /s/<token> — the board with no session, cloud mode only
 ├── routes/admin.py    /admin — signups and activations by week, for DINKYDASH_ADMIN_EMAILS only
+├── routes/status.py   /healthz/worker — the worker's last pass, 503 when stale; for the monitor, never the probe
 └── templates/         board.html, preview.html, auth/*.html, settings/*.html, admin/growth.html
 ```
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -256,6 +256,7 @@ or duplicate self-hosted config loader.
 | `/preview` | Three sizes of the local board | Authenticated preview of the tokenised board |
 | `/admin` | Not used | Signups and activations by week, for addresses in `DINKYDASH_ADMIN_EMAILS` only |
 | `/healthz` | Process health | Process health, not worker/database health |
+| `/healthz/worker` | Not used | The worker's last completed pass; 503 when stale. Read by the monitor workflow, never by the platform probe |
 
 Stripe routes are not implemented; their contract belongs to [DIN-53](https://linear.app/keepthescore/issue/DIN-53).
 
@@ -274,6 +275,7 @@ The SQL files in [migrations/](migrations/) are authoritative. The current table
 | `model_spend` | Daily per-family calls and reported tokens |
 | `global_model_spend` | Daily call totals without family identifiers; survives deletion |
 | `growth_by_day` | Daily signups and activations without family identifiers, kept by a trigger; survives deletion |
+| `worker_heartbeat` | One row per worker loop: when the last pass finished, families ticked, families that raised, duration; no family identifiers |
 | `calendar_health` | Schema exists; recurring-failure tracking is not yet wired up |
 | `schema_migrations` | Applied migration versions |
 
@@ -297,7 +299,11 @@ The spec is [`.do/app.yaml`](.do/app.yaml); secrets stay in encrypted platform e
 variables. The Python buildpack installs `requirements-cloud.txt`. No Dockerfile is needed.
 
 Changes on main deploy through App Platform with a pre-deploy migration job and
-`/healthz` readiness checks. GitHub CI checks pytest and gitleaks; the tests run with
+`/healthz` readiness checks. The probe reads nothing, so `create_app` also refuses to start
+until the pooled database answers (`db.ready`), which is what stops a wrong `DATABASE_URL`
+going live. After each push to `main`, and every fifteen minutes, the `Monitor` workflow
+runs `monitor.py` against both hostnames: the pages, the commit both `/healthz` report, and
+`/healthz/worker`. GitHub CI checks pytest and gitleaks; the tests run with
 Postgres 17 and without a configured database. The current branch rules and deployment
 history are recorded in [doc/operations.md](doc/operations.md).
 
@@ -320,7 +326,9 @@ PR #86 uses `pg_advisory_xact_lock` for token issuance: the lock belongs to the 
 transaction. It does not introduce a session-scoped lock or require session pooling.
 
 Managed backups are documented in operations; the independent restore drill remains
-[DIN-56](https://linear.app/keepthescore/issue/DIN-56). Worker liveness alerts remain MVP work ([DIN-54](https://linear.app/keepthescore/issue/DIN-54));
+[DIN-56](https://linear.app/keepthescore/issue/DIN-56). Worker liveness is a row the worker writes after each completed
+pass (`worker_heartbeat`, `dinkydash/heartbeat.py`), served at `/healthz/worker` and polled by the
+`Monitor` workflow, whose failed run is the alert ([DIN-54](https://linear.app/keepthescore/issue/DIN-54));
 Sentry instrumentation is Backlog ([DIN-35](https://linear.app/keepthescore/issue/DIN-35)).
 Cloud startup validates the session key and database configuration; model/email failures
 have their own runtime handling. Stripe credentials are not required before billing exists.
@@ -413,7 +421,7 @@ alone does not close the phase.
 
 - [x] Transactional email wired into signup/login ([DIN-36](https://linear.app/keepthescore/issue/DIN-36), [DIN-38](https://linear.app/keepthescore/issue/DIN-38)).
 - [ ] Sentry for web, worker and applicable frontend errors, with sensitive-data filtering ([DIN-35](https://linear.app/keepthescore/issue/DIN-35); Backlog).
-- [ ] Worker heartbeat and external health alerts, verified by a controlled failure ([DIN-54](https://linear.app/keepthescore/issue/DIN-54)).
+- [x] Worker heartbeat and external health alerts, verified by a controlled failure ([DIN-54](https://linear.app/keepthescore/issue/DIN-54)): the worker writes `worker_heartbeat` after each completed pass, `/healthz/worker` serves it and answers 503 when stale, and the `Monitor` workflow polls it every fifteen minutes and after each deploy. The stop-and-recover drill was run against an isolated worker and database on 10 September 2026 ([doc/operations.md](doc/operations.md)); the emailed notification of a failed run is GitHub's own and was not witnessed in that batch.
 - [ ] Repeatable restore into an isolated database, with a successful drill recorded ([DIN-56](https://linear.app/keepthescore/issue/DIN-56)).
 - [x] Preserve explicit preview database overrides ([DIN-48](https://linear.app/keepthescore/issue/DIN-48)).
 - [ ] Admin dashboard ([DIN-37](https://linear.app/keepthescore/issue/DIN-37)): signups and activations by week exist at `/admin`, behind `DINKYDASH_ADMIN_EMAILS` (migration 006, `dinkydash/growth.py`). Spend, trial status and calendar health, per the issue's triage, remain Backlog.

--- a/dinkydash/CLAUDE.md
+++ b/dinkydash/CLAUDE.md
@@ -68,7 +68,7 @@ thirty-day session can outlive the account it names, and that should sign the ho
 500. Catching the bare parent would swallow `KeyError` and `IndexError` too, which is to say every
 real bug, and send it to the login page.
 
-Four things are unscoped, all deliberately outside the store rather than weakening it, and each
+Five things are unscoped, all deliberately outside the store rather than weakening it, and each
 because there is no family to scope *to*:
 
 - **`worker.family_ids`**, whose whole job is to walk every family;
@@ -80,10 +80,15 @@ because there is no family to scope *to*:
 - **`dinkydash/growth.py`**, which reads the signup and activation counter for the operator's page
   (DIN-37). The narrowest of the four: `growth_by_day` is a date and two counts with no family
   identifier to scope by, kept by a trigger on `families` (migration 006) so that it survives
-  deletion the way `global_model_spend` does, and `families_now` is a bare `count(*)`.
+  deletion the way `global_model_spend` does, and `families_now` is a bare `count(*)`;
+- **`dinkydash/heartbeat.py`**, the worker's pulse (DIN-54): one row per worker loop, written by
+  `worker.run_pass` after a completed pass and nothing else — not after a stop request cut the walk
+  short, not after a pass that could not list the families — and read by `/healthz/worker` and the
+  operator's page. A time and three counts (families ticked, families that raised, milliseconds),
+  with no family identifier to scope by; the emptiest row in the schema (migration 007).
 
 Each of the first three hands its result to a `PostgresStore` built for exactly one family, and the
-fourth reads no row about any family at all, so the rule that matters is untouched. `web/family.py`
+fourth and fifth read no row about any family at all, so the rule that matters is untouched. `web/family.py`
 is where the second and third arrive, and it has both doors in one file on purpose — `is_admin`,
 the gate on the operator's page, sits beside them for the same reason: if another is ever added it
 should be as obvious as those are.
@@ -206,6 +211,15 @@ including local development and CI: psycopg 3 prepares a statement server-side o
 under transaction-mode pooling the next execution can land on a different backend connection. The
 full reasoning, and why KeepTheScore's clean record on psycopg2 does not transfer, is in PLAN.md
 under [Connection pooling](../PLAN.md#connection-pooling).
+
+**`db.ready(pool)` is what makes a wrong `DATABASE_URL` a failed deploy rather than a live one.**
+A pool opens in the background and a connection string that goes nowhere is only a warning in its
+log — the process came up, `/healthz` answered, and every request that needed the database then
+waited thirty seconds and failed. `create_app` calls `ready` right after building the pool, and it
+raises after `STARTUP_TIMEOUT` seconds naming the variable and nothing else; under gunicorn a
+worker that raises on boot halts the server, so the container never becomes healthy and the
+previous release keeps serving. The worker does not call it: it has no probe, and a worker looping
+on a dead database is a stale heartbeat, which is already the alert.
 
 **`psycopg` is in `requirements-cloud.txt`, not `requirements.txt`.** A Pi has no database and
 should not install a driver for one, so single mode never imports `pgstore` or `db` — the import in

--- a/dinkydash/db.py
+++ b/dinkydash/db.py
@@ -62,6 +62,42 @@ def pool(conninfo=None, min_size=1, max_size=3, **kwargs):
                           configure=_prepare, open=True, **kwargs)
 
 
+# How long a starting process waits for its first connection before it refuses
+# to start. Long enough for a cold pool and a TLS handshake; short enough that a
+# deploy fails before the platform's probe has given up on the container.
+STARTUP_TIMEOUT = 10.0
+
+
+def ready(pool, timeout=None):
+    """Wait for the pool's first connection, or refuse to start.
+
+    A pool opens in the background, and a wrong connection string is only a
+    warning in its log: the process comes up, `/healthz` answers, the deploy is
+    declared healthy, and every request that needs the database then waits
+    thirty seconds and fails. This was demonstrated, not guessed — the cloud
+    entry point built in half a second against a closed port and answered
+    200 on both hostnames. Waiting here turns that into a process that never
+    starts, which under gunicorn is a container that never becomes healthy,
+    which is a deploy that never goes live while the previous one carries on.
+
+    Not called by the worker: it has no probe, and a worker that loops on a
+    dead database is a stale heartbeat, which is already the alert.
+
+    The message names the variable and nothing else. A connection string
+    carries a password, and this runs on a start-up path that logs.
+    """
+    from psycopg_pool import PoolTimeout
+
+    # Read at call time rather than bound as a default, so a test can shorten it.
+    timeout = STARTUP_TIMEOUT if timeout is None else timeout
+    try:
+        pool.wait(timeout=timeout)
+    except PoolTimeout:
+        raise RuntimeError(
+            f"The database did not answer within {timeout:g} seconds. Cloud mode "
+            "will not start without it; check DATABASE_URL.") from None
+
+
 def connect(conninfo=None):
     """One connection, outside any pool. For migrations and one-off scripts.
 

--- a/dinkydash/heartbeat.py
+++ b/dinkydash/heartbeat.py
@@ -1,0 +1,92 @@
+"""The worker's pulse: written after every completed pass, read by whoever asks. Cloud only.
+
+    beat(pool, ticked, failed, took_ms)   the worker, once a pass has finished
+    last(pool)                            the last pass, or None if none has ever finished
+    verdict(row, now, stale_after)        ok, stale or never, with the age (pure)
+
+**A heartbeat means a pass finished**: every family that was due was
+considered, whatever happened to each. A family whose feed was down or whose
+model call was refused is handled inside the tick and still counts as a live
+worker — that is failed *work*, and `failed` counts it. What does not beat is
+a pass that a stop request cut short, or one that could not list the families
+at all: both leave the row as it was, so it goes stale.
+
+**Stale is the alert.** `/healthz/worker` (`web/routes/status.py`) answers 503
+once the last pass is older than `stale_after`, and the monitor workflow
+(`.github/workflows/monitor.yml`) turns that into a failed run, which is an
+email. The default allows three missed five-minute passes: enough for a
+redeploy — App Platform starts the new worker before it stops the old one, but
+not always promptly — and for one slow pass, without letting a dead worker
+hide for long. Change `DINKYDASH_WORKER_INTERVAL` and this has to move with it.
+
+**The fifth deliberately unscoped table, and the emptiest**: a name, a time and
+three counts. No family identifier, no calendar, no generated text — the same
+property `growth_by_day` has, for the same reason (`dinkydash/CLAUDE.md`).
+
+Like `growth.py`, this imports no driver: it is handed a pool and asks it for
+connections. `verdict` takes `now` rather than reading a clock, like everything
+else in this package.
+"""
+
+from datetime import datetime, timezone
+
+# The one loop there is. `python -m worker` walks every family; a second loop on
+# its own cadence would report under its own name.
+TICK = "tick"
+
+# How old the last pass may be before the worker is presumed dead: three missed
+# five-minute passes. `DINKYDASH_WORKER_STALE_AFTER` overrides it, in seconds.
+DEFAULT_STALE_AFTER = 900
+
+
+def beat(pool, ticked, failed, took_ms, name=TICK, now=None):
+    """Record that a pass finished now. One row per loop, overwritten each time."""
+    now = now or datetime.now(timezone.utc)
+    with pool.connection() as conn, conn.transaction(), conn.cursor() as cur:
+        cur.execute(
+            """INSERT INTO worker_heartbeat (name, passed_at, families, failed, took_ms)
+               VALUES (%s, %s, %s, %s, %s)
+               ON CONFLICT (name) DO UPDATE
+                   SET passed_at = EXCLUDED.passed_at,
+                       families = EXCLUDED.families,
+                       failed = EXCLUDED.failed,
+                       took_ms = EXCLUDED.took_ms""",
+            (name, now, max(0, int(ticked)), max(0, int(failed)), max(0, int(took_ms))))
+
+
+def last(pool, name=TICK):
+    """The last completed pass, or None if there has never been one."""
+    with pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            """SELECT passed_at, families, failed, took_ms
+               FROM worker_heartbeat WHERE name = %s""", (name,))
+        row = cur.fetchone()
+    if row is None:
+        return None
+    passed_at, families, failed, took_ms = row
+    return {"passed_at": passed_at, "families": families, "failed": failed,
+            "took_ms": took_ms}
+
+
+def verdict(row, now, stale_after=DEFAULT_STALE_AFTER):
+    """What the last pass says about the worker: `ok`, `stale` or `never`.
+
+    Pure. `row` is what `last` returned, `now` is the caller's clock and
+    `stale_after` is in seconds. The answer carries the age, so a reader can
+    see *how* stale, and the pass itself, so the operator's page can show it.
+    The age is clamped at zero: a heartbeat a few seconds in the future is two
+    clocks disagreeing, not a worker from tomorrow.
+    """
+    if row is None:
+        return {"status": "never", "age_seconds": None, "last_pass": None}
+    age = max(0, int((now - row["passed_at"]).total_seconds()))
+    return {
+        "status": "stale" if age > stale_after else "ok",
+        "age_seconds": age,
+        "last_pass": {
+            "passed_at": row["passed_at"].isoformat(),
+            "families": row["families"],
+            "failed": row["failed"],
+            "took_ms": row["took_ms"],
+        },
+    }

--- a/doc/operations.md
+++ b/doc/operations.md
@@ -575,3 +575,76 @@ new container; the one that died is under `--type run_restarted`. The health pro
 10 s on a ~2 ms cadence, so a probe that lands late is the cheap sign that a request was CPU-bound
 just then. There is still no memory graph outside the dashboard's Insights tab, and no alert on
 restarts.
+
+## The worker's pulse and the monitor, 10 September 2026 (DIN-54)
+
+**What the health check was, and was not, doing.** App Platform probes `/healthz` on its own
+`.ondigitalocean.app` hostname, so it is the marketing app that answers it (`wsgi.py` sends unknown
+hosts there), and it reads nothing on purpose. That makes it a good probe and a poor gate: it stops a
+container that cannot start, and nothing else. Demonstrated before this change by booting the cloud
+entry point with `DATABASE_URL` pointing at a closed port — the app built in half a second, both
+hostnames answered `200` on `/healthz` and on `/login`, and the pool kept retrying in the background.
+Such a deploy would have gone live and 500'd every board after a thirty-second wait. The migrate job
+would not have caught it either: it connects with `DATABASE_URL_DIRECT`, not the pooled URL.
+
+**Three things changed, none of them the probe.**
+
+- **`create_app` waits for the database before it will start** (`db.ready`, ten seconds). Under
+  gunicorn a worker that raises on boot halts the server, the container never becomes healthy, and
+  the previous release keeps serving. `tests/test_cloud_mode.py` covers it, including one real pool
+  against a closed port. The trade: if the database is down at the moment a container restarts, the
+  container loops until it returns, and the marketing site shares that container.
+- **The worker writes a heartbeat after every completed pass** — one row in `worker_heartbeat`
+  (migration 007, applied by the pre-deploy job on merge): when, how many families ticked, how many
+  raised, how long. `/healthz/worker` serves it and answers `503` once it is older than
+  `DINKYDASH_WORKER_STALE_AFTER` (default 900 s, three missed passes). A stop request that cuts a
+  pass short writes nothing, and neither does a pass that cannot list the families, so both go stale.
+  `/admin` shows the same row in a sentence.
+- **`.github/workflows/monitor.yml` runs `monitor.py` every fifteen minutes and after every push to
+  `main`**, the latter waiting up to fifteen minutes for both hostnames to report the pushed commit.
+  It checks the site's `/` and `/healthz`, the app's `/healthz`, `/login` and `/healthz/worker`, and
+  a failed run is the alert: GitHub emails whoever last committed the schedule line. No secrets, no
+  account anywhere, nothing new for the worker to reach — which is why this replaced the push-a-ping
+  design drafted in PR #97. **That PR's heartbeat half is superseded by this; its restore-drill half
+  (DIN-56) is untouched and still wants merging on its own.**
+
+**The drill, against a test worker and a test database, never production.** A scratch Postgres on
+this Mac, migrated from empty; the real `wsgi:application` on port 5199 with the site on `localhost`
+and the app on `127.0.0.1`; the real `python -m worker` with a pass every 5 s and the allowance cut
+to 20 s; `monitor.py` pointed at both. The model key was a fake, the spend brake was on and the
+email key empty, so nothing could leave the machine. All times UTC:
+
+| When | What | `monitor.py` said | Exit |
+|---|---|---|---|
+| 20:46:32 | web up, no worker has ever run | `FAIL app /healthz/worker: no pass has ever finished`; the other four checks `PASS` | 1 |
+| 20:46:37 | worker started 20:46:32, first pass complete 20:46:33 | `PASS ... alive, last pass 4 s ago` | 0 |
+| 20:46:38 | worker sent SIGTERM; "Stop requested; finishing the family in hand" then "Worker stopped" | — | — |
+| 20:46:46 | 8 s after the stop, inside the allowance | `PASS ... alive, last pass 13 s ago` | 0 |
+| 20:47:02 | 24 s after the stop, past the allowance | `FAIL app /healthz/worker: stale, last pass 29 s ago` | 1 |
+| 20:47:07 | worker started again 20:47:02 | `PASS ... alive, last pass 4 s ago` | 0 |
+
+The web log shows the one `503` at 20:47:02 and `200`s around it. What this proves: a stopped worker
+becomes a failed check within one allowance, and a restarted one clears it on its first pass. **What
+it does not prove: that GitHub's email arrives.** That is GitHub's own notification of a failed
+workflow run, and it was not witnessed in this batch.
+
+**To witness it, without touching anything live:** Actions → Monitor → Run workflow, and give `app`
+an address that cannot answer, such as `https://app.dinkydash.co/nowhere`. The run fails within a
+minute and the email goes to whoever pressed the button. The first run on `main` after the merge is
+the other thing to watch: it should pass, and if it does not, the run's log says which line failed.
+
+**Running `monitor.py` from this Mac** needs `SSL_CERT_FILE=$(venv/bin/python -m certifi)` in front
+of it: the python.org 3.11 here ships no CA bundle, so every HTTPS fetch fails verification without
+one. The GitHub runner needs nothing. Run that way against production on 10 September, before the
+merge, it passed the four page checks and failed `/healthz/worker` with a 404 — which is the failure
+path of the script working against the live service, not a fault in it.
+
+**How to read it next time.** `curl -s https://app.dinkydash.co/healthz/worker` is the whole
+status: `ok`, `stale` or `never`, with the age in seconds. `doctl apps logs <id> worker --type run`
+holds the worker's own "Pass complete" lines. A worker that has stopped restarts with
+`doctl apps restart <id> --components worker`; a deploy that went live broken rolls back from the
+dashboard's Deployments tab, and the monitor's push-triggered run will have said so first.
+
+**No spec apply needed.** `.do/app.yaml` gained comments only. `DINKYDASH_WORKER_STALE_AFTER` is
+defaulted in code and is not in the spec; if `DINKYDASH_WORKER_INTERVAL` is ever set there, set the
+allowance alongside it, or the monitor alerts on a worker that is merely slow by design.

--- a/migrations/007_worker_heartbeat.sql
+++ b/migrations/007_worker_heartbeat.sql
@@ -1,0 +1,24 @@
+-- The worker's pulse: when its last pass finished, and what that pass did (DIN-54).
+--
+-- One row per worker loop, overwritten every pass. There is exactly one loop
+-- today — `python -m worker`, which reports as 'tick' — and the key is there so
+-- that a second loop on its own cadence could report without a second table.
+--
+-- **Why a row and not a ping to a monitoring service.** The web service is
+-- already reachable from outside and already holds the database, so a row it
+-- can read means "is the worker alive" can be asked by anything that can fetch
+-- a URL: no account anywhere, no secret in the worker, nothing new the worker
+-- has to reach. `/healthz/worker` is the read; `.github/workflows/monitor.yml`
+-- is the asker. The web service's own `/healthz` stays as it is and reads
+-- nothing, because that one decides whether a deploy goes live.
+--
+-- **No family in the row**, like `global_model_spend` (004) and `growth_by_day`
+-- (006): a count of families walked, a count that raised, and how long it took.
+-- Nothing here leads back to an account, so nothing here is deleted with one.
+CREATE TABLE worker_heartbeat (
+    name      TEXT PRIMARY KEY,
+    passed_at TIMESTAMPTZ NOT NULL,
+    families  INTEGER NOT NULL DEFAULT 0 CHECK (families >= 0),
+    failed    INTEGER NOT NULL DEFAULT 0 CHECK (failed >= 0),
+    took_ms   INTEGER NOT NULL DEFAULT 0 CHECK (took_ms >= 0)
+);

--- a/monitor.py
+++ b/monitor.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Is the hosted service up, on the commit it should be, with a worker still ticking?
+
+    python monitor.py                                 # the live service, now
+    python monitor.py --commit <sha> --wait 900       # after a deploy: wait for that commit first
+    python monitor.py --site http://localhost:5173 --app http://127.0.0.1:5173
+                                                      # a local drill (doc/operations.md)
+
+One line per check, and exit status 0 only when every check passed. This is
+what `.github/workflows/monitor.yml` runs every fifteen minutes and after every
+push to `main`; a failed run there is the alert (DIN-54).
+
+**Why a script rather than a curl one-liner.** The checks are the contract —
+what "up" means for this service — and a contract written in a workflow file
+is a contract nobody tests. `tests/test_monitor.py` runs these against canned
+answers: a worker that never ran, a stale one, a deploy that never arrives.
+
+**Why the standard library.** The workflow runs on a bare runner with no
+`pip install`, so this imports nothing the interpreter did not come with.
+
+What it checks, and why each one is there:
+
+* the marketing site answers `/` and `/healthz` — the pages that rank;
+* the app answers `/healthz` and `/login` — the process is up and a page
+  renders. `/login` needs no database, so it is a check on the code, not the
+  cluster;
+* the app answers `/healthz/worker` with 200 — a pass finished recently, which
+  is the only thing that says the worker is alive, and it reads the database,
+  which is the only thing here that says the app can reach it;
+* with `--commit`, both `/healthz` report that commit — the deploy that was
+  pushed is the deploy that is live. App Platform builds for several minutes
+  after a push, so this is polled until it is true or `--wait` runs out.
+
+Nothing here carries a secret, and nothing it reads is anybody's data.
+"""
+
+import argparse
+import json
+import sys
+import time
+import urllib.error
+import urllib.request
+
+SITE = "https://dinkydash.co"
+APP = "https://app.dinkydash.co"
+
+TIMEOUT = 15   # seconds per request; a health path that takes longer is down
+POLL = 20      # seconds between looks while waiting for a commit to go live
+
+
+def fetch(url, timeout=TIMEOUT):
+    """`(status, body)` for a GET. An HTTP error is a status; no answer is `None`."""
+    request = urllib.request.Request(url, headers={"User-Agent": "dinkydash-monitor"})
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            return response.status, response.read().decode("utf-8", "replace")
+    except urllib.error.HTTPError as exc:
+        return exc.code, exc.read().decode("utf-8", "replace")
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        return None, f"{type(exc).__name__}: {getattr(exc, 'reason', exc)}"
+
+
+# -- the checks: each returns (passed, one line of detail) --------------------
+
+def healthz(fetch, base, commit=None):
+    """The process answers, and — if asked — it is running that commit."""
+    status, body = fetch(base + "/healthz")
+    said = _json(body)
+    if status != 200 or said.get("status") != "ok":
+        return False, _what_came_back(status, body)
+    running = str(said.get("commit", "unknown"))
+    if commit and not running.startswith(commit):
+        return False, f"running {running[:12]}, not {commit[:12]}"
+    return True, f"ok, commit {running[:12]}"
+
+
+def page(fetch, url):
+    """A page renders."""
+    status, body = fetch(url)
+    return status == 200, _what_came_back(status, body)
+
+
+def worker(fetch, base):
+    """A pass finished recently — the worker is alive and the app can reach the database."""
+    status, body = fetch(base + "/healthz/worker")
+    said = _json(body)
+    state, age = said.get("status"), said.get("age_seconds")
+    if status == 200 and state == "ok":
+        return True, f"alive, last pass {age} s ago"
+    if state == "never":
+        return False, "no pass has ever finished"
+    if state == "stale":
+        return False, f"stale, last pass {age} s ago"
+    return False, _what_came_back(status, body)
+
+
+def wait_for(fetch, bases, commit, wait, sleep=time.sleep, clock=time.monotonic):
+    """Poll until every base's `/healthz` reports `commit`, or `wait` seconds pass."""
+    deadline = clock() + wait
+    while True:
+        if all(healthz(fetch, base, commit)[0] for base in bases):
+            return True
+        if clock() >= deadline:
+            return False
+        sleep(POLL)
+
+
+def run(site=SITE, app=APP, commit=None, wait=0, fetch=fetch,
+        sleep=time.sleep, clock=time.monotonic, out=print):
+    """Every check, one line each. Returns the exit status."""
+    failed = 0
+    if commit and wait:
+        arrived = wait_for(fetch, (site, app), commit, wait, sleep, clock)
+        failed += not arrived
+        out(f"{'PASS' if arrived else 'FAIL'}  commit {commit[:12]} live on both "
+            f"hostnames{'' if arrived else f' (not within {wait} s)'}")
+
+    checks = (
+        ("site /healthz", lambda: healthz(fetch, site, commit)),
+        ("site /", lambda: page(fetch, site + "/")),
+        ("app /healthz", lambda: healthz(fetch, app, commit)),
+        ("app /login", lambda: page(fetch, app + "/login")),
+        ("app /healthz/worker", lambda: worker(fetch, app)),
+    )
+    for name, check in checks:
+        passed, detail = check()
+        failed += not passed
+        out(f"{'PASS' if passed else 'FAIL'}  {name}: {detail}")
+    return 0 if not failed else 1
+
+
+def _json(body):
+    try:
+        said = json.loads(body)
+    except (TypeError, ValueError):
+        return {}
+    return said if isinstance(said, dict) else {}
+
+
+def _what_came_back(status, body):
+    """A status code, or the transport error when there was no status at all."""
+    if status is None:
+        return f"no answer ({body})"
+    return f"HTTP {status}"
+
+
+def parse(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Check the hosted service: the site, the app, the worker.")
+    parser.add_argument("--site", default=SITE, help=f"the marketing site (default {SITE})")
+    parser.add_argument("--app", default=APP, help=f"the app (default {APP})")
+    parser.add_argument("--commit", help="the commit both /healthz must report")
+    parser.add_argument("--wait", type=int, default=0,
+                        help="seconds to wait for --commit to go live before checking")
+    args = parser.parse_args(argv)
+    args.site, args.app = args.site.rstrip("/"), args.app.rstrip("/")
+    return args
+
+
+def main(argv=None):
+    args = parse(argv)
+    return run(args.site, args.app, args.commit, args.wait)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -74,6 +74,9 @@ def forget_unowned_rows(pool):
             cur.execute("DELETE FROM login_tokens WHERE user_id IS NULL")
             cur.execute("DELETE FROM global_model_spend")
             cur.execute("DELETE FROM growth_by_day")
+            # The worker's pulse (007) has no family either, and a heartbeat
+            # left by one test is a live worker in the next.
+            cur.execute("DELETE FROM worker_heartbeat")
 
 
 @pytest.fixture

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -246,3 +246,46 @@ class TestWhatItShows:
         html = admin_client.get("/admin").get_data(as_text=True)
         assert not re.search(r'(src|href)="https?://', html.replace("https://dinkydash.co", ""))
         assert "<script" not in html
+
+
+# -- the worker's pulse (DIN-54) ----------------------------------------------
+
+class TestTheWorkerCard:
+    """The same row `/healthz/worker` serves to the monitor, in a sentence."""
+
+    def test_before_any_pass_it_says_so(self, admin_client):
+        html = admin_client.get("/admin").get_data(as_text=True)
+        assert "No pass has finished yet." in html
+        assert "Never run" in html
+
+    def test_a_recent_pass_is_alive_and_says_what_it_did(self, admin_client, pg_pool):
+        from dinkydash import heartbeat
+        heartbeat.beat(pg_pool, 3, 1, 1234)
+        html = admin_client.get("/admin").get_data(as_text=True)
+        assert "Last pass finished just now: 3 families, 1 failed, 1.2 s." in html
+        assert "Alive" in html
+
+    def test_a_worker_that_went_quiet_is_said_to_be_quiet(self, admin_client, pg_pool):
+        from datetime import datetime, timedelta, timezone
+
+        from dinkydash import heartbeat
+        heartbeat.beat(pg_pool, 1, 0, 400,
+                       now=datetime.now(timezone.utc) - timedelta(hours=2, minutes=1))
+        html = admin_client.get("/admin").get_data(as_text=True)
+        assert "Last pass finished 2 hours ago: 1 family, none failed, 0.4 s." in html
+        assert "Quiet" in html
+
+    @pytest.mark.parametrize("seconds,said", [
+        (0, "just now"), (59, "just now"), (60, "1 minute ago"), (119, "1 minute ago"),
+        (120, "2 minutes ago"), (3599, "59 minutes ago"), (3600, "1 hour ago"),
+        (7200, "2 hours ago"), (47 * 3600, "47 hours ago"), (48 * 3600, "2 days ago"),
+        (10 * 86400, "10 days ago"),
+    ])
+    def test_the_age_reads_as_a_person_would_say_it(self, seconds, said):
+        assert admin.ago(seconds) == said
+
+    def test_the_sentence_with_no_pass_and_with_one(self):
+        assert admin.pulse_text({"status": "never"}) == "No pass has finished yet."
+        assert admin.pulse_text({"status": "ok", "age_seconds": 30, "last_pass": {
+            "families": 0, "failed": 0, "took_ms": 5}}) == (
+            "Last pass finished just now: 0 families, none failed, 0.0 s.")

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -513,7 +513,7 @@ def test_hosted_callers_enforce_model_policy_at_the_api(
     assert before["max_tokens"] == stored_tokens
 
     if caller == "worker":
-        assert tick_all(pg_pool) == 1
+        assert tick_all(pg_pool).ticked == 1
     else:
         assert parent.post("/settings/generate").status_code == 302
 

--- a/tests/test_cloud_mode.py
+++ b/tests/test_cloud_mode.py
@@ -140,6 +140,69 @@ def client(pg_pool, pg_family, monkeypatch):
     return client
 
 
+class TestCloudModeWaitsForTheDatabase:
+    """A wrong `DATABASE_URL` used to start cleanly and fail every request.
+
+    The pool opens in the background and only warns, so the process came up,
+    `/healthz` answered, the deploy was declared healthy, and every board then
+    waited thirty seconds and 500'd. Now the process refuses to start, which
+    is a deploy that never goes live while the previous one carries on.
+    Nothing here needs a real database, except the last test, which needs a
+    closed port.
+    """
+
+    @pytest.fixture(autouse=True)
+    def cloud(self, monkeypatch):
+        pytest.importorskip("psycopg_pool")
+        monkeypatch.setenv("DINKYDASH_MODE", "cloud")
+        monkeypatch.setenv("DINKYDASH_SECRET_KEY", "a-real-one")
+        monkeypatch.setenv("DATABASE_URL", "postgresql://nobody:hunter2@127.0.0.1:1/nowhere")
+
+    def test_a_database_that_never_answers_is_a_refusal_to_start(self, monkeypatch):
+        from psycopg_pool import PoolTimeout
+
+        from dinkydash import db
+
+        class NeverReady:
+            def wait(self, timeout):
+                raise PoolTimeout("pool initialization incomplete")
+
+        monkeypatch.setattr(db, "pool", lambda *args, **kwargs: NeverReady())
+        with pytest.raises(RuntimeError, match="DATABASE_URL") as refused:
+            create_app()
+        # The variable's name, never its value: a connection string is a password.
+        assert "hunter2" not in str(refused.value)
+        assert "nowhere" not in str(refused.value)
+
+    def test_a_database_that_answers_lets_it_start(self, monkeypatch):
+        from dinkydash import db
+
+        class Ready:
+            waited = None
+
+            def wait(self, timeout):
+                self.waited = timeout
+
+        pool = Ready()
+        monkeypatch.setattr(db, "pool", lambda *args, **kwargs: pool)
+        app = create_app()
+        assert app.config["POOL"] is pool
+        assert pool.waited == db.STARTUP_TIMEOUT
+
+    def test_the_wait_is_bounded_and_shorter_than_the_probes_patience(self):
+        from dinkydash import db
+
+        assert 0 < db.STARTUP_TIMEOUT <= 15
+
+    def test_the_real_pool_really_does_refuse(self, monkeypatch):
+        """End to end: a real pool against a closed port, with the wait cut short."""
+        from dinkydash import db
+
+        monkeypatch.setattr(db, "STARTUP_TIMEOUT", 0.5)
+        with pytest.raises(RuntimeError, match="DATABASE_URL"):
+            create_app()
+
+
 class TestABoardOutOfPostgres:
     """DIN-31's "done when": a board renders in cloud mode, from rows."""
 

--- a/tests/test_deploy_spec.py
+++ b/tests/test_deploy_spec.py
@@ -1,0 +1,90 @@
+"""What `.do/app.yaml` promises about the health check, held against the code.
+
+The spec is reviewed like code, but a spec and a route drift apart in silence:
+the probe path is a string in one file and a decorator in another, and the
+first sign of a mismatch is a deploy that never goes live. Two other files
+already read the spec — `test_auth.py` for the access-log format,
+`test_tenancy.py` for the absence of a family id. This one is for the probe.
+
+* **the probe arrives on the platform's own hostname**, which is in no
+  `domains` block, so it is the *site* that has to answer it;
+* **the board app answers it too**, with no session and no database — the same
+  path on `app.dinkydash.co` must not redirect to `/login`;
+* **it is never `/healthz/worker`.** That path reads the database and answers
+  503 when the worker is quiet, which is what a monitor wants and what a probe
+  must never do: three quiet probes restart the container, and a rolled-back
+  deploy would be the answer to a dead worker.
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from tests.conftest import client_for
+from web import create_app
+from website.site import create_site_app
+from wsgi import dispatch
+
+REPO = Path(__file__).resolve().parent.parent
+PLATFORM_HOST = "clownfish-app-7xt89.ondigitalocean.app"
+
+
+@pytest.fixture(scope="module")
+def probe():
+    spec = yaml.safe_load((REPO / ".do" / "app.yaml").read_text())
+    (site,) = spec["services"]
+    return site["health_check"]
+
+
+class Exploding:
+    """A pool that fails on any use: the probe must not touch it."""
+
+    def __getattr__(self, name):
+        raise AssertionError(f"the probe touched the pool ({name})")
+
+
+def failing_board(environ, start_response):
+    raise AssertionError("the probe reached the board app on an unknown host")
+
+
+class TestTheProbePath:
+    def test_the_site_answers_it_on_the_platforms_own_hostname(self, probe):
+        application = dispatch(create_site_app(), failing_board, "app.dinkydash.co")
+        client = create_site_app().test_client()
+        response = client.get(probe["http_path"], headers={"Host": PLATFORM_HOST})
+        assert response.status_code == 200
+        assert response.get_json()["status"] == "ok"
+        # And through the dispatcher, which is what gunicorn actually runs.
+        status = []
+        body = application({"HTTP_HOST": PLATFORM_HOST, "PATH_INFO": probe["http_path"],
+                            "REQUEST_METHOD": "GET", "SERVER_NAME": "localhost",
+                            "SERVER_PORT": "8080", "wsgi.url_scheme": "http"},
+                           lambda s, h: status.append(s))
+        assert b"".join(body) and status[0].startswith("200")
+
+    def test_the_board_app_answers_it_with_no_session_and_no_database(self, probe, monkeypatch):
+        pytest.importorskip("psycopg")
+        monkeypatch.setenv("DINKYDASH_MODE", "cloud")
+        monkeypatch.setenv("DINKYDASH_SECRET_KEY", "a-real-one")
+        client = client_for(create_app(pool=Exploding()))
+        response = client.get(probe["http_path"])
+        assert response.status_code == 200
+        assert response.get_json()["status"] == "ok"
+
+    def test_it_is_not_the_worker_status(self, probe):
+        assert probe["http_path"] != "/healthz/worker"
+        assert not probe["http_path"].startswith("/healthz/")
+
+    def test_it_is_a_path_and_not_a_tcp_check(self, probe):
+        """Without `http_path` App Platform falls back to a TCP check, which a
+        process that binds the port and 500s every request would pass."""
+        assert probe["http_path"].startswith("/")
+
+    def test_the_container_has_time_to_wait_for_its_database(self, probe):
+        """`db.ready` waits before the process comes up; the probe's patience
+        has to outlast it, or a slow-but-healthy database fails every deploy."""
+        db = pytest.importorskip("dinkydash.db")
+        patience = (probe["initial_delay_seconds"]
+                    + probe["period_seconds"] * probe["failure_threshold"])
+        assert patience > db.STARTUP_TIMEOUT

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -1,0 +1,115 @@
+"""The worker's pulse: what a heartbeat means, and what its row may hold (DIN-54).
+
+* **the verdict is pure.** `ok`, `stale` or `never` from a row, a clock and an
+  allowance, with no database and no clock of its own;
+* **failed work is not a dead worker.** A pass in which every family raised
+  still beat; the count is carried, the verdict is `ok`;
+* **one row, overwritten**, and nothing in it names a family.
+
+The verdict tests run everywhere; the row tests skip without
+`DINKYDASH_TEST_DATABASE_URL`.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from dinkydash import heartbeat
+from tests.conftest import forget_unowned_rows
+
+NOW = datetime(2026, 9, 10, 20, 0, tzinfo=timezone.utc)
+
+
+def row(age_seconds, families=3, failed=0, took_ms=1200):
+    return {"passed_at": NOW - timedelta(seconds=age_seconds),
+            "families": families, "failed": failed, "took_ms": took_ms}
+
+
+class TestTheVerdict:
+    def test_no_row_is_never(self):
+        assert heartbeat.verdict(None, NOW) == {
+            "status": "never", "age_seconds": None, "last_pass": None}
+
+    @pytest.mark.parametrize("age", [0, 1, 299, 899, 900])
+    def test_within_the_allowance_is_ok(self, age):
+        said = heartbeat.verdict(row(age), NOW)
+        assert said["status"] == "ok"
+        assert said["age_seconds"] == age
+
+    @pytest.mark.parametrize("age", [901, 3600, 86400 * 3])
+    def test_beyond_it_is_stale(self, age):
+        said = heartbeat.verdict(row(age), NOW)
+        assert said["status"] == "stale"
+        assert said["age_seconds"] == age
+
+    def test_the_default_allowance_is_three_missed_passes(self):
+        assert heartbeat.DEFAULT_STALE_AFTER == 900
+
+    def test_the_allowance_is_a_parameter(self):
+        assert heartbeat.verdict(row(100), NOW, stale_after=60)["status"] == "stale"
+        assert heartbeat.verdict(row(100), NOW, stale_after=100)["status"] == "ok"
+
+    def test_a_heartbeat_from_the_future_is_age_zero_and_not_an_error(self):
+        """Two clocks disagreeing by a few seconds is not a worker from tomorrow."""
+        said = heartbeat.verdict(row(-30), NOW)
+        assert said == {**said, "status": "ok", "age_seconds": 0}
+
+    def test_failed_families_do_not_make_a_live_worker_stale(self):
+        said = heartbeat.verdict(row(10, families=3, failed=3), NOW)
+        assert said["status"] == "ok"
+        assert said["last_pass"]["failed"] == 3
+
+    def test_it_carries_the_pass_for_the_operators_page(self):
+        said = heartbeat.verdict(row(61, families=4, failed=1, took_ms=2500), NOW)
+        assert said["last_pass"] == {
+            "passed_at": "2026-09-10T19:58:59+00:00",
+            "families": 4, "failed": 1, "took_ms": 2500}
+
+
+# -- the row, in Postgres ----------------------------------------------------
+
+@pytest.fixture
+def pool(pg_pool):
+    """The shared pool, with no heartbeat before the test and none left after."""
+    forget_unowned_rows(pg_pool)
+    yield pg_pool
+    forget_unowned_rows(pg_pool)
+
+
+class TestTheRow:
+    def test_no_pass_yet_is_none(self, pool):
+        assert heartbeat.last(pool) is None
+
+    def test_a_beat_round_trips(self, pool):
+        heartbeat.beat(pool, 3, 1, 1234, now=NOW)
+        assert heartbeat.last(pool) == {
+            "passed_at": NOW, "families": 3, "failed": 1, "took_ms": 1234}
+
+    def test_a_beat_with_no_clock_given_is_now(self, pool):
+        before = datetime.now(timezone.utc)
+        heartbeat.beat(pool, 0, 0, 0)
+        assert heartbeat.last(pool)["passed_at"] >= before - timedelta(seconds=1)
+
+    def test_a_second_beat_overwrites_rather_than_accumulates(self, pool):
+        heartbeat.beat(pool, 3, 1, 1234, now=NOW)
+        heartbeat.beat(pool, 5, 0, 800, now=NOW + timedelta(minutes=5))
+        assert heartbeat.last(pool) == {
+            "passed_at": NOW + timedelta(minutes=5), "families": 5, "failed": 0,
+            "took_ms": 800}
+        with pool.connection() as conn, conn.cursor() as cur:
+            cur.execute("SELECT count(*) FROM worker_heartbeat")
+            assert cur.fetchone()[0] == 1
+
+    def test_negative_counts_are_clamped_rather_than_refused(self, pool):
+        """The table checks its counts; a bad number must not become a pass
+        with no heartbeat, which would look like a dead worker."""
+        heartbeat.beat(pool, -1, -1, -5, now=NOW)
+        assert heartbeat.last(pool) == {
+            "passed_at": NOW, "families": 0, "failed": 0, "took_ms": 0}
+
+    def test_the_row_names_no_family(self, pool):
+        with pool.connection() as conn, conn.cursor() as cur:
+            cur.execute("""SELECT column_name FROM information_schema.columns
+                           WHERE table_name = 'worker_heartbeat'""")
+            columns = {name for (name,) in cur.fetchall()}
+        assert columns == {"name", "passed_at", "families", "failed", "took_ms"}

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -1,0 +1,208 @@
+"""What `monitor.py` calls up, and what it calls down (DIN-54).
+
+The script is the contract for "the hosted service is up", and the workflow
+that runs it is only as good as these: a healthy service passes, a worker that
+never ran or went quiet fails, a deploy that never arrives fails, and one
+failing check never hides the others. Every fetch here is canned, every clock
+is fake, and nothing reaches the network.
+"""
+
+import json
+
+import pytest
+
+import monitor
+
+SITE, APP = "https://site.test", "https://app.test"
+COMMIT = "924aedfbbfc1c768d5bbc9df8b3b3b90e605df80"
+
+
+def healthy(commit=COMMIT):
+    return {
+        f"{SITE}/healthz": (200, json.dumps({"status": "ok", "commit": commit})),
+        f"{SITE}/": (200, "<html>the site</html>"),
+        f"{APP}/healthz": (200, json.dumps({"status": "ok", "commit": commit})),
+        f"{APP}/login": (200, "<html>sign in</html>"),
+        f"{APP}/healthz/worker": (200, json.dumps(
+            {"status": "ok", "age_seconds": 61, "last_pass": {"families": 3}})),
+    }
+
+
+def answering(canned):
+    """A fetch over canned `(status, body)` answers, recording what was asked."""
+    asked = []
+
+    def fetch(url, timeout=None):
+        asked.append(url)
+        return canned.get(url, (404, "not found"))
+
+    fetch.asked = asked
+    return fetch
+
+
+def run(canned, **kwargs):
+    """`monitor.run` against canned answers, with a clock that sleeping advances."""
+    lines, now = [], [0.0]
+
+    def sleep(seconds):
+        now[0] += seconds
+
+    fetch = answering(canned)
+    status = monitor.run(SITE, APP, fetch=fetch, out=lines.append, sleep=sleep,
+                         clock=lambda: now[0], **kwargs)
+    return status, lines, fetch
+
+
+def failures(lines):
+    return [line for line in lines if line.startswith("FAIL")]
+
+
+class TestAHealthyService:
+    def test_every_check_passes_and_the_exit_status_is_zero(self):
+        status, lines, _ = run(healthy())
+        assert status == 0
+        assert [line[:4] for line in lines] == ["PASS"] * 5
+
+    def test_each_check_says_what_it_saw(self):
+        _, lines, _ = run(healthy())
+        assert any("site /healthz: ok, commit 924aedfbbfc1" in line for line in lines)
+        assert any("app /healthz/worker: alive, last pass 61 s ago" in line for line in lines)
+
+    def test_it_asks_for_exactly_the_five_paths(self):
+        _, _, fetch = run(healthy())
+        assert fetch.asked == [f"{SITE}/healthz", f"{SITE}/", f"{APP}/healthz",
+                               f"{APP}/login", f"{APP}/healthz/worker"]
+
+
+class TestWhatBringsItDown:
+    def test_a_worker_that_never_ran(self):
+        canned = healthy()
+        canned[f"{APP}/healthz/worker"] = (503, json.dumps(
+            {"status": "never", "age_seconds": None, "last_pass": None}))
+        status, lines, _ = run(canned)
+        assert status == 1
+        assert failures(lines) == ["FAIL  app /healthz/worker: no pass has ever finished"]
+
+    def test_a_worker_that_went_quiet(self):
+        canned = healthy()
+        canned[f"{APP}/healthz/worker"] = (503, json.dumps(
+            {"status": "stale", "age_seconds": 1800, "last_pass": {}}))
+        status, lines, _ = run(canned)
+        assert status == 1
+        assert failures(lines) == ["FAIL  app /healthz/worker: stale, last pass 1800 s ago"]
+
+    def test_a_deploy_from_before_the_worker_status_existed(self):
+        canned = healthy()
+        canned[f"{APP}/healthz/worker"] = (404, "<html>not found</html>")
+        status, lines, _ = run(canned)
+        assert status == 1
+        assert failures(lines) == ["FAIL  app /healthz/worker: HTTP 404"]
+
+    def test_an_app_that_does_not_answer_at_all(self):
+        canned = healthy()
+        for path in ("/healthz", "/login", "/healthz/worker"):
+            canned[f"{APP}{path}"] = (None, "URLError: [Errno 61] Connection refused")
+        status, lines, _ = run(canned)
+        assert status == 1
+        assert len(failures(lines)) == 3
+        assert "no answer (URLError: [Errno 61] Connection refused)" in failures(lines)[0]
+
+    def test_a_marketing_page_that_500s(self):
+        canned = healthy()
+        canned[f"{SITE}/"] = (500, "<html>oops</html>")
+        status, lines, _ = run(canned)
+        assert status == 1
+        assert failures(lines) == ["FAIL  site /: HTTP 500"]
+
+    def test_a_health_path_that_answers_200_but_not_ok(self):
+        canned = healthy()
+        canned[f"{APP}/healthz"] = (200, json.dumps({"status": "degraded"}))
+        status, lines, _ = run(canned)
+        assert status == 1
+        assert failures(lines) == ["FAIL  app /healthz: HTTP 200"]
+
+    def test_a_health_path_that_is_not_json(self):
+        canned = healthy()
+        canned[f"{SITE}/healthz"] = (200, "<html>a maintenance page</html>")
+        status, lines, _ = run(canned)
+        assert status == 1
+        assert failures(lines) == ["FAIL  site /healthz: HTTP 200"]
+
+    def test_one_failure_does_not_hide_the_other_checks(self):
+        canned = healthy()
+        canned[f"{SITE}/"] = (500, "")
+        _, lines, _ = run(canned)
+        assert len(lines) == 5
+        assert sum(line.startswith("PASS") for line in lines) == 4
+
+
+class TestWaitingForACommit:
+    def test_a_commit_that_is_already_live_is_a_pass_with_no_waiting(self):
+        status, lines, _ = run(healthy(), commit=COMMIT, wait=900)
+        assert status == 0
+        assert lines[0] == f"PASS  commit {COMMIT[:12]} live on both hostnames"
+
+    def test_a_short_prefix_of_the_commit_is_enough(self):
+        status, _, _ = run(healthy(), commit=COMMIT[:7], wait=900)
+        assert status == 0
+
+    def test_it_polls_until_the_commit_arrives(self):
+        looks, old = [], healthy("f2e4080aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+        new = healthy()
+
+        def fetch(url, timeout=None):
+            looks.append(url)
+            # The old release answers the first two rounds; the new one after.
+            # Rounds are counted on the site, which is asked first every time.
+            return (old if looks.count(f"{SITE}/healthz") <= 2 else new)[url]
+
+        lines, now = [], [0.0]
+        status = monitor.run(SITE, APP, commit=COMMIT, wait=900, fetch=fetch,
+                             out=lines.append, sleep=lambda s: now.__setitem__(0, now[0] + s),
+                             clock=lambda: now[0])
+        assert status == 0
+        assert lines[0].startswith("PASS  commit")
+        assert now[0] == 2 * monitor.POLL
+
+    def test_a_commit_that_never_arrives_fails_within_the_wait(self):
+        status, lines, fetch = run(healthy("f2e4080aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+                                   commit=COMMIT, wait=900)
+        assert status == 1
+        assert lines[0] == f"FAIL  commit {COMMIT[:12]} live on both hostnames (not within 900 s)"
+        # And the health checks say which release is actually running.
+        assert "FAIL  app /healthz: running f2e4080aaaaa, not 924aedfbbfc1" in lines
+        # It gave up on the clock, not on a number of tries.
+        assert fetch.asked.count(f"{SITE}/healthz") >= 900 // monitor.POLL
+
+    def test_with_no_wait_the_commit_is_still_checked_once(self):
+        status, lines, _ = run(healthy("f2e4080aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"), commit=COMMIT)
+        assert status == 1
+        assert not lines[0].endswith("hostnames")
+        assert len(failures(lines)) == 2
+
+
+class TestTheCommandLine:
+    def test_the_defaults_are_the_live_service(self):
+        args = monitor.parse([])
+        assert (args.site, args.app) == ("https://dinkydash.co", "https://app.dinkydash.co")
+        assert args.commit is None and args.wait == 0
+
+    def test_a_local_drill_names_its_own_hosts(self):
+        args = monitor.parse(["--site", "http://localhost:5173/",
+                              "--app", "http://127.0.0.1:5173/",
+                              "--commit", "abc", "--wait", "30"])
+        assert (args.site, args.app) == ("http://localhost:5173", "http://127.0.0.1:5173")
+        assert (args.commit, args.wait) == ("abc", 30)
+
+    def test_it_imports_nothing_outside_the_standard_library(self):
+        """The workflow runs it on a bare runner with no `pip install`."""
+        import sys
+        from pathlib import Path
+        source = Path(monitor.__file__).read_text()
+        imported = {line.split()[1].split(".")[0] for line in source.splitlines()
+                    if line.startswith(("import ", "from "))}
+        assert imported <= set(sys.stdlib_module_names)
+
+    @pytest.mark.parametrize("body", ["", "null", "[1, 2]", "{not json"])
+    def test_an_odd_body_is_not_a_crash(self, body):
+        assert monitor._json(body) == {}

--- a/tests/test_private_logs.py
+++ b/tests/test_private_logs.py
@@ -103,7 +103,7 @@ def generated_store(tmp_path, monkeypatch):
 def test_real_worker_tick_logs_metadata_without_generated_text(generated_store, caplog):
     with caplog.at_level(logging.INFO):
         assert tick_all(FakePool(["family"]), store_factory=lambda _: generated_store,
-                        budget_factory=FakeBudget) == 1
+                        budget_factory=FakeBudget).ticked == 1
     assert "Board written for" in caplog.text
     assert "123 tokens in, 45 out" in caplog.text
     assert "Private headline marker" not in caplog.text

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -1,0 +1,124 @@
+"""`/healthz/worker`: the worker's pulse for whoever is watching from outside (DIN-54).
+
+* **single mode has no such path.** No worker, and no database to read;
+* **cloud mode answers it with no session, no family and no token**, because
+  the monitor has none of those and the row it reads names nobody;
+* **200 means a pass finished within the allowance; 503 means never, or too
+  long ago.** The allowance comes from `DINKYDASH_WORKER_STALE_AFTER`;
+* **it is neither cached nor indexed**, and it is never the platform's probe
+  (`tests/test_deploy_spec.py` holds that line).
+
+The parsing tests run everywhere; the rest skips without
+`DINKYDASH_TEST_DATABASE_URL`.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from dinkydash import heartbeat
+from dinkydash.store import FileStore
+from tests.conftest import client_for, forget_unowned_rows
+from web import create_app
+from web.routes import status
+
+
+def test_single_mode_has_no_worker_status(tmp_path, monkeypatch):
+    monkeypatch.delenv("DINKYDASH_MODE", raising=False)
+    (tmp_path / "config.yaml").write_text('family_name: "The Wilsons"\n')
+    client = client_for(create_app(FileStore(tmp_path / "config.yaml")))
+    assert client.get("/healthz/worker").status_code == 404
+
+
+class TestTheAllowance:
+    def test_it_defaults_to_three_missed_passes(self, monkeypatch):
+        monkeypatch.delenv(status.STALE_AFTER, raising=False)
+        assert status.stale_after() == heartbeat.DEFAULT_STALE_AFTER == 900
+
+    def test_the_environment_overrides_it(self, monkeypatch):
+        monkeypatch.setenv(status.STALE_AFTER, "1800")
+        assert status.stale_after() == 1800
+
+    def test_nonsense_falls_back_rather_than_failing_every_request(self, monkeypatch):
+        monkeypatch.setenv(status.STALE_AFTER, "fifteen minutes")
+        assert status.stale_after() == heartbeat.DEFAULT_STALE_AFTER
+
+    @pytest.mark.parametrize("value", ["0", "-60"])
+    def test_it_is_never_zero(self, monkeypatch, value):
+        monkeypatch.setenv(status.STALE_AFTER, value)
+        assert status.stale_after() == 1
+
+
+# -- in cloud mode -----------------------------------------------------------
+
+@pytest.fixture
+def cloud(pg_pool, monkeypatch):
+    monkeypatch.setenv("DINKYDASH_MODE", "cloud")
+    monkeypatch.setenv("DINKYDASH_SECRET_KEY", "a-real-one")
+    monkeypatch.delenv(status.STALE_AFTER, raising=False)
+    forget_unowned_rows(pg_pool)
+    yield client_for(create_app(pool=pg_pool))
+    forget_unowned_rows(pg_pool)
+
+
+class TestWhatItSays:
+    def test_before_any_pass_it_is_never_and_a_503(self, cloud):
+        response = cloud.get("/healthz/worker")
+        assert response.status_code == 503
+        assert response.get_json() == {
+            "status": "never", "age_seconds": None, "last_pass": None}
+
+    def test_after_a_pass_it_is_alive(self, cloud, pg_pool):
+        heartbeat.beat(pg_pool, 3, 1, 1234)
+        response = cloud.get("/healthz/worker")
+        assert response.status_code == 200
+        said = response.get_json()
+        assert said["status"] == "ok"
+        assert 0 <= said["age_seconds"] < 60
+        assert said["last_pass"]["families"] == 3
+        assert said["last_pass"]["failed"] == 1
+        assert said["last_pass"]["took_ms"] == 1234
+
+    def test_a_pass_too_long_ago_is_stale_and_a_503(self, cloud, pg_pool):
+        heartbeat.beat(pg_pool, 3, 0, 1234,
+                       now=datetime.now(timezone.utc) - timedelta(hours=2))
+        response = cloud.get("/healthz/worker")
+        assert response.status_code == 503
+        said = response.get_json()
+        assert said["status"] == "stale"
+        assert 7100 <= said["age_seconds"] <= 7300
+
+    def test_the_allowance_is_read_from_the_environment(self, cloud, pg_pool, monkeypatch):
+        heartbeat.beat(pg_pool, 3, 0, 1234,
+                       now=datetime.now(timezone.utc) - timedelta(hours=2))
+        monkeypatch.setenv(status.STALE_AFTER, str(3 * 3600))
+        assert cloud.get("/healthz/worker").status_code == 200
+
+    def test_the_row_it_serves_is_a_time_and_three_counts(self, cloud, pg_pool):
+        heartbeat.beat(pg_pool, 3, 0, 1234)
+        said = cloud.get("/healthz/worker").get_json()
+        assert set(said) == {"status", "age_seconds", "last_pass"}
+        assert set(said["last_pass"]) == {"passed_at", "families", "failed", "took_ms"}
+
+
+class TestHowItAnswers:
+    def test_it_needs_no_session(self, cloud):
+        """A redirect to `/login` here would be a monitor that alerts for ever."""
+        response = cloud.get("/healthz/worker")
+        assert response.status_code in (200, 503)
+        assert "Location" not in response.headers
+
+    def test_it_is_neither_cached_nor_indexed(self, cloud, pg_pool):
+        for _ in ("never", "ok"):
+            headers = cloud.get("/healthz/worker").headers
+            assert headers["Cache-Control"] == "no-store"
+            assert headers["X-Robots-Tag"] == "noindex"
+            heartbeat.beat(pg_pool, 1, 0, 10)
+
+    def test_it_promises_not_to_tell_a_referrer(self, cloud):
+        assert cloud.get("/healthz/worker").headers["Referrer-Policy"] == "no-referrer"
+
+    def test_the_platforms_own_probe_is_untouched_by_it(self, cloud):
+        """`/healthz` still reads nothing, so it still answers before any pass."""
+        assert cloud.get("/healthz").status_code == 200
+        assert cloud.get("/healthz/worker").status_code == 503

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -3,18 +3,20 @@
 The loop itself is not tested — a `while True` with a sleep in it is not worth
 a fake clock. `tick_all` is, because it holds the decisions: which families are
 walked, what happens when one of them raises, and what reaches a log when it
-does.
+does. `run_pass` is, because it decides what a heartbeat means (DIN-54).
 
 Nothing here needs Postgres. `tick_all` takes its store factory and its tick
-function as arguments, so the fakes below are the whole test rig.
+function as arguments, and `run_pass` its heartbeat, so the fakes below are the
+whole test rig.
 """
 
 import logging
 
 import pytest
 
+import worker
 from dinkydash.budget import NoBudget
-from worker import DEFAULT_INTERVAL, Stopping, interval, tick_all
+from worker import DEFAULT_INTERVAL, Pass, Stopping, interval, run_pass, tick_all
 
 
 class FakePool:
@@ -73,10 +75,10 @@ class TestWalkingTheFamilies:
         seen = []
         done = run(["a", "b", "c"], lambda config, store, budget=None: seen.append(store.family_id))
         assert seen == ["a", "b", "c"]
-        assert done == 3
+        assert done == Pass(ticked=3, failed=0)
 
     def test_no_families_is_not_an_error(self):
-        assert run([], lambda config, store, budget=None: None) == 0
+        assert run([], lambda config, store, budget=None: None) == Pass(0, 0)
 
     def test_the_config_comes_from_that_family_s_store(self):
         configs = []
@@ -102,13 +104,13 @@ class TestOneBadFamily:
 
         done = run(["a", "b", "c"], tick)
         assert seen == ["a", "b", "c"]
-        assert done == 2
+        assert done == Pass(ticked=2, failed=1)
 
     def test_every_family_can_fail_without_raising(self):
         def tick(config, store, budget=None):
             raise RuntimeError("everything is down")
 
-        assert run(["a", "b"], tick) == 0
+        assert run(["a", "b"], tick) == Pass(ticked=0, failed=2)
 
     def test_the_failure_log_names_the_id_and_not_the_config(self, caplog):
         """A config holds children's names, and a calendar URL is a password."""
@@ -134,7 +136,7 @@ class TestStopping:
 
         done = run(["a", "b", "c"], tick, stopping=stopping)
         assert seen == ["a"]
-        assert done == 1
+        assert done == Pass(ticked=1, failed=0)
 
     def test_a_fresh_stopping_is_falsey(self):
         assert not Stopping()
@@ -143,6 +145,108 @@ class TestStopping:
         s = Stopping()
         s.request()
         assert s
+
+
+class TestThePulse:
+    """A heartbeat means a pass finished — not that every family succeeded (DIN-54).
+
+    `run_pass` is the only place that knows whether a pass finished, so it is
+    the only place that beats. Everything it calls is replaced by a fake that
+    records the order; the pool is any object, because none of the fakes look
+    at it.
+    """
+
+    @pytest.fixture
+    def rig(self, monkeypatch):
+        calls, beats = [], []
+        monkeypatch.setattr("dinkydash.lifecycle.expire_trials",
+                            lambda pool: calls.append("expire") or 0)
+        monkeypatch.setattr(worker, "tick_all",
+                            lambda pool, stopping=None: calls.append("tick") or Pass(2, 1))
+        monkeypatch.setattr(worker, "sweep_logins",
+                            lambda pool: calls.append("sweep") or 0)
+
+        def beat(pool, ticked, failed, took_ms):
+            calls.append("beat")
+            beats.append((ticked, failed, took_ms))
+
+        return calls, beats, beat
+
+    def test_a_completed_pass_beats_last_and_carries_its_counts(self, rig):
+        calls, beats, beat = rig
+        assert run_pass(object(), Stopping(), beat=beat) == Pass(2, 1)
+        assert calls == ["expire", "tick", "sweep", "beat"]
+        (ticked, failed, took_ms), = beats
+        assert (ticked, failed) == (2, 1)
+        assert took_ms >= 0
+
+    def test_a_pass_in_which_every_family_failed_is_still_a_live_worker(self, rig, monkeypatch):
+        """Failed work is counted and shown; a dead worker is a different thing."""
+        calls, beats, beat = rig
+        monkeypatch.setattr(worker, "tick_all",
+                            lambda pool, stopping=None: calls.append("tick") or Pass(0, 3))
+        assert run_pass(object(), Stopping(), beat=beat) == Pass(0, 3)
+        assert beats[0][:2] == (0, 3)
+
+    def test_an_interrupted_pass_does_not_beat(self, rig, monkeypatch):
+        """A stop request mid-walk is a redeploy, not a finished pass."""
+        calls, beats, beat = rig
+        stopping = Stopping()
+
+        def interrupted(pool, stopping=None):
+            calls.append("tick")
+            stopping.request()
+            return Pass(1, 0)
+
+        monkeypatch.setattr(worker, "tick_all", interrupted)
+        assert run_pass(object(), stopping, beat=beat) is None
+        assert "beat" not in calls
+        assert beats == []
+
+    def test_a_pass_that_cannot_list_the_families_neither_beats_nor_raises(
+            self, rig, monkeypatch, caplog):
+        """A dead database is the usual cause. The worker keeps looping, the
+        heartbeat goes stale, and stale is the alert."""
+        calls, beats, beat = rig
+
+        def dead(pool, stopping=None):
+            calls.append("tick")
+            raise RuntimeError("connection failed")
+
+        monkeypatch.setattr(worker, "tick_all", dead)
+        with caplog.at_level(logging.ERROR):
+            assert run_pass(object(), Stopping(), beat=beat) is None
+        assert calls == ["expire", "tick"]
+        assert "next pass" in caplog.text
+
+    def test_a_heartbeat_that_cannot_be_written_does_not_stop_the_worker(self, rig, caplog):
+        calls, beats, _ = rig
+
+        def broken(pool, ticked, failed, took_ms):
+            raise RuntimeError("relation worker_heartbeat does not exist")
+
+        with caplog.at_level(logging.ERROR):
+            assert run_pass(object(), Stopping(), beat=broken) == Pass(2, 1)
+        assert "heartbeat" in caplog.text.lower()
+
+    def test_housekeeping_failing_does_not_stop_the_pass_or_the_beat(self, rig, monkeypatch):
+        calls, beats, beat = rig
+        monkeypatch.setattr("dinkydash.lifecycle.expire_trials",
+                            lambda pool: (_ for _ in ()).throw(RuntimeError("no")))
+        assert run_pass(object(), Stopping(), beat=beat) == Pass(2, 1)
+        assert calls[-1] == "beat"
+
+    def test_no_stopping_at_all_is_a_pass_that_finishes(self, rig):
+        calls, beats, beat = rig
+        assert run_pass(object(), beat=beat) == Pass(2, 1)
+        assert len(beats) == 1
+
+    def test_the_real_heartbeat_is_the_default(self, rig, monkeypatch):
+        calls, beats, _ = rig
+        monkeypatch.setattr("dinkydash.heartbeat.beat",
+                            lambda pool, ticked, failed, took_ms: beats.append("real"))
+        run_pass(object(), Stopping())
+        assert beats == ["real"]
 
 
 class TestInterval:

--- a/web/CLAUDE.md
+++ b/web/CLAUDE.md
@@ -46,9 +46,10 @@ process for anything scripted — it has no cookie policy and exercises the same
 into the `requests` half of that.
 
 **A route that touches a store needs `session.guard`**, and the board blueprint's `before_request`
-is where that is decided. `board.healthz` is the one exemption and it is load-bearing: App
-Platform's health check arrives with no cookie, and a 302 there fails it three times and rolls the
-release back. It is also the only route that reads nothing, so it needs no family.
+is where that is decided. `board.healthz` is the one exemption in that blueprint and it is
+load-bearing: App Platform's health check arrives with no cookie, and a 302 there fails it three
+times and rolls the release back. It is also the only route that reads nothing, so it needs no
+family.
 
 **`web/routes/screen.py` is the other exemption, and it is a separate blueprint for that reason.**
 `/s/<token>` has no session by design — a wall panel cannot sign in — so it is not behind `guard()`
@@ -72,7 +73,19 @@ route works out (`admin.chart`), because arithmetic in a template is arithmetic 
 two series colours are the shell's own `--accent` and `--purple`, checked as a pair on the card's
 white with the dataviz palette validator (CVD ΔE 24.7, both above 3:1); a third series means
 running it again, not picking a colour. `tests/test_admin.py` covers the gate, the bounds on
-`?weeks=` and the drawing.
+`?weeks=` and the drawing. The same page carries the worker's last pass in a sentence, from
+`dinkydash/heartbeat.py` — the row `/healthz/worker` serves to the monitor, for an operator who
+would rather not curl.
+
+**`web/routes/status.py` is the fourth cloud-only blueprint, and the one route that reads the
+database with no session** (DIN-54). `/healthz/worker` answers 200 while the worker's last
+completed pass is within `DINKYDASH_WORKER_STALE_AFTER` seconds (default 900, three missed passes)
+and 503 once it is not, and `.github/workflows/monitor.yml` turns that 503 into a failed run. It
+is public so the monitor needs no secret; the row it reads names no family; it is `no-store` and
+`noindex`. **It is not the platform's probe and must never become it** — `/healthz` reads nothing
+because three failed probes restart the container, and a probe that answered 503 for a quiet
+worker would answer a dead worker with a rolled-back deploy. `tests/test_deploy_spec.py` holds the
+spec to that, and `tests/test_status.py` covers the rest.
 
 **Every form that writes needs one hidden field.** `<input type="hidden" name="csrf_token"
 value="{{ csrf_token() }}">`, right inside the `<form>`. `csrf_token()` is a Jinja global set up by

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -36,6 +36,9 @@ def create_app(store=None, *, pool=None):
         if pool is None:
             from dinkydash import db
             pool = db.pool()
+            # Refuse to start rather than start and fail every request: a
+            # container that never comes up is a deploy that never goes live.
+            db.ready(pool)
     else:
         if pool is not None:
             raise ValueError("Single mode accepts a store, not a pool.")
@@ -70,6 +73,9 @@ def create_app(store=None, *, pool=None):
 
         from .routes.admin import bp as admin_bp
         app.register_blueprint(admin_bp)
+
+        from .routes.status import bp as status_bp
+        app.register_blueprint(status_bp)
 
         from dinkydash.pgstore import NoSuchFamily
 

--- a/web/routes/admin.py
+++ b/web/routes/admin.py
@@ -17,9 +17,12 @@ authorisation miss in this app follows. An empty or missing list means nobody,
 which is the safe way for a new deployment to be wrong.
 
 **No family is read here.** The page is built from `dinkydash/growth.py`,
-which reads a table with no family identifiers in it plus one `count(*)`.
-Nothing in this file takes an id from the request, the session or the URL, so
-there is no id to check and nothing for a bug here to leak.
+which reads a table with no family identifiers in it plus one `count(*)`, and
+from `dinkydash/heartbeat.py`, which reads the worker's last pass — a time and
+three counts, the same row `/healthz/worker` serves to the monitor, said in a
+sentence here so the operator can see it without curl. Nothing in this file
+takes an id from the request, the session or the URL, so there is no id to
+check and nothing for a bug here to leak.
 
 The chart is inline SVG drawn from numbers worked out below, with no script
 and no third-party request — the settings shell's own rules. Its two colours
@@ -33,8 +36,9 @@ from datetime import datetime, timezone
 from flask import (Blueprint, abort, current_app, make_response, render_template,
                    request)
 
-from dinkydash import growth
+from dinkydash import growth, heartbeat
 from web.family import is_admin
+from web.routes.status import stale_after
 from web.session import guard
 
 bp = Blueprint("admin", __name__)
@@ -89,6 +93,8 @@ def growth_page():
     weekly = growth.by_week(rows, weeks, today)
     total = growth.totals(rows)
     families = growth.families_now(pool)
+    pulse = heartbeat.verdict(heartbeat.last(pool), datetime.now(timezone.utc),
+                              stale_after())
     response = make_response(render_template(
         "admin/growth.html",
         weekly=weekly, latest=weekly[-1], span=weeks, spans=SPANS,
@@ -98,6 +104,8 @@ def growth_page():
         # the counter in a way the backfill could not see.
         deleted=max(0, total.signups - families),
         chart=chart(weekly),
+        pulse=pulse, pulse_word=PULSE_WORDS[pulse["status"]],
+        pulse_text=pulse_text(pulse),
     ))
     # Counts, not anybody's data — but it is the business's own page, and a
     # shared cache has no business holding it.
@@ -112,6 +120,38 @@ def span(raw):
     except (TypeError, ValueError):
         return DEFAULT_WEEKS
     return min(MOST_WEEKS, max(1, weeks))
+
+
+# -- the worker's pulse -------------------------------------------------------
+
+# One word for the pill beside the sentence: the three answers `heartbeat.verdict`
+# can give, in the operator's language.
+PULSE_WORDS = {"ok": "Alive", "stale": "Quiet", "never": "Never run"}
+
+
+def pulse_text(pulse):
+    """The worker's last pass in one sentence, from what `heartbeat.verdict` said."""
+    if pulse["status"] == "never":
+        return "No pass has finished yet."
+    last = pulse["last_pass"]
+    families = last["families"]
+    return (f"Last pass finished {ago(pulse['age_seconds'])}: "
+            f"{families} {'family' if families == 1 else 'families'}, "
+            f"{'none failed' if not last['failed'] else str(last['failed']) + ' failed'}, "
+            f"{last['took_ms'] / 1000:.1f} s.")
+
+
+def ago(seconds):
+    """`seconds` as a person would say it. Coarse on purpose: the page is not a clock."""
+    if seconds < 60:
+        return "just now"
+    minutes = seconds // 60
+    if minutes < 60:
+        return f"{minutes} minute{'' if minutes == 1 else 's'} ago"
+    hours = minutes // 60
+    if hours < 48:
+        return f"{hours} hour{'' if hours == 1 else 's'} ago"
+    return f"{hours // 24} days ago"
 
 
 # -- the drawing ------------------------------------------------------------

--- a/web/routes/status.py
+++ b/web/routes/status.py
@@ -1,0 +1,66 @@
+"""What the worker has been doing, for whoever is watching from outside. Cloud only.
+
+    GET /healthz/worker     200 if a pass finished recently, 503 if not
+
+Registered only in cloud mode, like `auth`, `screen` and `admin`. A self-hosted
+board has cron rather than a worker, and its board already shows a stale day
+for what it is.
+
+**This is not the platform's health check, and it must never become it.**
+`/healthz` (`web/routes/board.py`) is what App Platform probes, and it reads
+nothing on purpose: a probe that depends on the database turns a slow query
+into a restarted container and a rolled-back deploy. This path *does* read the
+database — one row, by primary key — and answers 503 when the worker has gone
+quiet, which is exactly what a probe must not do and exactly what an external
+monitor wants. `.github/workflows/monitor.yml` asks it every fifteen minutes
+and after every deploy; `tests/test_deploy_spec.py` fails if the spec ever
+points the probe here.
+
+**No session, no family, no token.** The row it reads has no family in it
+(`dinkydash/heartbeat.py`), and what it says — when the last pass finished,
+how many families it walked, how many raised, how long it took — is about the
+service, not about anybody. It is public so that the monitor needs no secret,
+and `no-store` and `noindex` because a status line is not content.
+
+The one thing a stranger can do with it is make the app read a row. That is a
+primary-key lookup, bounded by the pool, and the same class of cost as a
+`/s/<token>` that misses — which is not rate-limited either until it misses
+often.
+"""
+
+import os
+from datetime import datetime, timezone
+
+from flask import Blueprint, current_app, make_response
+
+from dinkydash import heartbeat
+
+bp = Blueprint("status", __name__)
+
+# Seconds since the last completed pass before the worker is presumed dead.
+# Defaults to three missed five-minute passes (`heartbeat.DEFAULT_STALE_AFTER`).
+STALE_AFTER = "DINKYDASH_WORKER_STALE_AFTER"
+
+HEADERS = {"Cache-Control": "no-store", "X-Robots-Tag": "noindex"}
+
+
+@bp.route("/healthz/worker")
+def worker():
+    row = heartbeat.last(current_app.config["POOL"])
+    said = heartbeat.verdict(row, datetime.now(timezone.utc), stale_after())
+    response = make_response(said, 200 if said["status"] == "ok" else 503)
+    for header, value in HEADERS.items():
+        response.headers[header] = value
+    return response
+
+
+def stale_after():
+    """How old the last pass may be, in seconds: the environment, or the default.
+
+    Nonsense falls back rather than failing, the way `worker.interval` does: a
+    typo in an app spec should not make every status request a 500.
+    """
+    try:
+        return max(1, int(os.environ.get(STALE_AFTER, heartbeat.DEFAULT_STALE_AFTER)))
+    except ValueError:
+        return heartbeat.DEFAULT_STALE_AFTER

--- a/web/templates/admin/growth.html
+++ b/web/templates/admin/growth.html
@@ -86,6 +86,16 @@
     </div>
 </div>
 
+{# The worker's pulse (DIN-54): the row /healthz/worker serves to the monitor,
+   in a sentence. "Quiet" here is what the monitor is emailing about. #}
+<div class="card pad worker" style="display:flex;justify-content:space-between;align-items:baseline;gap:0.5rem;flex-wrap:wrap;">
+    <div style="display:flex;flex-direction:column;gap:0.125rem;min-width:0;">
+        <div style="font-size:0.9375rem;font-weight:800;">Worker</div>
+        <div class="hint">{{ pulse_text }}</div>
+    </div>
+    <span class="pill {{ 'warm' if pulse.status == 'ok' else 'muted' }}">{{ pulse_word }}</span>
+</div>
+
 {# One row of range choices, above everything it scopes. #}
 <div class="spans">
     <span class="label">Last</span>

--- a/worker/__init__.py
+++ b/worker/__init__.py
@@ -22,16 +22,29 @@ copied. It is the shared orchestration over config, store and clock, and
 Housekeeping runs once a pass: `sweep_logins` deletes expired magic-link tokens
 and `lifecycle.expire_trials` records ended trials. Account access is also
 checked before each fetch and model call, independently of the sweep.
+
+**Every completed pass writes a heartbeat** (`dinkydash/heartbeat.py`, DIN-54),
+and `run_pass` is where "completed" is decided: a stop request that ended the
+walk early is not a finished pass, and neither is a pass that could not list
+the families. Both leave the last heartbeat where it was, so it goes stale,
+and `/healthz/worker` says so to the monitor. That is the whole of the
+worker's liveness story — there is no ping to an outside service and nothing
+here has a URL to reach.
 """
 
 import logging
 import os
 import signal
 import time
+from collections import namedtuple
 
 log = logging.getLogger("dinkydash.worker")
 
 DEFAULT_INTERVAL = 300  # five minutes, as PLAN.md's "three clocks" section says
+
+# What a pass did: how many families were ticked without raising, and how many
+# raised. Both are counts of families, never of anything inside one.
+Pass = namedtuple("Pass", "ticked failed")
 
 
 class Stopping:
@@ -79,7 +92,7 @@ def family_ids(pool):
 
 def tick_all(pool, store_factory=None, tick=None, stopping=None,
              budget_factory=None):
-    """Tick every family once. Returns how many were ticked without raising.
+    """Tick every family once. Returns a `Pass`: how many ticked, how many raised.
 
     One family's bad calendar feed, missing config or Anthropic outage must not
     stop the others: a shared worker that dies on the noisiest tenant is a
@@ -101,7 +114,7 @@ def tick_all(pool, store_factory=None, tick=None, stopping=None,
     if tick is None:
         from generate import tick
 
-    done = 0
+    done = failed = 0
     for family_id in family_ids(pool):
         if stopping:
             log.info("Stopping before family %s.", family_id)
@@ -116,7 +129,64 @@ def tick_all(pool, store_factory=None, tick=None, stopping=None,
             # the traceback, which is about our code rather than their data.
             log.exception("Tick failed for family %s; leaving it for the next pass.",
                           family_id)
-    return done
+            failed += 1
+    return Pass(done, failed)
+
+
+def run_pass(pool, stopping=None, beat=None):
+    """One pass: housekeeping, every family, the sweep — then the heartbeat.
+
+    Returns the `Pass`, or None when the pass did not finish.
+
+    **The heartbeat is written only after a completed pass**, and here rather
+    than in `tick_all`, because "finished" is decided here. A stop request
+    that ended the walk early is not a finished pass; nor is one that could
+    not list the families, which is the one thing `tick_all` cannot catch per
+    family because there is no family yet — a database that cannot be reached
+    is the usual cause. Both leave the last heartbeat where it was, so it goes
+    stale and `/healthz/worker` says so: that is the alert (DIN-54). A family
+    whose tick raised is *inside* the pass and is counted in `failed`; the
+    pass still finished, and the count is on the operator's page.
+
+    A failure to *write* the heartbeat is logged and otherwise ignored. The
+    boards were written; a pulse that stops the worker is a pulse that kills
+    the patient.
+
+    `beat` is injectable for the tests; the real one is `heartbeat.beat`.
+    """
+    if beat is None:
+        from dinkydash import heartbeat
+        beat = heartbeat.beat
+    from dinkydash import lifecycle
+
+    started = time.monotonic()
+    try:
+        expired = lifecycle.expire_trials(pool)
+        if expired:
+            log.info("Ended %s expired trial(s).", expired)
+    except Exception:
+        # Callers still check the deadline themselves if housekeeping fails.
+        log.exception("Could not mark expired trials; retrying next pass.")
+
+    try:
+        result = tick_all(pool, stopping=stopping)
+    except Exception:
+        log.exception("The pass could not list the families; leaving it for the "
+                      "next pass. No heartbeat.")
+        return None
+    swept = sweep_logins(pool)
+    took = time.monotonic() - started
+    if stopping:
+        log.info("Pass interrupted by a stop request after %.1fs; no heartbeat.", took)
+        return None
+
+    log.info("Pass complete: %s families ticked, %s failed, in %.1fs; %s dead "
+             "login token(s) deleted.", result.ticked, result.failed, took, swept)
+    try:
+        beat(pool, result.ticked, result.failed, int(took * 1000))
+    except Exception:
+        log.exception("Could not record the heartbeat; the pass itself finished.")
+    return result
 
 
 def sweep_logins(pool):
@@ -161,7 +231,7 @@ def main():  # pragma: no cover - the loop itself; tick_all is what is tested
         format="%(asctime)s [%(levelname)s] %(message)s",
     )
 
-    from dinkydash import db, lifecycle
+    from dinkydash import db
 
     stopping = Stopping()
     signal.signal(signal.SIGTERM, stopping.request)
@@ -172,18 +242,7 @@ def main():  # pragma: no cover - the loop itself; tick_all is what is tested
     log.info("Worker started; a pass every %s seconds.", every)
 
     while not stopping:
-        started = time.monotonic()
-        try:
-            expired = lifecycle.expire_trials(pool)
-            if expired:
-                log.info("Ended %s expired trial(s).", expired)
-        except Exception:
-            # Callers still check the deadline themselves if housekeeping fails.
-            log.exception("Could not mark expired trials; retrying next pass.")
-        ticked = tick_all(pool, stopping=stopping)
-        swept = sweep_logins(pool)
-        log.info("Pass complete: %s families ticked in %.1fs; %s dead login "
-                 "token(s) deleted.", ticked, time.monotonic() - started, swept)
+        run_pass(pool, stopping)
 
         # Sleep in slices so SIGTERM is noticed in seconds rather than minutes.
         # App Platform kills a container that ignores it for too long, and


### PR DESCRIPTION
## What this changes

`/healthz` stays a dumb probe: it decides whether a deploy goes live, and a probe that read the database would turn a slow query into a rolled-back release. Three things around it instead:

- **`db.ready` waits for the pooled database when the web app starts.** A wrong `DATABASE_URL` is now a container that never becomes healthy rather than a live deploy that 500s every board. Before this, the cloud entry point booted in half a second against a closed port and answered 200 on both hostnames; the migrate job would not have caught it either, because it uses the direct URL.
- **The worker writes a heartbeat after each completed pass** (`worker_heartbeat`, migration 007): when, families ticked, families that raised, duration. Not after a stop request cut the pass short, and not after a pass that could not list the families. `/healthz/worker` serves it and answers 503 once it is older than `DINKYDASH_WORKER_STALE_AFTER` (default 900 s); `/admin` says the same row in a sentence. The row names no family.
- **`.github/workflows/monitor.yml` runs `monitor.py` every fifteen minutes and after each push to `main`**, first waiting for both hostnames to report the pushed commit. It checks the site's `/` and `/healthz`, the app's `/healthz`, `/login` and `/healthz/worker`. A failed run is the alert. No secrets and no external account, which is why this replaces the push-a-ping half of draft #97 — its restore-drill half (DIN-56) is untouched and still wants merging on its own.

`tests/test_deploy_spec.py` pins the spec's probe path to a route that reads nothing and is never the worker status.

## Verified

- Both suites green, with and without Postgres.
- The stop-and-recover drill against an isolated worker and scratch database, timestamps in `doc/operations.md`: the check fails within one allowance of the stop and clears on the first pass after the restart.
- `monitor.py` against production today: the four page checks pass and `/healthz/worker` is a 404 until this deploys.

## After merging

- The pre-deploy job creates the table; the push-triggered Monitor run should go green once the deploy is live.
- To witness the alert email without touching anything live: Actions → Monitor → Run workflow with `app` = `https://app.dinkydash.co/nowhere`. Manual dispatch only works once the workflow file is on `main`.
- No spec apply needed; `.do/app.yaml` gained comments only.

Closes the mechanism side of DIN-54; the issue stays open until that email has been seen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
