### PR TITLE
Give every control a hover, press and keyboard state on desktop

### DIFF
--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -6,6 +6,8 @@ above shifted everybody below onto somebody else's edit form.
 """
 
 import json
+import pathlib
+import re
 from datetime import date, timedelta
 
 import pytest
@@ -948,3 +950,45 @@ class TestRefreshingTheCalendarsByHand:
         page = client.post("/settings/refresh-now", follow_redirects=True)
         assert page.status_code == 200
         assert "Could not refresh the calendars: the disk is full" in page.get_data(as_text=True)
+
+
+class TestTheControlsUnderAPointer:
+    """The settings UI is used from a desk as well as a phone. Every control has a hover, a
+    press and a keyboard state in `settings/base.html`; the three things below are the ones a
+    stylesheet cannot enforce on its own."""
+
+    TEMPLATES = pathlib.Path(__file__).resolve().parent.parent / "web" / "templates"
+
+    def test_a_persons_name_toggles_their_box(self, client):
+        # The name beside a chore's checkbox was a span, so clicking it did nothing.
+        page = client.get("/settings/recurring/new").get_data(as_text=True)
+        assert '<label for="p-1">Mia</label>' in page
+
+    def test_every_back_link_names_where_it_goes(self):
+        # The way back is `icons.back_to(href, label)`: the chevron and the name of the page
+        # it goes to. A bare `<a class="back">` in a page is a chevron with no name again.
+        bare, seen = [], 0
+        for path in self.TEMPLATES.rglob("*.html"):
+            if path.name == "_icons.html":
+                continue
+            text = path.read_text()
+            if re.search(r'<a\b[^>]*class="back"', text):
+                bare.append(str(path.relative_to(self.TEMPLATES)))
+            seen += len(re.findall(r"icons\.back_to\(", text))
+        assert bare == []
+        assert seen >= 6
+        assert "<span>{{ label }}</span>" in (self.TEMPLATES / "settings" / "_icons.html").read_text()
+
+    def test_no_button_carries_its_look_inline(self):
+        # An inline style beats every hover, press and disabled rule in the sheet, which is how
+        # "Not now" and "Delete my account" came to have none. A look is a `.btn` variant;
+        # layout (`flex`, `align-self`, a margin) may stay inline.
+        offenders, seen = [], 0
+        for path in self.TEMPLATES.rglob("*.html"):
+            for tag in re.findall(r'<(?:a|button)\b[^>]*\bclass="[^"]*\bbtn\b[^"]*"[^>]*>', path.read_text()):
+                seen += 1
+                style = re.search(r'style="([^"]*)"', tag)
+                if style and re.search(r"background|color|box-shadow|border", style.group(1)):
+                    offenders.append((str(path.relative_to(self.TEMPLATES)), tag))
+        assert offenders == []
+        assert seen >= 12

--- a/web/CLAUDE.md
+++ b/web/CLAUDE.md
@@ -22,6 +22,19 @@ field that is not a birthday needs a kind of its own rather than a looser bound 
 `web/templates/settings/home.html`. The list, edit, delete and reorder routes are generic and need
 no changes.
 
+**Every control has a hover, a press and a keyboard state, and a new one needs all three.** They
+live at the foot of the shared sheet in `settings/base.html`. Hover rules sit behind
+`@media (hover: hover)` — on a phone a hover is a tap that never ends, left glowing on the row
+you just came back from — while `:active` and `:focus-visible` apply everywhere. The cue is one
+the mockups set with `a:hover`: filled things darken, bare things get `--warm` or `--tint` behind
+them, links underline, and nothing changes size. **An inline `style` on a button beats every one
+of those rules**, which is why "Not now" and "Delete my account" became `.btn.quiet` and
+`.btn.danger.fill` rather than keeping theirs; a new look for a button is a variant, not an
+attribute. Two more things a pointer expects: `.btn:disabled` looks disabled and refuses the
+cursor, and on a list page the link stretches over the whole row (`a.row-main::after`), so the
+avatar and the pill open the item the way the home page's rows already did; anything that must
+stay its own target inside a row sits above it the way `.move` does.
+
 **A route gets its store from `web.family.current_store()`, never from `app.config`.** In single
 mode that is the one `FileStore` the process was built with. In cloud mode it is a `PostgresStore`
 built for this request from the family on the session, cached on `g`, over the process-wide pool.

--- a/web/templates/admin/growth.html
+++ b/web/templates/admin/growth.html
@@ -51,6 +51,7 @@
     .numbers tbody tr { border-top: 1px solid var(--border); }
     .numbers td + td { font-variant-numeric: tabular-nums; font-weight: 700; }
     .numbers td.zero { color: var(--faint); font-weight: 600; }
+    @media (hover: hover) { .numbers tbody tr:hover { background: var(--warm); } }
 
     /* The roster. An address can be long and has no spaces to break at. */
     .account .row-title { word-break: break-all; }

--- a/web/templates/preview.html
+++ b/web/templates/preview.html
@@ -22,6 +22,7 @@
         iframe { display: block; border: 0; }
         figcaption { font-size: 13px; text-align: center; letter-spacing: 0.03em; }
         a { color: #ff9a6b; }
+        a:hover { text-decoration: underline; }
         .bar { width: 100%; text-align: center; font-size: 13px; }
     </style>
 </head>

--- a/web/templates/settings/account.html
+++ b/web/templates/settings/account.html
@@ -85,10 +85,7 @@
                 <input type="text" id="confirm" name="confirm" autocomplete="off"
                        autocapitalize="off" autocorrect="off" spellcheck="false" required>
             </div>
-            <button class="btn" type="submit"
-                    style="background:var(--danger);border-color:var(--danger);">
-                Delete my account
-            </button>
+            <button class="btn danger fill" type="submit">Delete my account</button>
         </form>
     </div>
 </div>

--- a/web/templates/settings/base.html
+++ b/web/templates/settings/base.html
@@ -63,6 +63,11 @@
             --amber: #d97706;
             --amber-dark: #b45309;
             --danger: #c0392b;
+            --danger-dark: #a93226;
+            /* The wash a pointer puts behind a bare control — "Cancel", "Board",
+               "Not now", a muted pill. Rows and outline buttons take --warm
+               instead: on a white card that reads as warmth, this as dirt. */
+            --tint: rgba(154, 134, 119, 0.12);
         }
         *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
         /* An inline `display` beats the browser's own [hidden] rule, so say it here. */
@@ -74,6 +79,7 @@
         ::view-transition-old(root), ::view-transition-new(root) { animation-duration: 0.15s; }
         @media (prefers-reduced-motion: reduce) {
             ::view-transition-group(*), ::view-transition-old(*), ::view-transition-new(*) { animation: none !important; }
+            *, *::before, *::after { transition: none !important; }
         }
         /* Everything below is sized in rem off this one value, like the board. A phone gets the
            mockup's 16px; a desktop browser gets up to 20px, so the same layout reads at arm's
@@ -104,7 +110,8 @@
             min-width: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
         }
         /* The way back is a button, not a bare chevron: it names the page it goes to, and
-           its edges show the whole tap target rather than leaving a thumb to guess at it. */
+           its edges show the whole tap target rather than leaving a thumb to guess at it.
+           Its hover sits with the others at the foot of the sheet. */
         .appbar .back {
             display: inline-flex; align-items: center; gap: 0.125rem; flex-shrink: 0;
             min-height: 2.5rem; padding: 0 0.875rem 0 0.5rem;
@@ -112,26 +119,43 @@
             background: var(--surface); color: var(--text);
             font-size: 0.875rem; font-weight: 800; white-space: nowrap;
         }
-        .appbar .back:hover, .appbar .back:focus-visible { border-color: var(--accent); color: var(--accent); }
+        .appbar .back:focus-visible { border-color: var(--accent); color: var(--accent); }
         .appbar .back:active { background: var(--warm); }
         .appbar .action {
             display: inline-flex; align-items: center; justify-content: center;
             min-width: 2.75rem; height: 2.75rem; padding: 0 0.375rem;
             font-size: 0.9375rem; font-weight: 800; color: var(--accent);
+            border-radius: 0.625rem;
         }
         .appbar .action.muted { color: var(--text-muted); font-weight: 700; }
 
         .content { padding: 1rem; display: flex; flex-direction: column; gap: 1rem; }
 
-        .card { background: var(--surface); border: 1px solid var(--border); border-radius: 1rem; }
+        .card { --radius: 1rem; background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); }
         .card.pad { padding: 0.9375rem; }
         .row {
             display: flex; align-items: center; gap: 0.8125rem;
             padding: 0.75rem 0.875rem; min-height: 3.875rem;
-            color: inherit;
+            color: inherit; position: relative;
         }
         .row + .row { border-top: 1px solid var(--border); }
-        .row-main { flex-grow: 1; min-width: 0; }
+        /* The rows at either end follow the card's curve, so a wash on the first
+           or last row does not square its corners off. Inside a 1px border the
+           curve is 1px tighter. */
+        .card > .row:first-child, .card > .step:first-child > .row {
+            border-top-left-radius: calc(var(--radius) - 1px); border-top-right-radius: calc(var(--radius) - 1px);
+        }
+        .card > .row:last-child, .card > .step:last-child > .row {
+            border-bottom-left-radius: calc(var(--radius) - 1px); border-bottom-right-radius: calc(var(--radius) - 1px);
+        }
+        /* `color: inherit` because on a list page this is the link, and the global `a` colour
+           was turning every name orange — the People mockup sets them in ink. */
+        .row-main { flex-grow: 1; min-width: 0; color: inherit; }
+        /* On a list page the link is the text block, and the avatar, the pill and
+           the space beside them were dead — so the link stretches over the whole
+           row, the way the home page's rows already work. The move buttons sit
+           above it and stay their own targets. */
+        a.row-main::after { content: ""; position: absolute; inset: 0; }
         .row-title { font-size: 0.9375rem; font-weight: 700; }
         .row-sub { font-size: 0.8125rem; color: var(--text-muted); overflow: hidden; text-overflow: ellipsis; }
         .chev { flex-shrink: 0; color: var(--faint); }
@@ -166,7 +190,11 @@
         .btn.outline { background: transparent; color: var(--text); border: 2px solid var(--border); box-shadow: none; }
         .btn.dashed { background: transparent; color: var(--text-mid); border: 2px dashed var(--border-strong); box-shadow: none; height: 3.25rem; }
         .btn.danger { background: transparent; color: var(--danger); box-shadow: none; font-weight: 700; }
+        .btn.danger.fill { background: var(--danger); color: #fff; box-shadow: 0 2px 8px rgba(192, 57, 43, 0.25); }
+        .btn.quiet { background: transparent; color: var(--text-muted); box-shadow: none; }
         .btn.small { height: 2.5rem; font-size: 0.875rem; width: auto; padding: 0 1rem; }
+        /* On a lapsed board the two disabled buttons used to look exactly like live ones. */
+        .btn:disabled { opacity: 0.45; cursor: not-allowed; box-shadow: none; }
 
         .field { display: flex; flex-direction: column; gap: 0.375rem; }
         .field > label { font-size: 0.6875rem; font-weight: 800; letter-spacing: 0.07em; text-transform: uppercase; color: var(--text-muted); }
@@ -179,7 +207,8 @@
             font-family: inherit; font-size: 0.9375rem; font-weight: 600;
         }
         .field textarea { min-height: 4.75rem; resize: vertical; }
-        .field input:focus, .field select:focus, .field textarea:focus {
+        .field select { cursor: pointer; }
+        .field input:not([type=checkbox]):focus, .field select:focus, .field textarea:focus {
             outline: none; border-color: var(--accent);
         }
         .hint { font-size: 0.75rem; color: var(--text-muted); line-height: 1.5; }
@@ -195,10 +224,13 @@
         .picker input:checked + label { border: 2px solid var(--accent); background: rgba(232, 93, 36, 0.06); }
         .swatch { width: 2.125rem; height: 2.125rem; border-radius: 50%; display: block; }
         .picker.colors label { min-width: 2.875rem; height: 2.875rem; border-radius: 50%; border: none; padding: 0; }
-        .picker.colors input:checked + label { box-shadow: 0 0 0 2px var(--bg), 0 0 0 4px var(--accent); }
+        /* The ring is the whole cue. Without the two resets the generic checked rule above
+           wins on specificity and draws its 2px border inside the ring as well. */
+        .picker.colors input:checked + label { border: none; background: transparent; box-shadow: 0 0 0 2px var(--bg), 0 0 0 4px var(--accent); }
 
         .checkline { display: flex; align-items: center; gap: 0.6875rem; padding: 0.375rem 0.125rem; }
-        .checkline input { width: 1.375rem; height: 1.375rem; accent-color: var(--accent); }
+        .checkline input { width: 1.375rem; height: 1.375rem; accent-color: var(--accent); cursor: pointer; }
+        .checkline label { cursor: pointer; }
         .checkline span, .checkline label { font-size: 0.9375rem; font-weight: 700; }
 
         .calendar-intro { font-size: 0.875rem; color: var(--text-mid); }
@@ -257,11 +289,76 @@
         }
         .qr-code { background: #ffffff; border-radius: 0.875rem; padding: 0.75rem; }
         .qr-code svg { display: block; width: 100%; height: auto; }
-        .move { display: flex; flex-direction: column; gap: 0.125rem; }
+        .move { display: flex; flex-direction: column; gap: 0.125rem; position: relative; z-index: 1; }
         .move button {
             width: 1.875rem; height: 1.5rem; border: 1px solid var(--border); background: var(--surface);
             border-radius: 0.4375rem; cursor: pointer; color: var(--text-muted); font-size: 0.7rem; line-height: 1;
         }
+
+        /* ---- A pointer, a press, and a keyboard ----
+           Hover is for a mouse. On a phone a "hover" is a tap that never ends,
+           left glowing on the row you just came back from, so every hover rule
+           sits behind (hover: hover); press states and focus rings are for
+           everyone. One cue throughout, taken from the mockups' `a:hover`:
+           filled things darken, bare things get --warm or --tint behind them,
+           links underline. Nothing changes size, so a row under the pointer
+           never shifts the one below it. */
+        .btn, .row, .chev, .appbar .back, .appbar .action, .picker label, .move button,
+        .pill, .calendar-help summary, .checkline label, .hint a, .note-box a, .flash a,
+        .field input, .field select, .field textarea {
+            transition: background-color 0.12s ease, border-color 0.12s ease, color 0.12s ease,
+                        box-shadow 0.12s ease, transform 0.12s ease, opacity 0.12s ease;
+        }
+        @media (hover: hover) {
+            .btn:not(:disabled):hover { background: var(--accent-dark); box-shadow: 0 4px 12px rgba(232, 93, 36, 0.3); transform: translateY(-1px); }
+            .btn.outline:not(:disabled):hover { background: var(--warm); border-color: var(--border-strong); box-shadow: none; transform: none; }
+            .btn.dashed:not(:disabled):hover { background: rgba(232, 93, 36, 0.05); border-color: var(--accent); color: var(--accent-dark); box-shadow: none; transform: none; }
+            .btn.danger:not(:disabled):hover { background: rgba(192, 57, 43, 0.08); box-shadow: none; transform: none; }
+            .btn.danger.fill:not(:disabled):hover { background: var(--danger-dark); box-shadow: 0 4px 12px rgba(192, 57, 43, 0.3); transform: translateY(-1px); }
+            .btn.quiet:not(:disabled):hover { background: var(--tint); color: var(--text-mid); box-shadow: none; transform: none; }
+
+            .appbar .back:hover { border-color: var(--accent); color: var(--accent); }
+            .appbar .action:hover { background: rgba(232, 93, 36, 0.08); color: var(--accent-dark); }
+            .appbar .action.muted:hover { background: var(--tint); color: var(--text); }
+
+            /* Two rules rather than one list: a browser without :has() would
+               drop the whole list, home rows included. */
+            a.row:hover { background: var(--warm); }
+            a.row:hover .chev { color: var(--text-muted); transform: translateX(0.125rem); }
+            .row:has(> a.row-main:hover) { background: var(--warm); }
+            .row:has(> a.row-main:hover) .chev { color: var(--text-muted); transform: translateX(0.125rem); }
+
+            .move button:hover { background: var(--warm); border-color: var(--border-strong); color: var(--text); }
+            .picker input:not(:checked) + label:hover { background: var(--warm); border-color: var(--border-strong); }
+            .picker.colors input:not(:checked) + label:hover { background: transparent; box-shadow: 0 0 0 2px var(--bg), 0 0 0 4px var(--border-strong); }
+            .checkline label:hover, .calendar-help summary:hover { color: var(--accent-dark); }
+            .field input:not(:focus):hover, .field select:not(:focus):hover, .field textarea:not(:focus):hover { border-color: var(--border-strong); }
+            .hint a:hover, .note-box a:hover, .flash a:hover { color: var(--accent-dark); text-decoration: underline; }
+            a.pill.muted:hover { background: rgba(154, 134, 119, 0.2); color: var(--text); }
+            a.pill.warm:hover { background: rgba(232, 93, 36, 0.16); }
+        }
+        /* Pressed. After the hover block on purpose: at equal specificity the
+           later rule wins while both apply, and a press should beat a hover. */
+        .btn:not(:disabled):active { transform: none; box-shadow: 0 1px 3px rgba(232, 93, 36, 0.25); }
+        .btn.outline:not(:disabled):active, .btn.quiet:not(:disabled):active { background: var(--border); box-shadow: none; transform: none; }
+        .btn.dashed:not(:disabled):active { background: rgba(232, 93, 36, 0.1); box-shadow: none; transform: none; }
+        .btn.danger:not(:disabled):active { background: rgba(192, 57, 43, 0.14); box-shadow: none; transform: none; }
+        .btn.danger.fill:not(:disabled):active { background: var(--danger-dark); box-shadow: 0 1px 3px rgba(192, 57, 43, 0.25); transform: none; }
+        .appbar .action.muted:active { background: rgba(154, 134, 119, 0.2); }
+        .appbar .action:active { background: rgba(232, 93, 36, 0.14); }
+        a.row:active { background: var(--border); }
+        .row:has(> a.row-main:active) { background: var(--border); }
+        .move button:active { background: var(--border); }
+        /* Keyboard focus: one ring throughout, and only from the keyboard —
+           :focus-visible never draws for a click. Text inputs keep their own
+           cue (the border goes accent, above). The invisible radio behind a
+           picker hands its ring to the label the eye is on. */
+        :focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+        a.row:focus-visible { outline-offset: -2px; }
+        .row:has(> a.row-main:focus-visible) { outline: 2px solid var(--accent); outline-offset: -2px; }
+        .row:has(> a.row-main:focus-visible) > a.row-main { outline: none; }
+        .picker input:focus-visible + label { outline: 2px solid var(--accent); outline-offset: 2px; }
+        .move button:focus-visible { outline-offset: 1px; }
     </style>
 </head>
 <body>

--- a/web/templates/settings/edit.html
+++ b/web/templates/settings/edit.html
@@ -100,7 +100,7 @@
                 {% for person in people %}
                 <div class="checkline">
                     <input type="checkbox" id="p-{{ loop.index }}" name="{{ name }}" value="{{ person }}" {{ 'checked' if person in (item.get(name) or []) }}>
-                    <span>{{ person }}</span>
+                    <label for="p-{{ loop.index }}">{{ person }}</label>
                 </div>
                 {% endfor %}
             </div>

--- a/web/templates/settings/home.html
+++ b/web/templates/settings/home.html
@@ -280,10 +280,7 @@
         On Android, open the <strong>⋮</strong> menu, then <strong>Add to home screen</strong>.
     </div>
     <button class="btn" type="button" id="install-go" hidden>Add to home screen</button>
-    <button class="btn small" type="button" id="install-no"
-            style="background:transparent;color:var(--text-muted);box-shadow:none;align-self:center;">
-        Not now
-    </button>
+    <button class="btn small quiet" type="button" id="install-no" style="align-self:center;">Not now</button>
 </div>
 
 <script>

--- a/web/templates/settings/screen.html
+++ b/web/templates/settings/screen.html
@@ -2,6 +2,28 @@
 {% import "settings/_icons.html" as icons %}
 {% block title %}The screen{% endblock %}
 
+{% block head %}
+<style>
+    /* The two theme cards. Only this page has them. The chosen one is read off
+       the radio, so the choice shows the instant it is clicked, before the
+       form's own submit brings the page back. */
+    .theme-choice { flex: 1; cursor: pointer; position: relative; }
+    .theme-choice input { position: absolute; opacity: 0; pointer-events: none; }
+    .theme-card {
+        border: 1.5px solid var(--border); border-radius: 0.875rem; background: var(--surface);
+        padding: 0.5625rem 0.5625rem 0.625rem; display: flex; flex-direction: column; gap: 0.5rem;
+        transition: background-color 0.12s ease, border-color 0.12s ease;
+    }
+    .theme-name { text-align: center; font-size: 0.875rem; font-weight: 800; color: var(--text-mid); }
+    .theme-choice input:checked + .theme-card { border: 2px solid var(--accent); }
+    .theme-choice input:checked + .theme-card .theme-name { color: var(--accent-dark); }
+    .theme-choice input:focus-visible + .theme-card { outline: 2px solid var(--accent); outline-offset: 2px; }
+    @media (hover: hover) {
+        .theme-choice input:not(:checked) + .theme-card:hover { background: var(--warm); border-color: var(--border-strong); }
+    }
+</style>
+{% endblock %}
+
 {% block appbar %}
 {{ icons.back_to(url_for('settings.home'), 'Settings') }}
 <h1>{{ "The screen" if screen_link else "Colours" }}</h1>
@@ -13,12 +35,9 @@
     <div class="label">Board colours</div>
     <div style="display:flex;gap:0.625rem;">
         {% for theme in themes %}
-        <label style="flex:1;cursor:pointer;">
-            <input type="radio" name="theme" value="{{ theme }}" {{ 'checked' if config.theme == theme }}
-                   style="position:absolute;opacity:0;" onchange="this.form.submit()">
-            <div style="border:{{ '2px solid var(--accent)' if config.theme == theme else '1.5px solid var(--border)' }};
-                        border-radius:0.875rem;background:var(--surface);padding:0.5625rem 0.5625rem 0.625rem;
-                        display:flex;flex-direction:column;gap:0.5rem;">
+        <label class="theme-choice">
+            <input type="radio" name="theme" value="{{ theme }}" {{ 'checked' if config.theme == theme }} onchange="this.form.submit()">
+            <div class="theme-card">
                 {# A miniature of the real board, in that theme's actual palette. #}
                 <div style="height:4rem;border-radius:0.5625rem;padding:0.5625rem 0.625rem;display:flex;flex-direction:column;gap:0.3125rem;
                             {% if theme == 'dark' %}background:#17120f;{% else %}background:#ffffff;border:1px solid #f0e6da;{% endif %}">
@@ -27,10 +46,7 @@
                     <div style="width:72%;height:0.3125rem;border-radius:0.1875rem;background:{{ '#6f6053' if theme == 'dark' else '#c4b3a3' }};"></div>
                     <div style="width:86%;height:0.3125rem;border-radius:0.1875rem;background:{{ '#6f6053' if theme == 'dark' else '#c4b3a3' }};"></div>
                 </div>
-                <div style="text-align:center;font-size:0.875rem;font-weight:800;
-                            color:{{ 'var(--accent-dark)' if config.theme == theme else 'var(--text-mid)' }};">
-                    {{ theme | capitalize }}
-                </div>
+                <div class="theme-name">{{ theme | capitalize }}</div>
             </div>
         </label>
         {% endfor %}


### PR DESCRIPTION
The settings shell had no hover rules at all, so on a desktop nothing reacted to the mouse. Every button, link, row, picker, input and toggle now has a hover (behind `(hover: hover)`, so a phone never keeps one lit), a pressed state and a keyboard focus ring, with short transitions that switch off under reduced motion. Disabled buttons now look disabled and refuse the cursor, list rows are clickable across their whole width instead of only the text, and a chore's person names are real labels that toggle their box. Two inline-styled buttons and the theme cards became classes so the rules can reach them, list titles take the ink colour the mockup gives them, and the chosen colour swatch wears one ring rather than two. Three tests pin the label, the labelled back button and the rule that a button's look is a class variant rather than a style attribute, and `web/CLAUDE.md` records the convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
