### PR TITLE
Label the back button and move Save to the foot of every settings form

### DIFF
--- a/design/README.md
+++ b/design/README.md
@@ -49,6 +49,8 @@ raised to stay visible.
 ## Known gaps
 
 - Drag-to-reorder is not drawn; the "Reorder" affordance is a placeholder.
+- The artboards put Cancel and Save in the app bar. The built UI does not (September 2026):
+  the bar holds a labelled back button and the title, and Save ends the form.
 - Post-trial lapse behaviour is unresolved — an open question in [PLAN.md](../PLAN.md).
 - The QR code is an illustrative pattern, not a scannable code.
 - An Auto colour mode (dark after sunset, using the family timezone) is proposed

--- a/web/CLAUDE.md
+++ b/web/CLAUDE.md
@@ -77,6 +77,15 @@ white with the dataviz palette validator (CVD ΔE 24.7, both above 3:1); a third
 running it again, not picking a colour. `tests/test_admin.py` covers the gate, the bounds on
 `?weeks=` and the drawing.
 
+**The app bar holds the way back and the title, and never a Save.** A page that saves ends its
+form with a full-width `.btn` Save, where the fields are, and the bar's left-hand button is
+`icons.back_to(href, label)` — the chevron plus the *name of the page it goes to* ("Settings",
+or the section title on an edit form), drawn as a bordered pill so the tap target is visible.
+A header Save was tried and taken out: it sat in the shared chrome rather than with the form
+it saved, and the bare chevron beside it was too small to read as a button. The calendar
+form carries one unseen submit button ahead of "Test calendar link", because Enter presses
+a form's first submit button and Enter should save there as it does everywhere else.
+
 **Every form that writes needs one hidden field.** `<input type="hidden" name="csrf_token"
 value="{{ csrf_token() }}">`, right inside the `<form>`. `csrf_token()` is a Jinja global set up by
 `web/session.py`, so no route has to remember to pass anything — but a form without the field is a

--- a/web/templates/admin/growth.html
+++ b/web/templates/admin/growth.html
@@ -60,7 +60,7 @@
 {% endblock %}
 
 {% block appbar %}
-<a class="back" href="{{ url_for('settings.home') }}">{{ icons.back() }}</a>
+{{ icons.back_to(url_for('settings.home'), 'Settings') }}
 <h1>Growth</h1>
 {% endblock %}
 

--- a/web/templates/settings/_icons.html
+++ b/web/templates/settings/_icons.html
@@ -1,5 +1,9 @@
 {% macro chevron() %}<svg class="chev" style="width:1.125em;height:1.125em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"></polyline></svg>{% endmacro %}
 {% macro back() %}<svg style="width:1.375em;height:1.375em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"></polyline></svg>{% endmacro %}
+{# The way back: the chevron and the name of the page it goes to, drawn as a button.
+   `label` is the destination, never "Back" — a person on the edit form should know
+   that the arrow returns them to People and drops what they typed. #}
+{% macro back_to(href, label) %}<a class="back" href="{{ href }}">{{ back() }}<span>{{ label }}</span></a>{% endmacro %}
 {% macro plus() %}<svg style="width:1.1875em;height:1.1875em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round"><path d="M12 5v14"></path><path d="M5 12h14"></path></svg>{% endmacro %}
 {% macro refresh() %}<svg style="width:1.0625em;height:1.0625em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.1" stroke-linecap="round" stroke-linejoin="round"><path d="M20.5 12a8.5 8.5 0 1 1-2.7-6.2"></path><polyline points="20.8 4.2 20.8 9.4 15.6 9.4"></polyline></svg>{% endmacro %}
 {% macro screen() %}<svg style="width:1.0625em;height:1.0625em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.1" stroke-linecap="round" stroke-linejoin="round"><rect x="2.5" y="4" width="19" height="13" rx="2"></rect><path d="M8 20.5h8"></path></svg>{% endmacro %}

--- a/web/templates/settings/account.html
+++ b/web/templates/settings/account.html
@@ -20,7 +20,7 @@
 {% endblock %}
 
 {% block appbar %}
-<a class="back" href="{{ url_for('settings.home') }}">{{ icons.back() }}</a>
+{{ icons.back_to(url_for('settings.home'), 'Settings') }}
 <h1>Your data</h1>
 {% endblock %}
 

--- a/web/templates/settings/base.html
+++ b/web/templates/settings/base.html
@@ -91,20 +91,35 @@
         .shell { max-width: 28.75rem; margin: 0 auto; min-height: 100vh; background: var(--bg); }
         a { color: var(--accent); text-decoration: none; }
 
+        /* The bar holds the way back and the title, and nothing that writes: a page
+           that saves ends with its own Save button, where the form does. */
         .appbar {
-            display: flex; align-items: center; gap: 0.25rem;
+            display: flex; align-items: center; gap: 0.625rem;
             height: 3.5rem; padding: 0 0.75rem;
             border-bottom: 1px solid var(--border);
             position: sticky; top: 0; background: var(--bg); z-index: 5;
         }
-        .appbar h1 { font-size: 1.0625rem; font-weight: 800; letter-spacing: -0.01em; flex-grow: 1; }
-        .appbar .back, .appbar .action {
-            display: inline-flex; align-items: center; justify-content: center;
-            min-width: 2.75rem; height: 2.75rem; color: var(--text-mid);
+        .appbar h1 {
+            font-size: 1.0625rem; font-weight: 800; letter-spacing: -0.01em; flex-grow: 1;
+            min-width: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
         }
-        .appbar .action { font-size: 0.9375rem; font-weight: 800; color: var(--accent); padding: 0 0.375rem; }
+        /* The way back is a button, not a bare chevron: it names the page it goes to, and
+           its edges show the whole tap target rather than leaving a thumb to guess at it. */
+        .appbar .back {
+            display: inline-flex; align-items: center; gap: 0.125rem; flex-shrink: 0;
+            min-height: 2.5rem; padding: 0 0.875rem 0 0.5rem;
+            border: 1.5px solid var(--border-strong); border-radius: 999px;
+            background: var(--surface); color: var(--text);
+            font-size: 0.875rem; font-weight: 800; white-space: nowrap;
+        }
+        .appbar .back:hover, .appbar .back:focus-visible { border-color: var(--accent); color: var(--accent); }
+        .appbar .back:active { background: var(--warm); }
+        .appbar .action {
+            display: inline-flex; align-items: center; justify-content: center;
+            min-width: 2.75rem; height: 2.75rem; padding: 0 0.375rem;
+            font-size: 0.9375rem; font-weight: 800; color: var(--accent);
+        }
         .appbar .action.muted { color: var(--text-muted); font-weight: 700; }
-        .appbar button.action { border: none; background: transparent; font-family: inherit; cursor: pointer; }
 
         .content { padding: 1rem; display: flex; flex-direction: column; gap: 1rem; }
 

--- a/web/templates/settings/edit.html
+++ b/web/templates/settings/edit.html
@@ -3,9 +3,8 @@
 {% block title %}{{ ("New " ~ section.singular) if is_new else (item.name or item.title or item.label or section.singular) }}{% endblock %}
 
 {% block appbar %}
-<a class="action muted" href="{{ url_for('settings.section_list', section_name=section_name) }}">Cancel</a>
-<h1 style="text-align:center;">{{ ("New " ~ section.singular) if is_new else (item.name or item.title or item.label or section.singular) }}</h1>
-<button class="action" type="submit" form="edit-form" name="action" value="save">Save</button>
+{{ icons.back_to(url_for('settings.section_list', section_name=section_name), section.title) }}
+<h1>{{ ("New " ~ section.singular) if is_new else (item.name or item.title or item.label or section.singular) }}</h1>
 {% endblock %}
 
 {% block content %}
@@ -19,6 +18,12 @@
 
 <form id="edit-form" method="post" class="card pad" style="display:flex;flex-direction:column;gap:1rem;">
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+    {% if section_name == 'calendars' %}
+    {# Enter in a field presses the form's first submit button, and on this form the
+       first one a reader meets is "Test calendar link". This unseen one comes ahead
+       of it so that Enter still saves, as it does on every other page. #}
+    <button type="submit" name="action" value="save" hidden tabindex="-1"></button>
+    {% endif %}
     {% for name, label, kind, required, help in section.fields %}
     <div class="field">
         {% if kind != 'checkbox' %}<label for="f-{{ name }}">{{ label }}</label>{% endif %}
@@ -125,8 +130,9 @@
         </div>
         {% endif %}
     </div>
-    <button class="btn" type="submit" name="action" value="save">Save calendar</button>
     {% endif %}
+
+    <button class="btn" type="submit" name="action" value="save">{{ "Save calendar" if section_name == 'calendars' else "Save" }}</button>
 </form>
 
 {% if section_name == 'calendars' %}

--- a/web/templates/settings/list.html
+++ b/web/templates/settings/list.html
@@ -3,7 +3,7 @@
 {% block title %}{{ section.title }}{% endblock %}
 
 {% block appbar %}
-<a class="back" href="{{ url_for('settings.home') }}">{{ icons.back() }}</a>
+{{ icons.back_to(url_for('settings.home'), 'Settings') }}
 <h1>{{ section.title }}</h1>
 {% endblock %}
 

--- a/web/templates/settings/refresh.html
+++ b/web/templates/settings/refresh.html
@@ -3,9 +3,8 @@
 {% block title %}How often it updates{% endblock %}
 
 {% block appbar %}
-<a class="back" href="{{ url_for('settings.home') }}">{{ icons.back() }}</a>
+{{ icons.back_to(url_for('settings.home'), 'Settings') }}
 <h1>How often it updates</h1>
-<button class="action" type="submit" form="refresh-form">Save</button>
 {% endblock %}
 
 {% block content %}
@@ -38,6 +37,8 @@
             <strong>Rewrite now</strong> if you want a fresh one sooner.
         </div>
     </div>
+
+    <button class="btn" type="submit">Save</button>
 </form>
 
 <div class="note-box">

--- a/web/templates/settings/screen.html
+++ b/web/templates/settings/screen.html
@@ -3,7 +3,7 @@
 {% block title %}The screen{% endblock %}
 
 {% block appbar %}
-<a class="back" href="{{ url_for('settings.home') }}">{{ icons.back() }}</a>
+{{ icons.back_to(url_for('settings.home'), 'Settings') }}
 <h1>{{ "The screen" if screen_link else "Colours" }}</h1>
 {% endblock %}
 

--- a/web/templates/settings/system.html
+++ b/web/templates/settings/system.html
@@ -3,9 +3,8 @@
 {% block title %}Family &amp; system{% endblock %}
 
 {% block appbar %}
-<a class="back" href="{{ url_for('settings.home') }}">{{ icons.back() }}</a>
+{{ icons.back_to(url_for('settings.home'), 'Settings') }}
 <h1>Family &amp; system</h1>
-<button class="action" type="submit" form="system-form">Save</button>
 {% endblock %}
 
 {% block content %}
@@ -52,6 +51,8 @@
         </div>
     </div>
     {% endif %}
+
+    <button class="btn" type="submit">Save</button>
 </form>
 
 {# Nothing to say to a hosted family: there is no .env of theirs to put a key in. #}


### PR DESCRIPTION
The settings app bar's back button was a bare chevron with no visible tap target; it is now a bordered pill that names the page it returns to ("Settings", or the section title on an edit form), drawn by one new macro in `_icons.html` and used on every page with a way back. Save leaves the app bar on the edit, "Family & system" and "How often it updates" pages and ends each form as the full-width button the calendar form already had, and "Cancel" on the edit form goes with it. The calendar form keeps an unseen submit button ahead of "Test calendar link" so that pressing Enter in a field still saves rather than tests, which I confirmed in a browser. Long page titles now truncate with an ellipsis instead of wrapping the bar. `web/CLAUDE.md` records the rule and `design/README.md` notes that the artboards still show the old header layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)