### PR TITLE
Report errors to Sentry and watch the worker with a cron monitor (DIN-35, DIN-54)

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -40,6 +40,13 @@
 # **Never commit an `EV[...]` blob here either** — it is ciphertext of a
 # production credential, in a public repo.
 #
+# **The alert block below is applied by the same command**, and App Platform
+# keeps the alert's *destinations* outside the spec: an alert created this way
+# arrives addressed to the account owner (one email, as `doctl apps list-alerts
+# <APP_ID>` shows), and `doctl apps update-alert-destinations <APP_ID> <ALERT_ID>
+# --app-alert-destinations <file>` is how it gets more. See doc/operations.md,
+# Sentry and the deploy alert.
+#
 # No Dockerfile: App Platform's Python buildpack reads .python-version and
 # installs what `build_command` says (DIN-30, reversed).
 #
@@ -118,6 +125,17 @@ envs:
   - key: DINKYDASH_ADMIN_EMAILS
     scope: RUN_TIME
     type: SECRET
+  # Where error reports and the worker's check-ins go (DIN-35, DIN-54):
+  # `dinkydash/sentry.py`, in both the service and the worker. A DSN is not a
+  # password — its holder can only *send* events — but it is not published
+  # either, because a public DSN is an invitation to fill the project with
+  # junk. Merged in from `.env` like the secrets above; unset means nothing is
+  # initialised and nothing leaves the container. Reports are labelled with
+  # `SENTRY_ENVIRONMENT` if set, else "production" — a local drill sets it,
+  # so its check-ins never stand in for the real worker's.
+  - key: SENTRY_DSN
+    scope: RUN_TIME
+    type: SECRET
 
   # The spend breaker (DIN-43), in model calls a day. Written out at their
   # defaults rather than left implicit, because a ceiling nobody can see is a
@@ -136,6 +154,14 @@ envs:
   - key: DINKYDASH_GLOBAL_CALLS_PER_FAMILY
     scope: RUN_TIME
     value: "4"
+
+# A failed build or deploy is the platform's own alert (DIN-54): zero code, and
+# it fires exactly when `db.ready` refuses to start on a wrong DATABASE_URL, or
+# a migration fails in the pre-deploy job. The two things this cannot see — a
+# worker that has stopped, and a site that is up but broken — are Sentry's: the
+# worker's cron monitor and an uptime check on app.dinkydash.co/login.
+alerts:
+  - rule: DEPLOYMENT_FAILED
 
 services:
   # Named `site` rather than `web` because renaming a component destroys and
@@ -214,6 +240,13 @@ workers:
   # component rather than a thread in `site` because there is no lock on the
   # tick in cloud mode: two processes would both refresh and both pay Anthropic
   # for the same brief. One worker, however many web instances.
+  #
+  # After every completed pass the worker sends one check-in to Sentry's cron
+  # monitor (`dinkydash/sentry.py`, DIN-54): a slug, `ok` and a duration. The
+  # monitor expects the next one within DINKYDASH_WORKER_INTERVAL (300 s in
+  # code when unset) with twice that as grace, and a missed one is the alert.
+  # The interval is read from the environment each pass and rides along on
+  # the check-in, so setting it here retunes the monitor on the next pass.
   - name: worker
     github:
       repo: caspii/dinkydash

--- a/.env.example
+++ b/.env.example
@@ -40,6 +40,18 @@ ANTHROPIC_API_KEY=
 # Move both together when DinkyDash gets a mailbox of its own.
 # DINKYDASH_MAIL_REPLY_TO=
 
+# Error reports and the worker's check-ins (DIN-35, DIN-54). Sentry → the
+# project → Settings → Client Keys (DSN). Unset means nothing is initialised
+# and nothing leaves the machine, which is how every self-hosted board runs.
+# What a report may hold is decided in dinkydash/sentry.py: never a URL, a
+# token, a name, a calendar or a written line.
+# SENTRY_DSN=
+#
+# What reports and check-ins are labelled with. Defaults to "production". A
+# local drill sets something else, so its check-ins never stand in for the
+# real worker's.
+# SENTRY_ENVIRONMENT=
+
 # The spend breaker (DIN-43), in **model calls a day**, not money — a price
 # table goes stale silently and in the wrong direction. The defaults in
 # dinkydash/budget.py are what runs with these unset; they are here so a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -209,6 +209,18 @@ mode is a different product on the same code.
   the one path with no limit on it at all, and it is charged now too.
   The budget also applies the platform's model and output-token ceiling before hosted generation.
   Its global daily aggregate has no family identifiers and survives account deletion (DIN-49/51).
+- **Error reports leave the machine, and `dinkydash/sentry.py` decides what they may hold** (DIN-35).
+  With `SENTRY_DSN` set — cloud mode, and only there — an unhandled exception in a request or a
+  log record at ERROR becomes a Sentry event. What goes: the exception, where in *our* code it was
+  raised, the log line's **template**, the request's **method**, the release, the component. What
+  is stripped in `scrub`, whatever the SDK's PII switch says: the URL and query string (a screen
+  token, a login token), the Referer, headers, cookies and body, local variables, breadcrumbs, and
+  the log line's **arguments** — "Tick failed for family %s" is about our code and the `%s` is
+  which family. Free text is regex-scrubbed of URLs, tokens, addresses and UUIDs as well.
+  `tests/test_sentry.py` captures real events through an in-process transport and asserts each
+  absence; **a new `log.error` is an event, so keep the data in the arguments, never the
+  template**, and anything that adds a report path takes the same `scrub`. The privacy page and
+  `/settings/account` name Sentry as a sub-processor, and say what it never sees.
 
 ### The safety net, and what it does not cover
 
@@ -232,6 +244,22 @@ that way. The single allowlist entry is the Ahrefs Web Analytics site key, which
 committed `docs/`; with the site rendered on request there is one copy of it, in a template.
 **Allowlisting is for values that are public by design.** A real secret that reached a commit is
 fixed by rotating it.
+
+**What decides whether a deploy goes live, and what watches it afterwards** (DIN-54). App
+Platform probes `/healthz` on the platform's own hostname, so it is the marketing app that answers
+it; the probe reads nothing on purpose, because three failed probes restart the container and a
+probe that depended on the database would turn a slow query into a rolled-back deploy. So it only
+proves that the process came up — which is why `create_app` calls `db.ready` and refuses to start
+when the pooled database does not answer within ten seconds, turning a wrong `DATABASE_URL` into
+a deploy that never goes live, and App Platform's own `DEPLOYMENT_FAILED` alert (in `.do/app.yaml`)
+into the message. The two things a probe cannot see are Sentry's, with no code of ours beyond one
+call: **the worker checks in with a cron monitor after every completed pass** (`worker.run_pass` →
+`sentry.check_in`; a stop request or a pass that could not list the families sends nothing, and a
+missed check-in is the alert), and **an uptime monitor fetches `app.dinkydash.co/login`** from
+outside, which proves DNS, TLS, the container, the host routing and a rendered page with no
+database in the path. Nothing here polls, stores a heartbeat or runs a workflow; an in-house
+version of all this was built and dropped as 1,300 lines for what a monitoring service does with
+configuration. `tests/test_deploy_spec.py` pins the probe path, the alert and the DSN's shape.
 
 Two things the net does not catch, both worth knowing before trusting it:
 
@@ -316,6 +344,7 @@ dinkydash/
 ├── budget.py          what a family may spend on the model, and what everybody may
 │                     (`accounts.delete_family` is the hard delete; see phase 5)
 ├── growth.py          signups and activations per day, with no family in the row (cloud only)
+├── sentry.py          error reports and the worker's check-in, and what neither may carry (cloud only)
 └── runner.py          the two halves of the day, reading and writing through a store
 
 web/

--- a/PLAN.md
+++ b/PLAN.md
@@ -31,8 +31,7 @@ Optional features, promotion and additional operational tooling are Backlog.
 Hosted readiness is still open. The remaining sequence is:
 
 1. Complete Stripe conversion, subscription changes and cancellation before accepting payment ([DIN-53](https://linear.app/keepthescore/issue/DIN-53)).
-2. Add liveness alerts and recovery checks ([DIN-54](https://linear.app/keepthescore/issue/DIN-54),
-   [DIN-56](https://linear.app/keepthescore/issue/DIN-56)), and finish the trust work in Phase 5.
+2. Add the recovery drill ([DIN-56](https://linear.app/keepthescore/issue/DIN-56)) — liveness alerts are done ([DIN-54](https://linear.app/keepthescore/issue/DIN-54)) — and finish the trust work in Phase 5.
 3. Verify real screens and run the small private beta ([DIN-58](https://linear.app/keepthescore/issue/DIN-58)), collecting feedback through the existing support email. Use observed setup
    problems to decide whether the existing settings flow needs a wizard.
 
@@ -201,7 +200,8 @@ uniqueness, not a guarantee that concurrent callers cannot make two paid model c
 Every hosted attempt must continue to pass through the budget.
 
 Keep-last-good and retries on subsequent ticks exist. Persistent failure tracking,
-backoff and parent notification are Backlog ([DIN-55](https://linear.app/keepthescore/issue/DIN-55)); the MVP worker heartbeat remains [DIN-54](https://linear.app/keepthescore/issue/DIN-54).
+backoff and parent notification are Backlog ([DIN-55](https://linear.app/keepthescore/issue/DIN-55)); the worker's liveness is a Sentry cron
+check-in after each completed pass ([DIN-54](https://linear.app/keepthescore/issue/DIN-54)).
 Trial access ends at `trial_ends_at`, using the database's timezone-aware clock ([DIN-52](https://linear.app/keepthescore/issue/DIN-52)).
 The worker persists expired trials as lapsed; selection, manual feed checks, calendar refreshes
 and model calls also enforce the deadline independently of that sweep. Legacy trials with no
@@ -297,7 +297,11 @@ The spec is [`.do/app.yaml`](.do/app.yaml); secrets stay in encrypted platform e
 variables. The Python buildpack installs `requirements-cloud.txt`. No Dockerfile is needed.
 
 Changes on main deploy through App Platform with a pre-deploy migration job and
-`/healthz` readiness checks. GitHub CI checks pytest and gitleaks; the tests run with
+`/healthz` readiness checks. The probe reads nothing, so `create_app` also refuses to start
+until the pooled database answers (`db.ready`), which is what stops a wrong `DATABASE_URL`
+going live, and the spec carries App Platform's own `DEPLOYMENT_FAILED` alert. Error reports
+and the worker's liveness go to Sentry (`dinkydash/sentry.py`): a check-in after each completed
+pass, and an uptime monitor on `app.dinkydash.co/login`. GitHub CI checks pytest and gitleaks; the tests run with
 Postgres 17 and without a configured database. The current branch rules and deployment
 history are recorded in [doc/operations.md](doc/operations.md).
 
@@ -320,8 +324,11 @@ PR #86 uses `pg_advisory_xact_lock` for token issuance: the lock belongs to the 
 transaction. It does not introduce a session-scoped lock or require session pooling.
 
 Managed backups are documented in operations; the independent restore drill remains
-[DIN-56](https://linear.app/keepthescore/issue/DIN-56). Worker liveness alerts remain MVP work ([DIN-54](https://linear.app/keepthescore/issue/DIN-54));
-Sentry instrumentation is Backlog ([DIN-35](https://linear.app/keepthescore/issue/DIN-35)).
+[DIN-56](https://linear.app/keepthescore/issue/DIN-56). Worker liveness is a Sentry cron check-in after each completed pass and
+an uptime monitor on the sign-in page ([DIN-54](https://linear.app/keepthescore/issue/DIN-54)); error reports for the web service and the
+worker go to the same project with a scrubber that strips URLs, tokens, addresses, ids and log
+arguments ([DIN-35](https://linear.app/keepthescore/issue/DIN-35)). Frontend error capture is not done: the board and the settings
+pages make no third-party request, and a first-party reporting path is separate work.
 Cloud startup validates the session key and database configuration; model/email failures
 have their own runtime handling. Stripe credentials are not required before billing exists.
 
@@ -412,8 +419,8 @@ alone does not close the phase.
 ### Phase 6 — Ops
 
 - [x] Transactional email wired into signup/login ([DIN-36](https://linear.app/keepthescore/issue/DIN-36), [DIN-38](https://linear.app/keepthescore/issue/DIN-38)).
-- [ ] Sentry for web, worker and applicable frontend errors, with sensitive-data filtering ([DIN-35](https://linear.app/keepthescore/issue/DIN-35); Backlog).
-- [ ] Worker heartbeat and external health alerts, verified by a controlled failure ([DIN-54](https://linear.app/keepthescore/issue/DIN-54)).
+- [x] Sentry for web and worker errors, with sensitive-data filtering ([DIN-35](https://linear.app/keepthescore/issue/DIN-35)): `dinkydash/sentry.py`, on with `SENTRY_DSN` in cloud mode only, scrubbing asserted on real captured events in `tests/test_sentry.py`. Frontend errors are not captured — the board and settings pages make no third-party request — and remain open on that issue.
+- [x] Worker liveness and external health alerts, verified by a controlled failure ([DIN-54](https://linear.app/keepthescore/issue/DIN-54)): a Sentry cron check-in after each completed pass, a Sentry uptime monitor on the sign-in page, `db.ready` at start-up and App Platform's `DEPLOYMENT_FAILED` alert. The stop-and-recover drill was run against a local worker on 11 September 2026 ([doc/operations.md](doc/operations.md)).
 - [ ] Repeatable restore into an isolated database, with a successful drill recorded ([DIN-56](https://linear.app/keepthescore/issue/DIN-56)).
 - [x] Preserve explicit preview database overrides ([DIN-48](https://linear.app/keepthescore/issue/DIN-48)).
 - [ ] Admin dashboard ([DIN-37](https://linear.app/keepthescore/issue/DIN-37)): signups and activations by week and a roster of the newest accounts (address, created, activated, status, trial deadline, last sign-in) exist at `/admin`, behind `DINKYDASH_ADMIN_EMAILS` (migration 006, `dinkydash/growth.py`). Country of origin is not shown: App Platform forwards `do-connecting-ip` only, and `CF-IPCountry` would need the hostname proxied through our own Cloudflare zone, which App Platform's certificates rule out (DIN-29). Spend and calendar health, per the issue's triage, remain Backlog.
@@ -446,10 +453,10 @@ already exist and are not exclusions. Manual rewrites also already exist.
 Weather ([DIN-24](https://linear.app/keepthescore/issue/DIN-24)) and photo/screensaver mode ([DIN-11](https://linear.app/keepthescore/issue/DIN-11)) remain deferred scope decisions.
 Their issues must agree with the plan before either is promoted into the MVP.
 
-Additional edge rules, Sentry instrumentation, the rest of the admin dashboard (spend,
+Additional edge rules, frontend error capture, the rest of the admin dashboard (spend,
 trial status, calendar health), persisted retry backoff/parent notifications, a feedback
-widget and public launch promotion are also Backlog. Existing redacted logs, bounded retries and support email
-cover those needs for the MVP alongside the remaining liveness and recovery work.
+widget and public launch promotion are also Backlog. Existing redacted logs, bounded retries, Sentry and support email
+cover those needs for the MVP alongside the remaining recovery work.
 
 ## Open questions
 

--- a/dinkydash/CLAUDE.md
+++ b/dinkydash/CLAUDE.md
@@ -209,6 +209,22 @@ under transaction-mode pooling the next execution can land on a different backen
 full reasoning, and why KeepTheScore's clean record on psycopg2 does not transfer, is in PLAN.md
 under [Connection pooling](../PLAN.md#connection-pooling).
 
+**`db.ready(pool)` is what makes a wrong `DATABASE_URL` a failed deploy rather than a live one.**
+A pool opens in the background and a connection string that goes nowhere is only a warning in its
+log — the process came up, `/healthz` answered, and every request that needed the database then
+waited thirty seconds and failed. `create_app` calls `ready` right after building the pool, and it
+raises after `STARTUP_TIMEOUT` seconds naming the variable and nothing else; under gunicorn a
+worker that raises on boot halts the server, so the container never becomes healthy and the
+previous release keeps serving. The worker does not call it: it has no probe, and a worker looping
+on a dead database sends no check-in to Sentry, which is already the alert (DIN-54).
+
+**`sentry.py` is the other cloud-only module that talks to somebody else**, and it is the same
+shape as `mail.py`: a lazy import, nothing initialised without its variable, and one narrow
+promise about what leaves. The promise is in the root `CLAUDE.md` under *Hosted mode raises the
+stakes*; the check-in that `worker.run_pass` sends after a completed pass is the whole of the
+worker's liveness story, and `monitor_config` derives its schedule from `DINKYDASH_WORKER_INTERVAL`
+so there is nothing to keep in step by hand.
+
 **`psycopg` is in `requirements-cloud.txt`, not `requirements.txt`.** A Pi has no database and
 should not install a driver for one, so single mode never imports `pgstore` or `db` — the import in
 `create_app` is inside the cloud branch on purpose. **App Platform's Python buildpack installs

--- a/dinkydash/db.py
+++ b/dinkydash/db.py
@@ -62,6 +62,43 @@ def pool(conninfo=None, min_size=1, max_size=3, **kwargs):
                           configure=_prepare, open=True, **kwargs)
 
 
+# How long a starting process waits for its first connection before it refuses
+# to start. Long enough for a cold pool and a TLS handshake; short enough that a
+# deploy fails before the platform's probe has given up on the container.
+STARTUP_TIMEOUT = 10.0
+
+
+def ready(pool, timeout=None):
+    """Wait for the pool's first connection, or refuse to start.
+
+    A pool opens in the background, and a wrong connection string is only a
+    warning in its log: the process comes up, `/healthz` answers, the deploy is
+    declared healthy, and every request that needs the database then waits
+    thirty seconds and fails. This was demonstrated, not guessed — the cloud
+    entry point built in half a second against a closed port and answered
+    200 on both hostnames. Waiting here turns that into a process that never
+    starts, which under gunicorn is a container that never becomes healthy,
+    which is a deploy that never goes live while the previous one carries on —
+    and App Platform's own DEPLOYMENT_FAILED alert says so (DIN-54).
+
+    Not called by the worker: it has no probe, and a worker that loops on a
+    dead database sends no check-in, which is already the alert.
+
+    The message names the variable and nothing else. A connection string
+    carries a password, and this runs on a start-up path that logs.
+    """
+    from psycopg_pool import PoolTimeout
+
+    # Read at call time rather than bound as a default, so a test can shorten it.
+    timeout = STARTUP_TIMEOUT if timeout is None else timeout
+    try:
+        pool.wait(timeout=timeout)
+    except PoolTimeout:
+        raise RuntimeError(
+            f"The database did not answer within {timeout:g} seconds. Cloud mode "
+            "will not start without it; check DATABASE_URL.") from None
+
+
 def connect(conninfo=None):
     """One connection, outside any pool. For migrations and one-off scripts.
 

--- a/dinkydash/sentry.py
+++ b/dinkydash/sentry.py
@@ -1,0 +1,223 @@
+"""What leaves the machine when something breaks — and what never does.
+
+Cloud mode only. `init` is called from `wsgi.py` for the web service and from
+`worker.main` for the tick loop, and it reads `SENTRY_DSN`. With no DSN it
+returns False and nothing is imported, initialised or sent — which is every
+self-hosted board and every test run. `sentry-sdk` lives in
+`requirements-cloud.txt` for the same reason psycopg does: a Pi never installs it.
+
+Two kinds of thing go out:
+
+* **An error report**, for an unhandled exception in a web request, or a log
+  record at ERROR anywhere — the worker's "Tick failed for family", the
+  settings page's "Generation failed". WARNING-level feed failures stay in
+  the log: they are one family's problem, not the platform's.
+* **One check-in after every completed worker pass** (DIN-54). Sentry expects
+  the next within `DINKYDASH_WORKER_INTERVAL`, plus twice that as grace, and
+  a missed one is the alert. A check-in is a slug, a status and a duration —
+  no family, no calendar, no text. `worker.run_pass` is the only caller,
+  because it is the only place that knows a pass finished.
+
+**What an error report may hold is decided here, once, in `scrub`**, and it is
+narrow on purpose: the exception and where in *our* code it was raised, the
+log line's template, the request's method, the release, the component. Not
+the URL or the query string — a magic link rides in `?t=` and a screen token
+in `/s/<token>` — not the Referer, which carries the same, not the headers,
+the body or the cookies; not local variables (a config holds children's names
+and a calendar URL is a password); not breadcrumbs (an outgoing-request
+breadcrumb is the calendar URL again); and not the log line's *arguments*,
+which is where a family id, a label or an address would ride. The SDK's own
+PII switch is off as well, and it is not trusted alone: with it off, the SDK
+was observed to keep the URL, the query string and the Referer.
+`tests/test_sentry.py` captures real events through an in-process transport
+and asserts each absence.
+"""
+
+import logging
+import os
+import re
+
+log = logging.getLogger(__name__)
+
+# The worker's cron monitor. One slug, one monitor: Sentry creates it from the
+# `monitor_config` on the first check-in and updates it from every later one,
+# so there is nothing to set up by hand and the schedule follows
+# DINKYDASH_WORKER_INTERVAL.
+MONITOR_SLUG = "worker-pass"
+
+DEFAULT_ENVIRONMENT = "production"
+
+REDACTED = "[redacted]"
+
+# What an error report keeps at the top level. An allow-list rather than a
+# deny-list, so that a key the SDK starts attaching in some later version is
+# dropped until somebody decides it is safe. `request` is handled below.
+KEEP = frozenset({
+    "event_id", "timestamp", "platform", "level", "logger", "logentry",
+    "exception", "message", "release", "environment", "server_name", "sdk",
+    "contexts", "modules", "tags", "transaction", "transaction_info",
+    "fingerprint", "type",
+})
+
+# Anything in free text that could name a family or open a door. Any URL
+# scheme, because a calendar address is `https://` or `webcal://` and a
+# connection string is `postgresql://`; a magic-link token; a screen token;
+# an email address; a family id, which is a UUID.
+_A_URL = re.compile(r"[a-z][a-z0-9+.-]*://\S+", re.IGNORECASE)
+_A_TOKEN = re.compile(r"([?&]t=)[^&\s\"']+")
+_A_SCREEN = re.compile(r"(/s/)[^/\s\"']+")
+_AN_ADDRESS = re.compile(r"[^\s@\"'<>/]+@[^\s@\"'<>/]+")
+_AN_ID = re.compile(
+    r"\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b", re.IGNORECASE)
+
+_enabled = False
+
+
+def options(dsn, environment=None, release=None):
+    """The SDK's settings, as one dict. Pure, so a test can read them.
+
+    Everything that would carry data is off: PII, local variables, request
+    bodies, breadcrumbs, tracing, sessions, the SDK's own logs and metrics —
+    and its auto-enabled integrations, one of which instruments the Anthropic
+    client and would see the prompt. Two integrations, named: Flask, for the
+    unhandled exception in a request, and logging, for `log.exception`.
+    """
+    from sentry_sdk.integrations.flask import FlaskIntegration
+    from sentry_sdk.integrations.logging import LoggingIntegration
+
+    return dict(
+        dsn=dsn,
+        environment=environment or DEFAULT_ENVIRONMENT,
+        release=release or None,
+        send_default_pii=False,
+        include_local_variables=False,
+        max_breadcrumbs=0,
+        max_request_body_size="never",
+        attach_stacktrace=False,
+        auto_session_tracking=False,
+        auto_enabling_integrations=False,
+        integrations=[
+            FlaskIntegration(),
+            # `level=None`: no breadcrumbs from the log at all. ERROR and above
+            # become a report; WARNING stays where it was written.
+            LoggingIntegration(level=None, event_level=logging.ERROR),
+        ],
+        before_send=scrub,
+        enable_logs=False,
+        enable_metrics=False,
+    )
+
+
+def init(component, **overrides):
+    """Start reporting if `SENTRY_DSN` is set. Returns whether it did.
+
+    `component` — "web" or "worker" — is a tag on every report, because the
+    same exception means different things in a request and in a pass.
+    `overrides` are for the tests, which pass a transport that keeps the
+    envelopes in a list instead of sending them.
+    """
+    global _enabled
+    dsn = os.environ.get("SENTRY_DSN", "").strip()
+    if not dsn:
+        log.info("SENTRY_DSN is not set; errors stay in the log.")
+        return False
+
+    import sentry_sdk
+
+    settings = options(dsn, environment=os.environ.get("SENTRY_ENVIRONMENT"),
+                       release=os.environ.get("GIT_SHA"))
+    sentry_sdk.init(**{**settings, **overrides})
+    sentry_sdk.get_global_scope().set_tag("component", component)
+    _enabled = True
+    log.info("Reporting errors to Sentry as %s.", component)
+    return True
+
+
+def check_in(interval_seconds, duration_seconds):
+    """Tell Sentry a worker pass finished, and how long it took.
+
+    A no-op without a DSN. The monitor's schedule and grace ride along on
+    every check-in, so the monitor exists after the first one and follows a
+    changed interval after the next. Returns the check-in id, or None.
+    """
+    if not _enabled:
+        return None
+
+    from sentry_sdk.crons import capture_checkin
+
+    return capture_checkin(monitor_slug=MONITOR_SLUG, status="ok",
+                           duration=float(duration_seconds),
+                           monitor_config=monitor_config(interval_seconds))
+
+
+def monitor_config(interval_seconds):
+    """The monitor, derived from the worker's interval and nothing else.
+
+    Sentry counts in whole minutes. A five-minute interval is expected every
+    five minutes with ten minutes' grace, so the issue opens when the third
+    pass in a row has failed to check in — the allowance the in-house design
+    had. The grace also has to cover a pass that runs long: the check-in is
+    sent when a pass *ends*, so a pass longer than two intervals reads as
+    missed, which by then it fairly is.
+    """
+    minutes = max(1, round(interval_seconds / 60))
+    return {
+        "schedule": {"type": "interval", "value": minutes, "unit": "minute"},
+        "checkin_margin": 2 * minutes,
+        "failure_issue_threshold": 1,
+        "recovery_threshold": 1,
+        "timezone": "UTC",
+    }
+
+
+def scrub(event, hint=None):
+    """`before_send`: the whole report, reduced to what may leave.
+
+    A check-in passes through untouched — it is a slug, a status and a
+    duration, and the allow-list below would strip the slug.
+    """
+    if event.get("type") == "check_in":
+        return event
+
+    kept = {key: value for key, value in event.items() if key in KEEP}
+
+    # The method and nothing else. The URL holds a screen token, the query
+    # string a login token, the Referer either, the headers the host, and the
+    # body whatever somebody just typed into the settings.
+    method = (event.get("request") or {}).get("method")
+    if method:
+        kept["request"] = {"method": method}
+
+    # The template, never the arguments: "Tick failed for family %s" is about
+    # our code, and the %s is which family.
+    if "logentry" in kept:
+        entry = kept["logentry"] or {}
+        kept["logentry"] = {"message": scrub_text(entry.get("message")
+                                                  or entry.get("formatted") or "")}
+    if "message" in kept:
+        if isinstance(kept["message"], str):
+            kept["message"] = scrub_text(kept["message"])
+        else:
+            del kept["message"]
+
+    # Exception text is written by whoever raised, including libraries that
+    # quote the URL they failed on. The frames are our own source, which is
+    # public; their local variables are not, and are off at the SDK too.
+    for value in (kept.get("exception") or {}).get("values") or []:
+        if "value" in value:
+            value["value"] = scrub_text(value["value"])
+        for frame in (value.get("stacktrace") or {}).get("frames") or []:
+            frame.pop("vars", None)
+
+    return kept
+
+
+def scrub_text(text):
+    """Free text with every URL, token, address and family id taken out."""
+    if not isinstance(text, str):
+        return text
+    text = _A_URL.sub(REDACTED, text)
+    text = _A_TOKEN.sub(r"\g<1>" + REDACTED, text)
+    text = _A_SCREEN.sub(r"\g<1>" + REDACTED, text)
+    text = _AN_ADDRESS.sub(REDACTED, text)
+    return _AN_ID.sub(REDACTED, text)

--- a/doc/operations.md
+++ b/doc/operations.md
@@ -575,3 +575,85 @@ new container; the one that died is under `--type run_restarted`. The health pro
 10 s on a ~2 ms cadence, so a probe that lands late is the cheap sign that a request was CPU-bound
 just then. There is still no memory graph outside the dashboard's Insights tab, and no alert on
 restarts.
+
+## Sentry and the deploy alert, 11 September 2026 (DIN-35, DIN-54)
+
+**Two in-house monitors were built and dropped.** Draft PR #97 pinged a heartbeat URL after each
+pass; draft PR #108 (branch `caspar/health-check-audit`, commit `4d65b38`) wrote a `worker_heartbeat`
+row, served it at `/healthz/worker`, and polled it from a GitHub Actions cron with `monitor.py` —
+about 1,300 lines to do what a monitoring service does with configuration, and its alert was a
+failed workflow's email, which GitHub switches off after 60 days without a push. The owner called
+it overengineering; Sentry does both halves. #108 is closed; the `db.ready` piece of it is kept.
+#97's restore-drill half (DIN-56) is untouched and still wants merging on its own.
+
+**What runs now.**
+
+- **Error reports** from the web service and the worker go to the `dinkydash` project in the
+  `keepthescore` Sentry org (US region; the org's other projects are KeepTheScore's). The DSN is in
+  `.env` of the main checkout and in the live App Platform spec as the `SENTRY_DSN` secret, never
+  in a commit. What a report may hold is decided in `dinkydash/sentry.py` and asserted on real
+  captured events in `tests/test_sentry.py`; the privacy page and `/settings/account` name Sentry
+  and say what it never sees.
+- **Worker liveness** is a Sentry cron monitor, slug `worker-pass`, created by the worker's own
+  first check-in — one `ok` after each completed pass, with the schedule derived from
+  `DINKYDASH_WORKER_INTERVAL`: 5 minutes, 10 minutes' grace, so the third silent pass opens an
+  issue, and the next check-in closes it. A stop request or a pass that cannot list the families
+  sends nothing. Crons → `worker-pass` is the whole status; `find_monitors` in the Sentry MCP
+  lists it with each environment's last check-in (`get_monitor_details` 404s on the slug).
+- **Uptime** is a Sentry uptime monitor on `https://app.dinkydash.co/login` (id 10299376, one
+  request a minute, down after three failures). **It is disabled**: creating it succeeded, but
+  the org's one included uptime seat is on `keepthescore.com`, and activating a second answers
+  *"You don't have enough pay-as-you-go available to create a new seat"*. Either move the seat or
+  add pay-as-you-go budget; a code change is not involved.
+- **A failed build or deploy** is App Platform's own `DEPLOYMENT_FAILED` alert, now in
+  `.do/app.yaml` and applied. `db.ready` is what makes a wrong `DATABASE_URL` one of those rather
+  than a live deploy that 500s every board.
+- **Alerting inside Sentry** is the project's default rule, *Send a notification for high priority
+  issues* (id 3975564, created with the project on 10 September). Error events at ERROR level,
+  missed cron check-ins and uptime failures are all high priority, so one rule covers the three.
+  The MCP's `find_alert_rules` needs `kind: issue`; `kind: all` is HTTP 410.
+
+**The spec apply.** Done from this branch with the merge snippet in the file's header, after
+diffing `doctl apps spec get` against the committed file (only env order and the platform's own
+`ingress` block differed). Deployment `7abc8538` ("app spec updated", 05:47 UTC) went ACTIVE within
+two minutes — a spec-only change on the code already on `main`, which ignores `SENTRY_DSN` until
+this branch merges. The alert arrived already addressed to the account owner (`doctl apps
+list-alerts` shows one email), so `update-alert-destinations` was not needed.
+
+**The drill, against a local worker and a scratch database, never production.** Scratch Postgres
+17 on this Mac on a private port, migrated by the test fixture, holding no families; the real
+`python -m worker` with `DINKYDASH_WORKER_INTERVAL=60`, `SENTRY_ENVIRONMENT=drill`, the real DSN, a
+fake model key and the spend brake at 0, so nothing but check-ins could leave the machine. Zero
+families still completes a pass. Sentry counts in whole minutes, so the drill monitor expected a
+check-in every minute with two minutes' grace. All times UTC:
+
+| When | What | Sentry said (`drill` environment) |
+|---|---|---|
+| 05:46:08 | worker started; first pass complete in 0.1 s | monitor `worker-pass` created, `ok` |
+| 05:47:08, 05:48:08 | two more passes, two more check-ins | `ok`, last check-in 05:48:08 |
+| 05:48:27 | SIGTERM; "Stop requested … Worker stopped", no check-in | `ok`, still 05:48:08 |
+| 05:49:08, 05:50:08 | two expected check-ins pass with nothing sent | `ok` — inside the grace |
+| 05:51:00 | the third expected check-in is a minute late | issue **DINKYDASH-1**, *Cron failure: worker-pass*, "A missed check-in was detected", environment `drill`, level error; environment `error` |
+| 05:52:34 | worker started again; first pass complete, check-in sent | environment `ok`, last check-in 05:52:34 |
+| 05:53 | — | DINKYDASH-1 **resolved** on its own (`recovery_threshold: 1`) |
+
+What this proves: a stopped worker is an open Sentry issue within one grace period — the default
+project rule emails it — and a restarted one closes the issue on its first pass. The missed
+detection took the three intervals the margin promises (last check-in 05:48:08, issue at 05:51:00).
+
+**How to read it next time.** Crons → `worker-pass` → the `production` environment is the
+worker's pulse; an open *missed check-in* issue is the alert, and it resolves itself on the next
+check-in. `doctl apps logs <id> worker --type run` holds the worker's own "Pass complete" lines.
+A worker that has stopped restarts with `doctl apps restart <id> --components worker`. Running
+anything HTTPS from this venv's Python still needs `SSL_CERT_FILE=$(venv/bin/python -m certifi)`.
+
+**The `drill` environment outlived the drill.** The local worker was stopped for good at 05:53:54,
+so that environment misses its check-ins from then on. The REST call that deletes one environment
+(`DELETE .../monitors/worker-pass/?environment=drill`) answered 403 with the token on this Mac, so
+DINKYDASH-1 was archived for seven days with a note instead, and **the environment wants deleting
+in the UI** — Crons → `worker-pass` → the `drill` row's menu. Until then it shows as failed on the
+monitor page; it never stands in for `production`, which is its own environment with its own
+issue.
+
+**Not done here.** Frontend error capture (DIN-35's third leg): the board and the settings pages
+make no third-party request by design, and a first-party reporting path is separate work.

--- a/requirements-cloud.txt
+++ b/requirements-cloud.txt
@@ -30,3 +30,13 @@ psycopg-pool==3.3.1
 # Cloud only, and imported lazily in `settings.qr_svg`: a Pi has no screen token
 # and must not install a library it can never use.
 segno==1.6.6
+
+# Error reports and the worker's liveness (DIN-35, DIN-54). The one outbound
+# call this app makes that is about *us* rather than about a family, and the
+# reason it is allowed in an app holding other people's calendars is that
+# `dinkydash/sentry.py` decides what a report may hold before it leaves — and
+# `tests/test_sentry.py` captures real events to prove it. Its own
+# dependencies are `urllib3` and `certifi`, both already here under
+# `requests`. Cloud only and imported lazily: with no SENTRY_DSN nothing is
+# initialised, and a Pi never installs it at all.
+sentry-sdk==2.69.1

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -326,3 +326,12 @@ class TestSingleModeHasNoAccount:
     def test_the_settings_home_does_not_offer_one(self, single):
         page = single.test_client().get("/settings/").get_data(as_text=True)
         assert "Your data" not in page
+
+
+class TestWhereItGoes:
+    """The account page says who sees what, beside the buttons (DIN-44)."""
+
+    @pytest.mark.parametrize("who", ["Anthropic", "SendGrid", "Sentry"])
+    def test_it_names(self, parent, who):
+        page = parent.get("/settings/account").get_data(as_text=True)
+        assert who in page

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -513,7 +513,7 @@ def test_hosted_callers_enforce_model_policy_at_the_api(
     assert before["max_tokens"] == stored_tokens
 
     if caller == "worker":
-        assert tick_all(pg_pool) == 1
+        assert tick_all(pg_pool).ticked == 1
     else:
         assert parent.post("/settings/generate").status_code == 302
 

--- a/tests/test_cloud_mode.py
+++ b/tests/test_cloud_mode.py
@@ -140,6 +140,70 @@ def client(pg_pool, pg_family, monkeypatch):
     return client
 
 
+class TestCloudModeWaitsForTheDatabase:
+    """A wrong `DATABASE_URL` used to start cleanly and fail every request.
+
+    The pool opens in the background and only warns, so the process came up,
+    `/healthz` answered, the deploy was declared healthy, and every board then
+    waited thirty seconds and 500'd. Now the process refuses to start, which
+    is a deploy that never goes live while the previous one carries on — and
+    App Platform's DEPLOYMENT_FAILED alert is what says so (DIN-54). Nothing
+    here needs a real database, except the last test, which needs a closed
+    port.
+    """
+
+    @pytest.fixture(autouse=True)
+    def cloud(self, monkeypatch):
+        pytest.importorskip("psycopg_pool")
+        monkeypatch.setenv("DINKYDASH_MODE", "cloud")
+        monkeypatch.setenv("DINKYDASH_SECRET_KEY", "a-real-one")
+        monkeypatch.setenv("DATABASE_URL", "postgresql://nobody:hunter2@127.0.0.1:1/nowhere")
+
+    def test_a_database_that_never_answers_is_a_refusal_to_start(self, monkeypatch):
+        from psycopg_pool import PoolTimeout
+
+        from dinkydash import db
+
+        class NeverReady:
+            def wait(self, timeout):
+                raise PoolTimeout("pool initialization incomplete")
+
+        monkeypatch.setattr(db, "pool", lambda *args, **kwargs: NeverReady())
+        with pytest.raises(RuntimeError, match="DATABASE_URL") as refused:
+            create_app()
+        # The variable's name, never its value: a connection string is a password.
+        assert "hunter2" not in str(refused.value)
+        assert "nowhere" not in str(refused.value)
+
+    def test_a_database_that_answers_lets_it_start(self, monkeypatch):
+        from dinkydash import db
+
+        class Ready:
+            waited = None
+
+            def wait(self, timeout):
+                self.waited = timeout
+
+        pool = Ready()
+        monkeypatch.setattr(db, "pool", lambda *args, **kwargs: pool)
+        app = create_app()
+        assert app.config["POOL"] is pool
+        assert pool.waited == db.STARTUP_TIMEOUT
+
+    def test_the_wait_is_bounded_and_shorter_than_the_probes_patience(self):
+        from dinkydash import db
+
+        assert 0 < db.STARTUP_TIMEOUT <= 15
+
+    def test_the_real_pool_really_does_refuse(self, monkeypatch):
+        """End to end: a real pool against a closed port, with the wait cut short."""
+        from dinkydash import db
+
+        monkeypatch.setattr(db, "STARTUP_TIMEOUT", 0.5)
+        with pytest.raises(RuntimeError, match="DATABASE_URL"):
+            create_app()
+
+
 class TestABoardOutOfPostgres:
     """DIN-31's "done when": a board renders in cloud mode, from rows."""
 

--- a/tests/test_deploy_spec.py
+++ b/tests/test_deploy_spec.py
@@ -1,0 +1,99 @@
+"""What `.do/app.yaml` promises, held against the code (DIN-54).
+
+The spec is reviewed like code, but a spec and a route drift apart in silence:
+the probe path is a string in one file and a decorator in another, and the
+first sign of a mismatch is a deploy that never goes live. Two other files
+already read the spec — `test_auth.py` for the access-log format,
+`test_tenancy.py` for the absence of a family id. This one is for the probe,
+the alert, and the one variable Sentry needs.
+
+* **the probe arrives on the platform's own hostname**, which is in no
+  `domains` block, so it is the *site* that has to answer it;
+* **the board app answers it too**, with no session and no database — the same
+  path on `app.dinkydash.co` must not redirect to `/login`;
+* **the container has time to wait for its database**: `db.ready` holds the
+  process back, and the probe's patience has to outlast it;
+* **a failed deploy is the platform's own alert**, and **the DSN is a secret
+  with no value in the file**, like every other credential here.
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from tests.conftest import client_for
+from web import create_app
+from website.site import create_site_app
+
+REPO = Path(__file__).resolve().parent.parent
+SPEC = REPO / ".do" / "app.yaml"
+PLATFORM_HOST = "clownfish-app-7xt89.ondigitalocean.app"
+
+
+@pytest.fixture(scope="module")
+def spec():
+    return yaml.safe_load(SPEC.read_text())
+
+
+@pytest.fixture(scope="module")
+def probe(spec):
+    (site,) = spec["services"]
+    return site["health_check"]
+
+
+class Exploding:
+    """A pool that fails on any use: the probe must not touch it."""
+
+    def __getattr__(self, name):
+        raise AssertionError(f"the probe touched the pool ({name})")
+
+
+class TestTheProbe:
+    def test_the_site_answers_it_on_the_platforms_own_hostname(self, probe):
+        client = create_site_app().test_client()
+        response = client.get(probe["http_path"], headers={"Host": PLATFORM_HOST})
+        assert response.status_code == 200
+        assert response.get_json()["status"] == "ok"
+
+    def test_the_board_app_answers_it_with_no_session_and_no_database(self, probe, monkeypatch):
+        pytest.importorskip("psycopg")
+        monkeypatch.setenv("DINKYDASH_MODE", "cloud")
+        monkeypatch.setenv("DINKYDASH_SECRET_KEY", "a-real-one")
+        client = client_for(create_app(pool=Exploding()))
+        response = client.get(probe["http_path"])
+        assert response.status_code == 200
+        assert response.get_json()["status"] == "ok"
+
+    def test_it_is_a_path_and_not_a_tcp_check(self, probe):
+        """Without `http_path` App Platform falls back to a TCP check, which a
+        process that binds the port and 500s every request would pass."""
+        assert probe["http_path"].startswith("/")
+
+    def test_the_container_has_time_to_wait_for_its_database(self, probe):
+        """`db.ready` waits before the process comes up; the probe's patience
+        has to outlast it, or a slow-but-healthy database fails every deploy."""
+        db = pytest.importorskip("dinkydash.db")
+        patience = (probe["initial_delay_seconds"]
+                    + probe["period_seconds"] * probe["failure_threshold"])
+        assert patience > db.STARTUP_TIMEOUT
+
+
+class TestWhatWatchesIt:
+    def test_a_failed_deploy_is_the_platforms_own_alert(self, spec):
+        assert {"rule": "DEPLOYMENT_FAILED"} in spec["alerts"]
+
+    def test_the_dsn_is_a_secret_with_no_value_in_the_file(self, spec):
+        envs = {env["key"]: env for env in spec["envs"]}
+        assert envs["SENTRY_DSN"]["type"] == "SECRET"
+        assert "value" not in envs["SENTRY_DSN"]
+
+    def test_no_secret_carries_a_value_and_no_ciphertext_is_committed(self, spec):
+        """`EV[...]` is a production credential encrypted, in a public repo —
+        and `doctl apps spec get` writes exactly that shape, so a round-tripped
+        spec pasted over this file would carry every secret in ciphertext."""
+        components = [c for kind in ("services", "workers", "jobs") for c in spec.get(kind, [])]
+        for env in spec["envs"] + [e for c in components for e in c.get("envs", [])]:
+            if env.get("type") == "SECRET":
+                assert "value" not in env, env["key"]
+            assert not str(env.get("value", "")).startswith("EV["), env["key"]

--- a/tests/test_private_logs.py
+++ b/tests/test_private_logs.py
@@ -103,7 +103,7 @@ def generated_store(tmp_path, monkeypatch):
 def test_real_worker_tick_logs_metadata_without_generated_text(generated_store, caplog):
     with caplog.at_level(logging.INFO):
         assert tick_all(FakePool(["family"]), store_factory=lambda _: generated_store,
-                        budget_factory=FakeBudget) == 1
+                        budget_factory=FakeBudget).ticked == 1
     assert "Board written for" in caplog.text
     assert "123 tokens in, 45 out" in caplog.text
     assert "Private headline marker" not in caplog.text

--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -1,0 +1,327 @@
+"""What reaches Sentry, what must not (DIN-35), and the worker's check-in (DIN-54).
+
+Real events, not a mocked SDK. `sentry_sdk` is initialised with exactly the
+options the app uses, plus a transport that keeps every envelope in a list.
+Then a request carrying every credential the app has is made to raise, and the
+JSON of what *would* have been sent is searched for each one. That is the only
+kind of test that means anything here: a scrubber asserted against a
+hand-built dict would pass on the day the SDK started attaching something new.
+
+The things it must not carry, and where each would ride:
+
+* a **magic-link token** — the query string, and the Referer of the next page;
+* a **screen token** — the URL's path;
+* the **session cookie** and an **Authorization header**;
+* the **request body** — a calendar URL somebody just pasted;
+* the **caller's address**;
+* a **calendar URL** inside an exception message, because `requests` puts the
+  whole URL in every error it raises;
+* a **family id** in a log line's arguments, because "Tick failed for family
+  %s" is about our code and the `%s` is which family.
+
+Skips when sentry-sdk is not installed, which is every self-hosted run.
+"""
+
+import json
+import logging
+
+import pytest
+
+sentry_sdk = pytest.importorskip("sentry_sdk")
+from sentry_sdk.transport import Transport  # noqa: E402
+
+from dinkydash import sentry  # noqa: E402
+from dinkydash.store import FileStore  # noqa: E402
+from tests.conftest import client_for  # noqa: E402
+from web import create_app  # noqa: E402
+
+A_DSN = "https://public@example.invalid/1"
+A_CALENDAR = "https://calendar.google.com/calendar/ical/x/private-3f9c1a7bDEADBEEF/basic.ics"
+A_FAMILY = "b3f2c1a0-1234-4bcd-9ef0-123456789abc"
+
+
+class Recorder(Transport):
+    """A transport that keeps what it is given, so a test can read it."""
+
+    def __init__(self):
+        super().__init__()
+        self.items = []
+
+    def capture_envelope(self, envelope):
+        for item in envelope.items:
+            self.items.append((item.type, item.payload.json))
+
+    def events(self):
+        return [payload for kind, payload in self.items if kind == "event"]
+
+    def check_ins(self):
+        return [payload for kind, payload in self.items if kind == "check_in"]
+
+
+@pytest.fixture
+def recorder(monkeypatch):
+    """The SDK, switched on the way the app switches it on, into a list."""
+    monkeypatch.setenv("SENTRY_DSN", A_DSN)
+    monkeypatch.delenv("SENTRY_ENVIRONMENT", raising=False)
+    monkeypatch.delenv("GIT_SHA", raising=False)
+    monkeypatch.setattr(sentry, "_enabled", False)
+    recorder = Recorder()
+    assert sentry.init("test", transport=recorder) is True
+    yield recorder
+    sentry_sdk.flush()
+    sentry_sdk.get_global_scope().set_client(None)
+
+
+@pytest.fixture
+def app(tmp_path):
+    """A real app with two routes that raise, at the two URL shapes that carry
+    a credential. Single mode: the scrubber does not know the mode, and this
+    keeps the test off Postgres."""
+    (tmp_path / "config.yaml").write_text(
+        'family_name: "The Wilsons"\ntimezone: "Europe/Berlin"\n')
+    app = create_app(FileStore(tmp_path / "config.yaml"))
+
+    @app.route("/s/<token>", methods=["GET", "POST"])
+    def a_screen(token):
+        raise RuntimeError(f"could not fetch {A_CALENDAR}")
+
+    @app.route("/login/link")
+    def a_link():
+        raise RuntimeError("no such token")
+
+    return app
+
+
+def sent(recorder):
+    sentry_sdk.flush()
+    (event,) = recorder.events()
+    return event, json.dumps(event)
+
+
+class TestARequestThatRaises:
+    SECRETS = {
+        "the screen token": "abcdEfghjkmn",
+        "the login token in the query string": "QUERYSECRET",
+        "the login token in the Referer": "REFSECRET",
+        "the session cookie": "COOKIESECRET",
+        "the Authorization header": "AUTHSECRET",
+        "the calendar URL in the exception": "DEADBEEF",
+        "the caller's address": "203.0.113.9",
+        "the hostname": "app.example.test",
+    }
+
+    @pytest.fixture
+    def event(self, app, recorder):
+        """A GET, so the fake session cookie is not a CSRF failure first."""
+        client = client_for(app)
+        with pytest.raises(RuntimeError):
+            client.get(
+                "/s/abcdEfghjkmn?t=QUERYSECRET",
+                headers={"Referer": "https://app.example.test/login/link?t=REFSECRET",
+                         "Cookie": "session=COOKIESECRET",
+                         "Authorization": "Bearer AUTHSECRET",
+                         "X-Forwarded-For": "203.0.113.9",
+                         "DO-Connecting-IP": "203.0.113.9"},
+                base_url="https://app.example.test")
+        return sent(recorder)
+
+    @pytest.mark.parametrize("what", sorted(SECRETS))
+    def test_nothing_that_identifies_the_request_leaves(self, event, what):
+        _, body = event
+        assert self.SECRETS[what] not in body, what
+
+    def test_the_request_is_reduced_to_its_method(self, event):
+        payload, _ = event
+        assert payload["request"] == {"method": "GET"}
+
+    def test_a_form_that_raises_leaves_its_body_and_its_csrf_token_behind(self, app, recorder):
+        """A real signed session, the way a browser posts a settings form: the
+        pasted calendar URL and the CSRF token are both in the request, and
+        neither is in the report."""
+        client = client_for(app)
+        with pytest.raises(RuntimeError):
+            client.post("/s/abcdEfghjkmn",
+                        data={"calendar_url": A_CALENDAR.replace("DEADBEEF", "BODYSECRET")})
+        with client.session_transaction() as stored:
+            csrf = stored["csrf"]
+        payload, body = sent(recorder)
+        assert payload["request"] == {"method": "POST"}
+        assert "BODYSECRET" not in body
+        assert csrf not in body
+
+    def test_the_exception_and_where_it_was_raised_do_leave(self, event):
+        """The report still has to be worth reading."""
+        payload, _ = event
+        (exc,) = payload["exception"]["values"]
+        assert exc["type"] == "RuntimeError"
+        assert exc["value"] == "could not fetch [redacted]"
+        assert exc["stacktrace"]["frames"][-1]["function"] == "a_screen"
+        assert payload["transaction"] == "a_screen"
+        assert payload["tags"]["component"] == "test"
+        assert payload["environment"] == "production"
+
+    def test_no_frame_carries_local_variables(self, event):
+        """A config dict in a local is children's names; a URL in one is a password."""
+        payload, _ = event
+        for value in payload["exception"]["values"]:
+            for frame in value["stacktrace"]["frames"]:
+                assert "vars" not in frame
+
+    def test_the_blocks_that_only_ever_hold_data_are_gone(self, event):
+        payload, _ = event
+        for block in ("user", "breadcrumbs", "extra"):
+            assert block not in payload
+
+
+class TestALogRecord:
+    def test_error_reports_the_template_and_never_the_arguments(self, recorder):
+        try:
+            raise RuntimeError(f"their feed: {A_CALENDAR}")
+        except RuntimeError:
+            logging.getLogger("dinkydash.worker").exception(
+                "Tick failed for family %s; leaving it for the next pass.", A_FAMILY)
+        payload, body = sent(recorder)
+        assert payload["logentry"] == {
+            "message": "Tick failed for family %s; leaving it for the next pass."}
+        assert payload["logger"] == "dinkydash.worker"
+        assert payload["level"] == "error"
+        assert A_FAMILY not in body
+        assert "DEADBEEF" not in body
+
+    def test_an_error_without_an_exception_is_still_a_report(self, recorder):
+        logging.getLogger("dinkydash.mail").error("SendGrid said %s", "ARGUMENTSECRET")
+        payload, body = sent(recorder)
+        assert payload["logentry"] == {"message": "SendGrid said %s"}
+        assert "ARGUMENTSECRET" not in body
+
+    def test_a_warning_stays_in_the_log(self, recorder):
+        """A failed feed is one family's problem, not the platform's."""
+        logging.getLogger("dinkydash.calendars").warning("Feed %s failed: 404", "Dad's")
+        sentry_sdk.flush()
+        assert recorder.events() == []
+
+
+class TestTheTextScrubber:
+    @pytest.mark.parametrize("text, expected", [
+        (f"404 for url: {A_CALENDAR}", "404 for url: [redacted]"),
+        ("webcal://p12-caldav.icloud.com/published/2/abc", "[redacted]"),
+        ("postgresql://user:hunter2@db.example/dinkydash", "[redacted]"),
+        ("GET /login/link?t=abc123&x=1", "GET /login/link?t=[redacted]&x=1"),
+        ("GET /s/abcdEfghjkmn/manifest.webmanifest", "GET /s/[redacted]/manifest.webmanifest"),
+        ("sent to parent@example.com today", "sent to [redacted] today"),
+        (f"family {A_FAMILY} is gone", "family [redacted] is gone"),
+        ("Could not mark expired trials", "Could not mark expired trials"),
+    ])
+    def test_it_takes_out_what_names_a_family_or_opens_a_door(self, text, expected):
+        assert sentry.scrub_text(text) == expected
+
+    def test_it_leaves_anything_that_is_not_text_alone(self):
+        assert sentry.scrub_text(None) is None
+        assert sentry.scrub_text(42) == 42
+
+
+class TestTheCheckIn:
+    """The worker's pulse: a slug, a status and a duration (DIN-54)."""
+
+    def test_it_is_a_slug_a_status_a_duration_and_the_schedule(self, recorder):
+        sentry.check_in(300, 12.5)
+        sentry_sdk.flush()
+        (item,) = recorder.check_ins()
+        assert item["monitor_slug"] == "worker-pass"
+        assert item["status"] == "ok"
+        assert item["duration"] == 12.5
+        assert item["environment"] == "production"
+        assert item["monitor_config"] == {
+            "schedule": {"type": "interval", "value": 5, "unit": "minute"},
+            "checkin_margin": 10,
+            "failure_issue_threshold": 1,
+            "recovery_threshold": 1,
+            "timezone": "UTC",
+        }
+
+    def test_it_carries_nothing_about_anybody(self, recorder):
+        sentry.check_in(300, 1.0)
+        sentry_sdk.flush()
+        (item,) = recorder.check_ins()
+        assert set(item) <= {
+            "type", "monitor_slug", "check_in_id", "status", "duration",
+            "environment", "release", "monitor_config", "event_id", "timestamp",
+            "contexts", "server_name", "sdk", "platform",
+        }
+
+    def test_the_scrubber_lets_it_through_whole(self, recorder):
+        """`before_send` sees check-ins too, and the allow-list would strip the slug."""
+        sentry.check_in(300, 1.0)
+        sentry_sdk.flush()
+        assert recorder.check_ins()[0]["monitor_slug"] == "worker-pass"
+
+    def test_it_is_labelled_with_the_environment_and_release(self, recorder, monkeypatch):
+        monkeypatch.setenv("SENTRY_ENVIRONMENT", "drill")
+        monkeypatch.setenv("GIT_SHA", "abc1234")
+        monkeypatch.setattr(sentry, "_enabled", False)
+        sentry_sdk.get_global_scope().set_client(None)
+        recorder = Recorder()
+        sentry.init("worker", transport=recorder)
+        sentry.check_in(300, 1.0)
+        sentry_sdk.flush()
+        (item,) = recorder.check_ins()
+        assert item["environment"] == "drill"
+        assert item["release"] == "abc1234"
+
+    @pytest.mark.parametrize("seconds, minutes, margin", [
+        (300, 5, 10),   # the default: missed after the third silent pass
+        (900, 15, 30),
+        (60, 1, 2),
+        (5, 1, 2),      # a local drill; Sentry counts in whole minutes
+    ])
+    def test_the_monitor_follows_the_workers_interval(self, seconds, minutes, margin):
+        config = sentry.monitor_config(seconds)
+        assert config["schedule"] == {"type": "interval", "value": minutes, "unit": "minute"}
+        assert config["checkin_margin"] == margin
+
+
+class TestWithoutADsn:
+    """Every self-hosted board, and every test that is not this file."""
+
+    @pytest.fixture(autouse=True)
+    def no_dsn(self, monkeypatch):
+        monkeypatch.delenv("SENTRY_DSN", raising=False)
+        monkeypatch.setattr(sentry, "_enabled", False)
+
+    def test_init_does_nothing_and_says_so(self):
+        assert sentry.init("web") is False
+        assert not sentry_sdk.is_initialized()
+
+    def test_an_empty_dsn_is_no_dsn(self, monkeypatch):
+        monkeypatch.setenv("SENTRY_DSN", "  ")
+        assert sentry.init("web") is False
+
+    def test_a_check_in_is_a_no_op(self):
+        assert sentry.check_in(300, 1.0) is None
+
+
+class TestTheOptions:
+    def test_everything_that_would_carry_data_is_off(self):
+        options = sentry.options(A_DSN)
+        assert options["send_default_pii"] is False
+        assert options["include_local_variables"] is False
+        assert options["max_request_body_size"] == "never"
+        assert options["max_breadcrumbs"] == 0
+        assert options["attach_stacktrace"] is False
+        assert options["auto_session_tracking"] is False
+        assert options["enable_logs"] is False
+        assert options["enable_metrics"] is False
+        assert options.get("traces_sample_rate") is None
+        assert options["before_send"] is sentry.scrub
+
+    def test_only_the_two_named_integrations_are_on(self):
+        """The auto-enabled set includes one that instruments the Anthropic
+        client, which would see the prompt — the whole of a family's day."""
+        options = sentry.options(A_DSN)
+        assert options["auto_enabling_integrations"] is False
+        assert {type(i).__name__ for i in options["integrations"]} == {
+            "FlaskIntegration", "LoggingIntegration"}
+
+    def test_the_environment_defaults_to_production(self):
+        assert sentry.options(A_DSN)["environment"] == "production"
+        assert sentry.options(A_DSN, environment="drill")["environment"] == "drill"

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -337,3 +337,21 @@ class TestCloudflareDoesNotEatShellCommands:
         page = client.get("/getting-started/").get_data(as_text=True)
         assert page.count("<!--email_off-->") == page.count("<!--email_on-->")
         assert page.count("<!--email_off-->") > 1, "one pair per code block"
+
+
+class TestThePrivacyPageNamesEverySubProcessor:
+    """A sub-processor list is a promise that nothing else is called (CLAUDE.md).
+
+    Every service the hosted app sends anything to is on it — including the
+    one that only ever sees an error report (DIN-35).
+    """
+
+    @pytest.mark.parametrize("who", ["Anthropic", "DigitalOcean", "SendGrid",
+                                     "Cloudflare", "Sentry"])
+    def test_it_names(self, client, who):
+        page = client.get("/privacy/").get_data(as_text=True)
+        assert who in page
+
+    def test_it_says_what_sentry_never_sees(self, client):
+        page = client.get("/privacy/").get_data(as_text=True)
+        assert "Sentry sees that something broke" in page

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -3,18 +3,20 @@
 The loop itself is not tested — a `while True` with a sleep in it is not worth
 a fake clock. `tick_all` is, because it holds the decisions: which families are
 walked, what happens when one of them raises, and what reaches a log when it
-does.
+does. `run_pass` is, because it decides what a check-in means (DIN-54).
 
 Nothing here needs Postgres. `tick_all` takes its store factory and its tick
-function as arguments, so the fakes below are the whole test rig.
+function as arguments, and `run_pass` its check-in, so the fakes below are the
+whole test rig.
 """
 
 import logging
 
 import pytest
 
+import worker
 from dinkydash.budget import NoBudget
-from worker import DEFAULT_INTERVAL, Stopping, interval, tick_all
+from worker import DEFAULT_INTERVAL, Pass, Stopping, interval, run_pass, tick_all
 
 
 class FakePool:
@@ -73,10 +75,10 @@ class TestWalkingTheFamilies:
         seen = []
         done = run(["a", "b", "c"], lambda config, store, budget=None: seen.append(store.family_id))
         assert seen == ["a", "b", "c"]
-        assert done == 3
+        assert done == Pass(ticked=3, failed=0)
 
     def test_no_families_is_not_an_error(self):
-        assert run([], lambda config, store, budget=None: None) == 0
+        assert run([], lambda config, store, budget=None: None) == Pass(0, 0)
 
     def test_the_config_comes_from_that_family_s_store(self):
         configs = []
@@ -102,13 +104,13 @@ class TestOneBadFamily:
 
         done = run(["a", "b", "c"], tick)
         assert seen == ["a", "b", "c"]
-        assert done == 2
+        assert done == Pass(ticked=2, failed=1)
 
     def test_every_family_can_fail_without_raising(self):
         def tick(config, store, budget=None):
             raise RuntimeError("everything is down")
 
-        assert run(["a", "b"], tick) == 0
+        assert run(["a", "b"], tick) == Pass(ticked=0, failed=2)
 
     def test_the_failure_log_names_the_id_and_not_the_config(self, caplog):
         """A config holds children's names, and a calendar URL is a password."""
@@ -134,7 +136,7 @@ class TestStopping:
 
         done = run(["a", "b", "c"], tick, stopping=stopping)
         assert seen == ["a"]
-        assert done == 1
+        assert done == Pass(ticked=1, failed=0)
 
     def test_a_fresh_stopping_is_falsey(self):
         assert not Stopping()
@@ -143,6 +145,115 @@ class TestStopping:
         s = Stopping()
         s.request()
         assert s
+
+
+class TestTheCheckIn:
+    """A check-in means a pass finished — not that every family succeeded (DIN-54).
+
+    `run_pass` is the only place that knows whether a pass finished, so it is
+    the only place that checks in. Everything it calls is replaced by a fake
+    that records the order; the pool is any object, because none of the fakes
+    look at it.
+    """
+
+    @pytest.fixture
+    def rig(self, monkeypatch):
+        calls, check_ins = [], []
+        monkeypatch.setenv("DINKYDASH_WORKER_INTERVAL", "300")
+        monkeypatch.setattr("dinkydash.lifecycle.expire_trials",
+                            lambda pool: calls.append("expire") or 0)
+        monkeypatch.setattr(worker, "tick_all",
+                            lambda pool, stopping=None: calls.append("tick") or Pass(2, 1))
+        monkeypatch.setattr(worker, "sweep_logins",
+                            lambda pool: calls.append("sweep") or 0)
+
+        def check_in(every, took):
+            calls.append("check_in")
+            check_ins.append((every, took))
+
+        return calls, check_ins, check_in
+
+    def test_a_completed_pass_checks_in_last_with_the_interval_and_its_duration(self, rig):
+        calls, check_ins, check_in = rig
+        assert run_pass(object(), Stopping(), check_in=check_in) == Pass(2, 1)
+        assert calls == ["expire", "tick", "sweep", "check_in"]
+        ((every, took),) = check_ins
+        assert every == 300
+        assert took >= 0
+
+    def test_a_pass_in_which_every_family_failed_is_still_a_live_worker(self, rig, monkeypatch):
+        """Failed work is a Sentry event of its own; a dead worker is a different thing."""
+        calls, check_ins, check_in = rig
+        monkeypatch.setattr(worker, "tick_all",
+                            lambda pool, stopping=None: calls.append("tick") or Pass(0, 3))
+        assert run_pass(object(), Stopping(), check_in=check_in) == Pass(0, 3)
+        assert len(check_ins) == 1
+
+    def test_an_interrupted_pass_does_not_check_in(self, rig, monkeypatch):
+        """A stop request mid-walk is a redeploy, not a finished pass."""
+        calls, check_ins, check_in = rig
+        stopping = Stopping()
+
+        def interrupted(pool, stopping=None):
+            calls.append("tick")
+            stopping.request()
+            return Pass(1, 0)
+
+        monkeypatch.setattr(worker, "tick_all", interrupted)
+        assert run_pass(object(), stopping, check_in=check_in) is None
+        assert "check_in" not in calls
+        assert check_ins == []
+
+    def test_a_pass_that_cannot_list_the_families_neither_checks_in_nor_raises(
+            self, rig, monkeypatch, caplog):
+        """A dead database is the usual cause. The worker keeps looping, the
+        check-in goes missed, and missed is the alert."""
+        calls, check_ins, check_in = rig
+
+        def dead(pool, stopping=None):
+            calls.append("tick")
+            raise RuntimeError("connection failed")
+
+        monkeypatch.setattr(worker, "tick_all", dead)
+        with caplog.at_level(logging.ERROR):
+            assert run_pass(object(), Stopping(), check_in=check_in) is None
+        assert calls == ["expire", "tick"]
+        assert "next pass" in caplog.text
+
+    def test_a_check_in_that_cannot_be_sent_does_not_stop_the_worker(self, rig, caplog):
+        calls, check_ins, _ = rig
+
+        def broken(every, took):
+            raise RuntimeError("no route to host")
+
+        with caplog.at_level(logging.ERROR):
+            assert run_pass(object(), Stopping(), check_in=broken) == Pass(2, 1)
+        assert "check-in" in caplog.text.lower()
+
+    def test_housekeeping_failing_does_not_stop_the_pass_or_the_check_in(self, rig, monkeypatch):
+        calls, check_ins, check_in = rig
+        monkeypatch.setattr("dinkydash.lifecycle.expire_trials",
+                            lambda pool: (_ for _ in ()).throw(RuntimeError("no")))
+        assert run_pass(object(), Stopping(), check_in=check_in) == Pass(2, 1)
+        assert calls[-1] == "check_in"
+
+    def test_no_stopping_at_all_is_a_pass_that_finishes(self, rig):
+        calls, check_ins, check_in = rig
+        assert run_pass(object(), check_in=check_in) == Pass(2, 1)
+        assert len(check_ins) == 1
+
+    def test_the_real_check_in_is_the_default(self, rig, monkeypatch):
+        calls, check_ins, _ = rig
+        monkeypatch.setattr("dinkydash.sentry.check_in",
+                            lambda every, took: check_ins.append("real"))
+        run_pass(object(), Stopping())
+        assert check_ins == ["real"]
+
+    def test_the_default_check_in_is_a_no_op_without_a_dsn(self, rig, monkeypatch):
+        """No DSN, no network: the pass finishes and nothing is reached for."""
+        monkeypatch.delenv("SENTRY_DSN", raising=False)
+        monkeypatch.setattr("dinkydash.sentry._enabled", False)
+        assert run_pass(object(), Stopping()) == Pass(2, 1)
 
 
 class TestInterval:

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -113,3 +113,21 @@ class TestRefusals:
         monkeypatch.delenv("DINKYDASH_MODE", raising=False)
         with pytest.raises(RuntimeError, match="app.py"):
             create_application()
+
+
+class TestReporting:
+    def test_the_cloud_entry_point_starts_reporting_before_building_either_app(self, monkeypatch):
+        """A container that cannot build its apps should say so somewhere other
+        than a log nobody is reading. No DSN in this test: `init` is replaced."""
+        calls = []
+        monkeypatch.setenv("DINKYDASH_MODE", "cloud")
+        monkeypatch.setenv("DINKYDASH_APP_HOST", "app.example.test")
+        monkeypatch.setattr("dinkydash.sentry.init",
+                            lambda component, **kw: calls.append(("init", component)) or True)
+        monkeypatch.setattr("web.create_app",
+                            lambda *a, **k: calls.append("app") or stub(BOARD))
+        monkeypatch.setattr("website.site.create_site_app",
+                            lambda *a, **k: calls.append("site") or stub(SITE))
+        create_application()
+        assert calls[0] == ("init", "web")
+        assert set(calls[1:]) == {"app", "site"}

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -36,6 +36,9 @@ def create_app(store=None, *, pool=None):
         if pool is None:
             from dinkydash import db
             pool = db.pool()
+            # Refuse to start rather than start and fail every request: a
+            # container that never comes up is a deploy that never goes live.
+            db.ready(pool)
     else:
         if pool is not None:
             raise ValueError("Single mode accepts a store, not a pool.")

--- a/web/templates/settings/account.html
+++ b/web/templates/settings/account.html
@@ -61,6 +61,10 @@
             and the link, never a calendar.
         </div>
         <div class="hint">
+            <strong>Sentry</strong> sees that something broke, and not whose board it was — the
+            line of our code that failed, never a name, a calendar or a written line.
+        </div>
+        <div class="hint">
             The full list is in the <a href="https://dinkydash.co/privacy/">privacy policy</a>.
         </div>
     </div>

--- a/website/content/privacy.md
+++ b/website/content/privacy.md
@@ -5,7 +5,7 @@ template: page.html
 description: What DinkyDash stores, who it is sent to, how long it is kept, and how to get it back or delete it.
 ---
 
-*Last updated: 10 September 2026.*
+*Last updated: 11 September 2026.*
 
 DinkyDash puts a family's day on a screen. That means the things it holds are a
 household's names, dates of birth and movements — which is about as personal as
@@ -43,8 +43,8 @@ Analytics, which is cookieless and collects no personal data.
 
 ## Where it goes
 
-Two things leave our servers, they are different in kind, and it matters which
-is which.
+Three things leave our servers, they are different in kind, and it matters
+which is which.
 
 **Anthropic sees your family's day.** Once each morning the day's agenda — the
 event titles and times, your family's names and interests — is sent to
@@ -55,6 +55,16 @@ models.
 **SendGrid sees who is signing in, and nothing else.** When you ask for a sign-in
 link, your email address and the link go to SendGrid to be delivered. SendGrid
 never sees a calendar, a name or a date of birth.
+
+**Sentry sees that something broke, and not whose board it was.** When the app
+or the background worker hits an error, a report goes to Sentry: which line of
+our code failed, the kind of request it was in, and which version was running.
+Never the page's address, and never a name, a calendar link, an appointment, an
+email address or a written line — those are stripped before the report leaves,
+and a test in the code base fails if they are not. The worker also tells Sentry
+every few minutes that it is still running, which is how we find out when it is
+not, and Sentry checks from outside that the sign-in page answers. Neither
+carries anything about you.
 
 If you would rather Anthropic saw nothing, self-host: the board works with no
 API key at all, and simply goes without the written line.
@@ -67,10 +77,12 @@ API key at all, and simply goes without the written line.
 | **DigitalOcean** | Runs the app and the database | Frankfurt, Germany (US company) |
 | **SendGrid** (Twilio) | Delivers sign-in emails | United States |
 | **Cloudflare** | DNS, and TLS at the edge | Global (US company) |
+| **Sentry** (Functional Software) | Error reports, and the checks that the app and the worker are running | United States |
 
 The app and the database are in **Frankfurt**. DigitalOcean and Cloudflare are
-United States companies operating them, so transfers outside the EU are covered
-by standard contractual clauses.
+United States companies operating them, and SendGrid and Sentry are in the
+United States, so transfers outside the EU are covered by standard contractual
+clauses.
 
 **Google Fonts is not on this list, and that is deliberate.** The typeface is
 served from our own servers, so no page of DinkyDash — not the board, not the

--- a/worker/__init__.py
+++ b/worker/__init__.py
@@ -22,16 +22,29 @@ copied. It is the shared orchestration over config, store and clock, and
 Housekeeping runs once a pass: `sweep_logins` deletes expired magic-link tokens
 and `lifecycle.expire_trials` records ended trials. Account access is also
 checked before each fetch and model call, independently of the sweep.
+
+**Every completed pass checks in with Sentry's cron monitor** (DIN-54,
+`dinkydash/sentry.py`), and `run_pass` is where "completed" is decided: a stop
+request that ended the walk early is not a finished pass, and neither is a
+pass that could not list the families. Both send nothing, so the monitor's
+next expected check-in goes *missed*, and missed is the alert. That is the
+whole of the worker's liveness story. With no `SENTRY_DSN` the check-in is a
+no-op and nothing here has a URL to reach.
 """
 
 import logging
 import os
 import signal
 import time
+from collections import namedtuple
 
 log = logging.getLogger("dinkydash.worker")
 
 DEFAULT_INTERVAL = 300  # five minutes, as PLAN.md's "three clocks" section says
+
+# What a pass did: how many families were ticked without raising, and how many
+# raised. Both are counts of families, never of anything inside one.
+Pass = namedtuple("Pass", "ticked failed")
 
 
 class Stopping:
@@ -79,7 +92,7 @@ def family_ids(pool):
 
 def tick_all(pool, store_factory=None, tick=None, stopping=None,
              budget_factory=None):
-    """Tick every family once. Returns how many were ticked without raising.
+    """Tick every family once. Returns a `Pass`: how many ticked, how many raised.
 
     One family's bad calendar feed, missing config or Anthropic outage must not
     stop the others: a shared worker that dies on the noisiest tenant is a
@@ -101,7 +114,7 @@ def tick_all(pool, store_factory=None, tick=None, stopping=None,
     if tick is None:
         from generate import tick
 
-    done = 0
+    done = failed = 0
     for family_id in family_ids(pool):
         if stopping:
             log.info("Stopping before family %s.", family_id)
@@ -116,7 +129,64 @@ def tick_all(pool, store_factory=None, tick=None, stopping=None,
             # the traceback, which is about our code rather than their data.
             log.exception("Tick failed for family %s; leaving it for the next pass.",
                           family_id)
-    return done
+            failed += 1
+    return Pass(done, failed)
+
+
+def run_pass(pool, stopping=None, check_in=None):
+    """One pass: housekeeping, every family, the sweep — then the check-in.
+
+    Returns the `Pass`, or None when the pass did not finish.
+
+    **The check-in is sent only after a completed pass**, and from here rather
+    than from `tick_all`, because "finished" is decided here. A stop request
+    that ended the walk early is not a finished pass; nor is one that could
+    not list the families, which is the one thing `tick_all` cannot catch per
+    family because there is no family yet — a database that cannot be reached
+    is the usual cause. Both send nothing, so the monitor's next expected
+    check-in goes missed, and missed is the alert (DIN-54). A family whose
+    tick raised is *inside* the pass and is counted in `failed`; the pass
+    still finished, and the failure is a Sentry event of its own.
+
+    A check-in that cannot be sent is logged and otherwise ignored. The boards
+    were written; a pulse that stops the worker is a pulse that kills the
+    patient.
+
+    `check_in` is injectable for the tests; the real one is `sentry.check_in`.
+    """
+    if check_in is None:
+        from dinkydash import sentry
+        check_in = sentry.check_in
+    from dinkydash import lifecycle
+
+    started = time.monotonic()
+    try:
+        expired = lifecycle.expire_trials(pool)
+        if expired:
+            log.info("Ended %s expired trial(s).", expired)
+    except Exception:
+        # Callers still check the deadline themselves if housekeeping fails.
+        log.exception("Could not mark expired trials; retrying next pass.")
+
+    try:
+        result = tick_all(pool, stopping=stopping)
+    except Exception:
+        log.exception("The pass could not list the families; leaving it for the "
+                      "next pass. No check-in.")
+        return None
+    swept = sweep_logins(pool)
+    took = time.monotonic() - started
+    if stopping:
+        log.info("Pass interrupted by a stop request after %.1fs; no check-in.", took)
+        return None
+
+    log.info("Pass complete: %s families ticked, %s failed, in %.1fs; %s dead "
+             "login token(s) deleted.", result.ticked, result.failed, took, swept)
+    try:
+        check_in(interval(), took)
+    except Exception:
+        log.exception("Could not send the check-in; the pass itself finished.")
+    return result
 
 
 def sweep_logins(pool):
@@ -161,7 +231,11 @@ def main():  # pragma: no cover - the loop itself; tick_all is what is tested
         format="%(asctime)s [%(levelname)s] %(message)s",
     )
 
-    from dinkydash import db, lifecycle
+    from dinkydash import db, sentry
+
+    # Before anything that can fail: a worker that cannot reach its database
+    # is exactly the report worth having. A no-op without SENTRY_DSN.
+    sentry.init("worker")
 
     stopping = Stopping()
     signal.signal(signal.SIGTERM, stopping.request)
@@ -172,18 +246,7 @@ def main():  # pragma: no cover - the loop itself; tick_all is what is tested
     log.info("Worker started; a pass every %s seconds.", every)
 
     while not stopping:
-        started = time.monotonic()
-        try:
-            expired = lifecycle.expire_trials(pool)
-            if expired:
-                log.info("Ended %s expired trial(s).", expired)
-        except Exception:
-            # Callers still check the deadline themselves if housekeeping fails.
-            log.exception("Could not mark expired trials; retrying next pass.")
-        ticked = tick_all(pool, stopping=stopping)
-        swept = sweep_logins(pool)
-        log.info("Pass complete: %s families ticked in %.1fs; %s dead login "
-                 "token(s) deleted.", ticked, time.monotonic() - started, swept)
+        run_pass(pool, stopping)
 
         # Sleep in slices so SIGTERM is noticed in seconds rather than minutes.
         # App Platform kills a container that ignores it for too long, and

--- a/wsgi.py
+++ b/wsgi.py
@@ -87,8 +87,13 @@ def create_application():
             "wsgi.py is the cloud entry point. Single mode runs app.py."
         )
 
+    from dinkydash import sentry
     from web import create_app
     from website.site import create_site_app
+
+    # First, so that a container that cannot build its apps says so somewhere
+    # other than a log nobody is reading. A no-op without SENTRY_DSN.
+    sentry.init("web")
 
     return dispatch(create_site_app(), create_app(), _board_host())
 


### PR DESCRIPTION
## Summary

Replaces the in-house monitor (draft PR #108: a `worker_heartbeat` table, `/healthz/worker`, `monitor.py`, an admin pill and a GitHub Actions cron — about 1,300 lines) with Sentry, which does both halves of DIN-54 with configuration, and lands DIN-35's error reporting on the same code.

- **`dinkydash/sentry.py`** (cloud only, lazy import, nothing initialised without `SENTRY_DSN`): `init` from `wsgi.py` and `worker.main`; unhandled request exceptions and `log.exception` become events; `check_in` sends one `ok` check-in per completed worker pass to the cron monitor `worker-pass`, with the schedule derived from `DINKYDASH_WORKER_INTERVAL` (5 min, 10 min grace: the third silent pass alerts).
- **`scrub` is `before_send` and is an allow-list.** The request is reduced to its method — with PII off the SDK was observed to keep the URL (a screen token), the query string (a login token) and the Referer. The log line is reduced to its template, never its arguments ("Tick failed for family %s"). Free text is scrubbed of URLs, tokens, addresses and UUIDs; local variables and breadcrumbs are off at the SDK and dropped again here. `tests/test_sentry.py` captures real events through an in-process transport and asserts each absence.
- **`worker.run_pass`** decides "completed": a stop request or a failure to list the families sends nothing. `tick_all` returns `Pass(ticked, failed)`.
- **`db.ready`** (the one piece kept from #108): a wrong `DATABASE_URL` is a container that never becomes healthy, so the previous release keeps serving — and App Platform's own **`DEPLOYMENT_FAILED`** alert, now in `.do/app.yaml`, is the message.
- **Privacy page and `/settings/account`** name Sentry as a sub-processor and say what it never sees, in the same change as the code.
- `sentry-sdk==2.69.1` in `requirements-cloud.txt` only; a Pi never installs it.

## Already done outside the repo

- The spec was applied on 11 September 2026 (deployment `7abc8538`, ACTIVE): `SENTRY_DSN` is set, the `DEPLOYMENT_FAILED` alert exists and is addressed to the account owner.
- Cron monitor `worker-pass` exists in `keepthescore/dinkydash`, created by a local drill worker in a `drill` environment. Stop-and-recover drill record in `doc/operations.md`.
- Uptime monitor on `https://app.dinkydash.co/login` (id 10299376) exists but is **disabled**: the org's one uptime seat is on keepthescore.com. Activating it is a billing decision.

## After the merge

`deploy_on_push` ships the code; the worker's first production pass creates the `production` environment on the cron monitor and resets its schedule to 5 minutes. Check `Crons → worker-pass` shows it.

## Test plan

- [x] `venv/bin/python -m pytest tests/ -q` (self-hoster: 867 passed, 345 skipped)
- [x] the same with `DINKYDASH_TEST_DATABASE_URL` against a scratch Postgres 17 (1212 passed)
- [x] a real `sentry_sdk` event captured in-process from a request carrying a screen token, a login token in the query string and the Referer, a cookie, an Authorization header, a forwarded address and a calendar URL in the exception — none reaches the payload
- [x] a local worker checked in, was stopped, went missed, was restarted and recovered (`doc/operations.md`)

Closes DIN-54. Frontend error capture stays open on DIN-35.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
