### PR TITLE
Start dashboard and website together in Conductor

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -1,7 +1,8 @@
 "$schema" = "https://conductor.build/schemas/settings.repo.schema.json"
 
 [scripts]
-run_mode = "concurrent"
+# Copied .env files may select the same database across workspaces.
+run_mode = "nonconcurrent"
 
 # requirements-cloud.txt is the superset — it pulls in requirements-site.txt,
 # which pulls in requirements.txt — so this one line installs psycopg, the
@@ -21,66 +22,12 @@ venv/bin/pip install -q -r requirements-cloud.txt
 venv/bin/python sample_board.py
 """
 
-# The preview URL, and the only web server Conductor starts. **Always cloud
-# mode**: development is on the hosted product, so the preview is the hosted
-# product. `DINKYDASH_MODE` is the whole difference — `create_app` reads it to
-# choose PostgresStore over FileStore — and it is set unconditionally here
-# rather than sniffed from the environment, because a preview that silently
-# falls back to config.yaml is how you end up debugging the wrong board.
-#
-# It refuses to start without a database, and says why. That is the right
-# failure: a fallback would be indistinguishable from success.
-#
-# **It opens on /login, because the board is one family's board and cloud mode
-# reads which family from the session.** `login_link.py` prints a working link
-# without waiting on email — the same token the email would carry, minted by
-# the same code. The script above prints the exact command with this
-# workspace's port already in it.
-#
-# **Chrome or Firefox, not Safari.** The session cookie is `Secure` in cloud
-# mode, and Safari has no loopback exception for that — it silently drops the
-# cookie over `http://localhost`, so signing in fails and looks like a broken
-# form rather than a cookie policy. `web/CLAUDE.md` has the table.
-#
-# Export DATABASE_URL to select a scratch database. Explicit environment values
-# take precedence over .env defaults; with no override, the file selects the
-# database, which may be production. The connection string is never printed.
-#
-# Single mode still matters and still has to work; it is just not what the
-# preview shows. To look at it:
-#     DINKYDASH_MODE=single FLASK_APP=app.py venv/bin/flask run --port 5050
-[scripts.run.dashboard]
-available_in = [ "local" ]
-command = """
-venv/bin/python - <<'PY'
-import os
-import sys
-from dotenv import load_dotenv
-
-load_dotenv('.env', override=False)
-if not os.environ.get('DATABASE_URL'):
-    sys.exit('Cloud mode needs DATABASE_URL in the environment or .env. '
-             'Use Files to copy for this gitignored file.')
-os.environ['DINKYDASH_MODE'] = 'cloud'
-os.environ['FLASK_APP'] = 'app.py'
-port = os.environ.get('CONDUCTOR_PORT') or '5000'
-print('The board is behind a sign-in. For a link without waiting on email:')
-print(f'  venv/bin/python login_link.py you@example.com --base-url http://127.0.0.1:{port}')
-print('Use Chrome or Firefox; Safari will not send a Secure cookie over http://localhost.', flush=True)
-os.execv('venv/bin/flask', ['flask', 'run', '--port', port, '--debug'])
-PY
-"""
+# Both Flask apps, supervised together. Configuration and database checks live
+# in dev.py so the same command works in a terminal outside Conductor.
+[scripts.run.dev]
+command = "venv/bin/python dev.py"
 default = true
-icon = "cloud"
-
-# The marketing site, on the second of the ten ports this workspace owns.
-# Hardcoding 5001 would collide the moment two workspaces ran at once.
-# DINKYDASH_APP_URL points its "Start your free trial" buttons at the
-# dashboard above rather than at production, which is where they go by default.
-[scripts.run.website]
-available_in = [ "local" ]
-command = "DINKYDASH_APP_URL=http://127.0.0.1:${CONDUCTOR_PORT:-5000} FLASK_APP=website.site venv/bin/flask run --port $((${CONDUCTOR_PORT:-5000} + 1))"
-icon = "book-open"
+icon = "play"
 
 [scripts.run.generate]
 command = "venv/bin/python generate.py"

--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,7 @@
 # Copy to .env and fill in. .env is gitignored and must never be committed.
 #
-# Nothing in the app reads FLASK_ENV, SECRET_KEY, DATABASE_URL or UPLOAD_FOLDER;
-# the session key comes from DINKYDASH_SECRET_KEY in the environment, not from
-# here.
+# Self-hosted mode does not use FLASK_ENV, SECRET_KEY, DATABASE_URL or
+# UPLOAD_FOLDER. Hosted settings and local development are described below.
 #
 # Get a key at https://console.anthropic.com/settings/keys. It is used once a
 # day, for the headline and the one written line. Everything else on the board
@@ -14,6 +13,14 @@ ANTHROPIC_API_KEY=
 # Cloud mode only. A self-hoster needs none of the below and can stop here:
 # one family on its own network has no logins to mail and no database.
 # ---------------------------------------------------------------------------
+
+# Local hosted development: `venv/bin/python dev.py` starts both web apps.
+# Select a development database, apply migrations explicitly, and set a session
+# key below. See doc/development.md. The launcher never runs migrations itself.
+# DATABASE_URL=postgresql:///dinkydash_dev
+# Outside Conductor (which supplies CONDUCTOR_PORT and CONDUCTOR_PORT + 1):
+# DINKYDASH_PORT=5000
+# DINKYDASH_WEBSITE_PORT=5001
 
 # Signs the session cookie. In cloud mode the session *is* the login, so the
 # app refuses to start without one. Generate with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -395,7 +395,16 @@ python generate.py --date 2026-12-24  # any date, for testing
 decides where `dashboard_data.json` and `content_history.json` live, so a scratch config keeps its
 generated files beside it.
 
-**Run the app**
+**Run the hosted dashboard and marketing site together**
+```bash
+venv/bin/python dev.py              # also Conductor's default dev run action
+```
+Requires a development `DATABASE_URL` with migrations applied and a
+`DINKYDASH_SECRET_KEY`. See [doc/development.md](doc/development.md) for setup,
+port overrides, sign-in and Conductor configuration pickup. Both processes stop
+together; the launcher always selects cloud mode and refuses invalid setup.
+
+**Run the self-hosted app**
 ```bash
 python app.py                       # or: flask run --host=0.0.0.0
 ```

--- a/README.md
+++ b/README.md
@@ -108,6 +108,14 @@ the whole Raspberry Pi build with systemd, kiosk mode and the screen schedule.
 The install and Pi guides live on the website rather than here, so there is one copy of each
 to keep right.
 
+## Local hosted development
+
+Conductor's **dev** run action starts the hosted dashboard and marketing website
+together. The same command outside Conductor is `venv/bin/python dev.py`.
+See [local development](doc/development.md) for the required development database
+and session key, ports, sign-in, and how Conductor picks up the run configuration.
+The self-hosted quickstart above is unchanged.
+
 ## Running the tests
 
 ```bash

--- a/dev.py
+++ b/dev.py
@@ -1,0 +1,186 @@
+"""Run the hosted dashboard and marketing site together for local development.
+
+Uses two spawned processes in the launcher's process group. No reloader or
+debugger subprocesses: restart the run action after changing Python/content.
+Production uses wsgi.py; a self-hosted Pi continues to use app.py.
+"""
+
+import logging
+import multiprocessing
+import os
+from pathlib import Path
+import signal
+import sys
+import time
+
+ROOT = Path(__file__).resolve().parent
+HOST = "127.0.0.1"
+START_TIMEOUT = 15
+STOP_TIMEOUT = 5
+
+
+def configure():
+    from dotenv import load_dotenv
+
+    load_dotenv(ROOT / ".env", override=False)
+    for name in ("DATABASE_URL", "DINKYDASH_SECRET_KEY"):
+        if not os.environ.get(name, "").strip():
+            raise RuntimeError(f"{name} is required; set it in the environment or .env.")
+    from web import SELF_HOSTED_KEY
+
+    if os.environ["DINKYDASH_SECRET_KEY"] == SELF_HOSTED_KEY:
+        raise RuntimeError("DINKYDASH_SECRET_KEY must be a private development key.")
+
+    def port(name, default):
+        try:
+            value = int(os.environ.get(name, default))
+            if 1 <= value <= 65535:
+                return value
+        except ValueError:
+            pass
+        raise RuntimeError(f"{name} must be an integer between 1 and 65535.")
+
+    if "CONDUCTOR_PORT" in os.environ:
+        dashboard = port("CONDUCTOR_PORT", 5000)
+        website = dashboard + 1
+    else:
+        dashboard = port("DINKYDASH_PORT", 5000)
+        website = port("DINKYDASH_WEBSITE_PORT", dashboard + 1)
+    if website > 65535 or website == dashboard:
+        raise RuntimeError("Dashboard and website need distinct ports between 1 and 65535.")
+
+    os.environ.update(
+        DINKYDASH_MODE="cloud",
+        DINKYDASH_APP_URL=f"http://{HOST}:{dashboard}",
+        # Let dashboard URLs use the local request host, not a production .env value.
+        DINKYDASH_APP_HOST="",
+    )
+    return {"Dashboard": dashboard, "Website": website}
+
+
+def validate_database():
+    """Read-only check: reachable database with all repository migrations applied."""
+    from dinkydash import db
+    from psycopg.conninfo import make_conninfo
+
+    try:
+        conninfo = make_conninfo(os.environ["DATABASE_URL"], connect_timeout=5)
+        with db.connect(conninfo) as conn:
+            conn.execute("SET statement_timeout = '5s'")
+            conn.execute("SET default_transaction_read_only = on")
+            applied = {row[0] for row in conn.execute("SELECT name FROM schema_migrations")}
+    except Exception as exc:
+        # Driver exceptions can contain credentials or connection details.
+        raise RuntimeError(
+            f"Database validation failed ({type(exc).__name__}). Check DATABASE_URL "
+            "and apply migrations to your development database with migrate.py."
+        ) from None
+    if any(path.name not in applied for path in db.migrations()):
+        raise RuntimeError("Database migrations are missing; run migrate.py on your development database.")
+
+
+def serve(name, port, ready):
+    """Signal readiness only after the real app has initialized and bound its port."""
+    signal.signal(signal.SIGINT, signal.SIG_IGN)  # the supervisor handles Ctrl-C
+    logging.basicConfig(level=logging.INFO, format=f"[{name}] %(message)s")
+    pool = None
+    try:
+        from werkzeug.serving import make_server
+
+        if name == "Dashboard":
+            from web import create_app
+
+            app = create_app()
+            pool = app.config["POOL"]
+            pool.wait(timeout=5)
+        else:
+            from website.site import create_site_app
+
+            app = create_site_app()
+        with make_server(HOST, port, app, threaded=True) as server:
+            ready.send(True)
+            ready.close()
+            server.serve_forever()
+    except (Exception, SystemExit) as exc:
+        print(f"{name} failed to start or serve on port {port} ({type(exc).__name__}).",
+              file=sys.stderr, flush=True)
+        raise SystemExit(1) from None
+    finally:
+        ready.close()
+        if pool is not None:
+            pool.close()
+
+
+def supervise(ports):
+    context = multiprocessing.get_context("spawn")
+    children = []
+    stopping = False
+
+    def stop(signum, frame):
+        nonlocal stopping
+        stopping = True
+
+    previous = {sig: signal.signal(sig, stop) for sig in (signal.SIGINT, signal.SIGTERM)}
+    try:
+        for name, port in ports.items():
+            if stopping:
+                return 0
+            reader, writer = context.Pipe(duplex=False)
+            process = context.Process(target=serve, args=(name, port, writer), name=name)
+            process.start()
+            writer.close()
+            children.append((name, process, reader))
+            print(f"Starting {name} (PID {process.pid}) on port {port}.", flush=True)
+
+        pending = {name for name, _, _ in children}
+        deadline = time.monotonic() + START_TIMEOUT
+        while not stopping:
+            for name, process, reader in children:
+                if process.exitcode is not None:
+                    raise RuntimeError(f"{name} exited unexpectedly (status {process.exitcode}); stopping both apps.")
+                if name in pending and reader.poll():
+                    try:
+                        reader.recv()
+                    except EOFError:
+                        raise RuntimeError(f"{name} failed during startup; stopping both apps.") from None
+                    pending.remove(name)
+                    if not pending:
+                        print(f"Dashboard: http://{HOST}:{ports['Dashboard']}/login", flush=True)
+                        print(f"Website:   http://{HOST}:{ports['Website']}/", flush=True)
+                        print("Use Chrome or Firefox for local sign-in (Secure cookies). "
+                              "Restart this command after code/content changes. Ctrl-C stops both apps.", flush=True)
+            if pending and time.monotonic() >= deadline:
+                raise RuntimeError(f"Startup timed out: {', '.join(sorted(pending))}; stopping both apps.")
+            time.sleep(0.1)
+        return 0
+    finally:
+        for _, process, reader in children:
+            reader.close()
+            if process.is_alive():
+                process.terminate()
+        deadline = time.monotonic() + STOP_TIMEOUT
+        for _, process, _ in children:
+            process.join(max(0, deadline - time.monotonic()))
+            if process.is_alive():
+                process.kill()
+                process.join()
+        for sig, handler in previous.items():
+            signal.signal(sig, handler)
+
+
+def main():
+    try:
+        ports = configure()
+        validate_database()
+        return supervise(ports)
+    except ImportError as exc:
+        print(f"Development dependency missing ({exc.name}); install requirements-cloud.txt.", file=sys.stderr)
+    except (RuntimeError, OSError) as exc:
+        print(f"Development startup failed: {exc}", file=sys.stderr)
+    except KeyboardInterrupt:
+        return 0
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/doc/development.md
+++ b/doc/development.md
@@ -1,0 +1,74 @@
+# Local hosted development
+
+From the repository root, install the existing dependencies and prepare a local
+Postgres database (Postgres must already be running):
+
+```bash
+python3 -m venv venv
+venv/bin/pip install -r requirements-dev.txt -r requirements-cloud.txt
+createdb dinkydash_dev
+export DATABASE_URL=postgresql:///dinkydash_dev
+export DINKYDASH_SECRET_KEY="$(venv/bin/python -c 'import secrets; print(secrets.token_hex(32))')"
+venv/bin/python migrate.py --database-url "$DATABASE_URL"
+venv/bin/python dev.py
+```
+
+Use a separate database name for each workspace. For Conductor's Run action, put
+the development `DATABASE_URL` and `DINKYDASH_SECRET_KEY` in the workspace's
+gitignored `.env`, or supply them in the run environment. A terminal export alone
+does not change Conductor's environment. Explicit environment values override
+`.env`; inspect which database you selected before migrating or signing in.
+The launcher never applies migrations or creates sample accounts.
+
+The single **dev** run action starts both existing Flask apps:
+
+| App | In Conductor | Outside Conductor |
+|---|---|---|
+| Hosted dashboard | `CONDUCTOR_PORT` | `DINKYDASH_PORT`, default `5000` |
+| Marketing website | `CONDUCTOR_PORT + 1` | `DINKYDASH_WEBSITE_PORT`, default dashboard port + 1 |
+
+Both bind to `127.0.0.1`. The launcher prints labeled URLs after both servers
+have initialized and bound their ports. `CONDUCTOR_PORT` takes precedence over
+both port overrides; an empty, invalid, out-of-range or conflicting port fails.
+For example, outside Conductor:
+
+```bash
+DINKYDASH_PORT=5100 DINKYDASH_WEBSITE_PORT=5101 venv/bin/python dev.py
+```
+
+The dashboard always runs in cloud mode. A missing database URL, missing session
+key, unreachable database or unapplied migration fails startup; it never falls
+back to the self-hosted board. Website login and trial/signup links, including
+those in Markdown pages, open this local dashboard's `/login`. The launcher
+overrides `DINKYDASH_APP_URL` and clears the production `DINKYDASH_APP_HOST` for
+its child processes.
+
+Stop the Conductor run action or press Ctrl-C to stop both servers. If either
+cannot start, times out during startup, or exits unexpectedly (even with status
+zero), the launcher stops the other and exits with an error. Restart the run
+action after Python, template or Markdown changes; there is no automatic reloader
+or interactive debugger.
+
+Use Chrome or Firefox for local sign-in. Hosted sessions retain their Secure
+cookie policy; Safari does not support this HTTP loopback workflow. Email delivery
+requires `SENDGRID_API_KEY`. For an existing account in your development database,
+you can instead mint a link without email (substitute the printed dashboard port):
+
+```bash
+venv/bin/python login_link.py you@example.com \
+  --database-url "$DATABASE_URL" --base-url http://127.0.0.1:5000
+```
+
+Neither an email key nor an Anthropic key is required to start the servers.
+Generation still requires an Anthropic key when you request it.
+
+Conductor reads shared `.conductor/settings.toml` from the remote default branch.
+Merge the configuration into `main` for the shared run action to take effect.
+Until then, run `venv/bin/python dev.py` in this workspace's terminal or set that
+command as a repository-local run override. Higher-precedence Conductor settings
+can override the shared action. Runs are nonconcurrent because copied `.env`
+files can share a database; only enable concurrent runs when every workspace has
+its own database as well as its allocated ports.
+
+Production still uses `wsgi.py` to route the two apps by hostname. Self-hosted
+Raspberry Pis still use `app.py` / `run_app.sh` and need only `requirements.txt`.

--- a/tests/test_conductor.py
+++ b/tests/test_conductor.py
@@ -1,18 +1,24 @@
-"""Run the configured preview command with invented environment values."""
+"""Conductor delegates to the same validated launcher used in a terminal."""
 
-import json
 import os
 from pathlib import Path
-import shlex
-import subprocess
-import sys
 import tomllib
 
 import pytest
 
+import dev
+
 ROOT = Path(__file__).resolve().parents[1]
 FILE_URL = 'postgresql:///invented_file_database'
 SCRATCH_URL = 'postgresql:///invented_scratch_database'
+
+
+def test_one_default_run_starts_both_apps():
+    settings = tomllib.loads((ROOT / '.conductor/settings.toml').read_text())
+    runs = settings['scripts']['run']
+    assert runs['dev']['command'] == 'venv/bin/python dev.py'
+    assert runs['dev']['default'] is True
+    assert 'dashboard' not in runs and 'website' not in runs
 
 
 @pytest.mark.parametrize('exported,file_value,expected', [
@@ -23,38 +29,40 @@ SCRATCH_URL = 'postgresql:///invented_scratch_database'
     ('', FILE_URL, None),
 ])
 def test_preview_preserves_explicit_environment_and_never_prints_the_database(
-        tmp_path, exported, file_value, expected):
+        tmp_path, monkeypatch, capsys, exported, file_value, expected):
     if file_value is not None:
         (tmp_path / '.env').write_text(f'DATABASE_URL="{file_value}"\nDINKYDASH_MODE=single\n')
-    executables = tmp_path / 'venv/bin'
-    executables.mkdir(parents=True)
-    python = executables / 'python'
-    python.write_text(f'#!/bin/sh\nexec {shlex.quote(sys.executable)} "$@"\n')
-    python.chmod(0o755)
-    flask = executables / 'flask'
-    flask.write_text(f'#!{sys.executable}\n' + '''import json, os, pathlib, sys
-pathlib.Path('captured.json').write_text(json.dumps({
-    'database': os.environ['DATABASE_URL'], 'mode': os.environ['DINKYDASH_MODE'],
-    'app': os.environ['FLASK_APP'], 'args': sys.argv[1:]}))
-''')
-    flask.chmod(0o755)
-    env = {key: value for key, value in os.environ.items()
-           if key not in {'DATABASE_URL', 'DATABASE_URL_DIRECT', 'DINKYDASH_MODE'}}
-    env['CONDUCTOR_PORT'] = '5123'
+    for key in ('DATABASE_URL', 'DINKYDASH_MODE', 'DINKYDASH_APP_URL', 'DINKYDASH_APP_HOST'):
+        # Record absent keys too, so configure's environment changes are undone.
+        monkeypatch.setenv(key, '')
+        monkeypatch.delenv(key)
+    monkeypatch.setenv('DINKYDASH_SECRET_KEY', 'development-test-key')
+    monkeypatch.setenv('CONDUCTOR_PORT', '5123')
     if exported is not None:
-        env['DATABASE_URL'] = exported
-    settings = tomllib.loads((ROOT / '.conductor/settings.toml').read_text())
-    command = settings['scripts']['run']['dashboard']['command']
-    result = subprocess.run(['sh', '-c', command], cwd=tmp_path, env=env,
-                            text=True, capture_output=True, timeout=10)
-    assert FILE_URL not in result.stdout + result.stderr
-    assert SCRATCH_URL not in result.stdout + result.stderr
+        monkeypatch.setenv('DATABASE_URL', exported)
+    monkeypatch.setattr(dev, 'ROOT', tmp_path)
+    captured = {}
+
+    def validate():
+        captured['database'] = os.environ['DATABASE_URL']
+
+    def supervise(ports):
+        captured.update(mode=os.environ['DINKYDASH_MODE'], ports=ports)
+        return 0
+
+    monkeypatch.setattr(dev, 'validate_database', validate)
+    monkeypatch.setattr(dev, 'supervise', supervise)
+    result = dev.main()
+    output = capsys.readouterr()
+    assert FILE_URL not in output.out + output.err
+    assert SCRATCH_URL not in output.out + output.err
     if expected is None:
-        assert result.returncode != 0
-        assert 'Cloud mode needs DATABASE_URL' in result.stderr
-        assert not (tmp_path / 'captured.json').exists()
+        assert result != 0
+        assert 'DATABASE_URL is required' in output.err
+        assert not captured
     else:
-        assert result.returncode == 0, result.stderr
-        assert json.loads((tmp_path / 'captured.json').read_text()) == {
-            'database': expected, 'mode': 'cloud', 'app': 'app.py',
-            'args': ['run', '--port', '5123', '--debug']}
+        assert result == 0, output.err
+        assert captured == {
+            'database': expected, 'mode': 'cloud',
+            'ports': {'Dashboard': 5123, 'Website': 5124},
+        }

--- a/tests/test_dev.py
+++ b/tests/test_dev.py
@@ -1,0 +1,240 @@
+"""Exercise the real two-process launcher against the opt-in scratch database."""
+
+import os
+from pathlib import Path
+import re
+import signal
+import socket
+import subprocess
+import sys
+import time
+from urllib.request import urlopen
+
+import pytest
+
+import dev
+
+
+@pytest.fixture(autouse=True)
+def isolated_config(monkeypatch, tmp_path):
+    monkeypatch.setattr(dev, "ROOT", tmp_path)
+    for name in ("CONDUCTOR_PORT", "DINKYDASH_PORT", "DINKYDASH_WEBSITE_PORT"):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv("DATABASE_URL", "")
+    monkeypatch.setenv("DINKYDASH_SECRET_KEY", "development-test-key")
+    # configure() changes these for its children; restore them after unit tests.
+    monkeypatch.setenv("DINKYDASH_MODE", "single")
+    monkeypatch.setenv("DINKYDASH_APP_URL", "https://app.example.test")
+    monkeypatch.setenv("DINKYDASH_APP_HOST", "app.example.test")
+    monkeypatch.setenv("SENDGRID_API_KEY", "")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "")
+
+
+def test_dotenv_defaults_and_environment_precedence(monkeypatch, tmp_path):
+    (tmp_path / ".env").write_text("DATABASE_URL=postgresql:///example\nDINKYDASH_PORT=5200\n")
+    monkeypatch.delenv("DATABASE_URL")
+    monkeypatch.setenv("DINKYDASH_PORT", "5300")
+    monkeypatch.setenv("DINKYDASH_MODE", "single")
+    monkeypatch.setenv("DINKYDASH_APP_URL", "https://app.example.test")
+    assert dev.configure() == {"Dashboard": 5300, "Website": 5301}
+    assert os.environ["DINKYDASH_MODE"] == "cloud"
+    assert os.environ["DINKYDASH_APP_URL"] == "http://127.0.0.1:5300"
+
+
+@pytest.mark.parametrize("values, expected", [
+    ({}, (5000, 5001)),
+    ({"DINKYDASH_PORT": "5100", "DINKYDASH_WEBSITE_PORT": "5200"}, (5100, 5200)),
+    ({"CONDUCTOR_PORT": "5400", "DINKYDASH_PORT": "bad", "DINKYDASH_WEBSITE_PORT": "bad"}, (5400, 5401)),
+])
+def test_ports(monkeypatch, values, expected):
+    monkeypatch.setenv("DATABASE_URL", "postgresql:///example")
+    for name, value in values.items():
+        monkeypatch.setenv(name, value)
+    assert tuple(dev.configure().values()) == expected
+
+
+@pytest.mark.parametrize("values, error", [
+    ({"DATABASE_URL": " "}, "DATABASE_URL"),
+    ({"DINKYDASH_SECRET_KEY": ""}, "DINKYDASH_SECRET_KEY"),
+    ({"DINKYDASH_SECRET_KEY": "dinkydash-self-hosted"}, "private development key"),
+    ({"CONDUCTOR_PORT": ""}, "CONDUCTOR_PORT"),
+    ({"CONDUCTOR_PORT": "abc"}, "CONDUCTOR_PORT"),
+    ({"CONDUCTOR_PORT": "0"}, "CONDUCTOR_PORT"),
+    ({"CONDUCTOR_PORT": "65535"}, "distinct ports"),
+    ({"DINKYDASH_PORT": "65535"}, "DINKYDASH_WEBSITE_PORT"),
+    ({"DINKYDASH_WEBSITE_PORT": "5000"}, "distinct ports"),
+    ({"DINKYDASH_WEBSITE_PORT": "65536"}, "DINKYDASH_WEBSITE_PORT"),
+])
+def test_invalid_configuration(monkeypatch, values, error):
+    monkeypatch.setenv("DATABASE_URL", "postgresql:///example")
+    for name, value in values.items():
+        monkeypatch.setenv(name, value)
+    with pytest.raises(RuntimeError, match=error):
+        dev.configure()
+
+
+@pytest.fixture
+def ports():
+    for _ in range(100):
+        with socket.socket() as first, socket.socket() as second:
+            first.bind((dev.HOST, 0))
+            port = first.getsockname()[1]
+            if port == 65535:
+                continue
+            try:
+                second.bind((dev.HOST, port + 1))
+            except OSError:
+                continue
+            return port, port + 1
+    pytest.fail("Could not allocate adjacent test ports")
+
+
+@pytest.fixture
+def launch(tmp_path):
+    processes = []
+
+    def start(extra):
+        log = tmp_path / f"run-{len(processes)}.log"
+        with log.open("w") as output:
+            process = subprocess.Popen(
+                [sys.executable, "dev.py"], cwd=Path(__file__).resolve().parents[1],
+                env={**os.environ, **extra}, stdout=output, stderr=subprocess.STDOUT,
+                start_new_session=True,
+            )
+        processes.append(process)
+        return process, log
+
+    yield start
+    for process in processes:
+        if process.poll() is None:
+            process.terminate()
+            process.wait(timeout=10)
+        # Also clean up orphans if a lifecycle assertion failed.
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+
+
+def wait_ready(process, log):
+    deadline = time.monotonic() + 20
+    while time.monotonic() < deadline:
+        text = log.read_text()
+        assert process.poll() is None, text
+        if "Website:   http://" in text:
+            return
+        time.sleep(0.05)
+    pytest.fail(log.read_text())
+
+
+def assert_stopped(ports, log):
+    for pid in re.findall(r"Starting \w+ \(PID (\d+)\)", log.read_text()):
+        with pytest.raises(ProcessLookupError):
+            os.kill(int(pid), 0)
+    for port in ports:
+        with socket.socket() as probe:
+            assert probe.connect_ex((dev.HOST, port)) != 0
+
+
+@pytest.mark.parametrize("shutdown", [signal.SIGINT, signal.SIGTERM])
+def test_start_links_and_shutdown(pg_pool, ports, launch, shutdown):
+    dashboard, website = ports
+    process, log = launch({
+        "DATABASE_URL": os.environ["DINKYDASH_TEST_DATABASE_URL"],
+        "CONDUCTOR_PORT": str(dashboard),
+        "DINKYDASH_MODE": "single",
+        "DINKYDASH_APP_URL": "https://app.example.test",
+    })
+    wait_ready(process, log)
+    assert f"Dashboard: http://127.0.0.1:{dashboard}/login" in log.read_text()
+    # Both the homepage templates and Markdown links must lead to this run.
+    for path in ("/", "/about/", "/ipad-calendar-display/"):
+        with urlopen(f"http://{dev.HOST}:{website}{path}") as response:
+            body = response.read().decode()
+        assert f'href="http://{dev.HOST}:{dashboard}/login"' in body, path
+        assert 'href="https://app.dinkydash.co/login"' not in body
+    with urlopen(f"http://{dev.HOST}:{dashboard}/") as response:
+        assert response.url.endswith("/login")  # cloud auth, never single mode
+        assert response.status == 200
+    if shutdown == signal.SIGTERM:
+        os.killpg(process.pid, shutdown)  # Conductor can stop the whole group
+    else:
+        process.send_signal(shutdown)  # stopping only the supervisor works too
+    assert process.wait(timeout=10) == 0, log.read_text()
+    assert_stopped(ports, log)
+
+
+@pytest.mark.parametrize("failed", ["Dashboard", "Website"])
+def test_unexpected_exit_stops_sibling(pg_pool, ports, launch, failed):
+    process, log = launch({
+        "DATABASE_URL": os.environ["DINKYDASH_TEST_DATABASE_URL"],
+        "DINKYDASH_PORT": str(ports[0]), "DINKYDASH_WEBSITE_PORT": str(ports[1]),
+    })
+    wait_ready(process, log)
+    pid = int(re.search(rf"Starting {failed} \(PID (\d+)\)", log.read_text())[1])
+    os.kill(pid, signal.SIGKILL)
+    assert process.wait(timeout=10) == 1
+    assert f"{failed} exited unexpectedly" in log.read_text()
+    assert_stopped(ports, log)
+
+
+@pytest.mark.parametrize("occupied", [0, 1])
+def test_port_conflict_stops_both(pg_pool, ports, launch, occupied):
+    with socket.socket() as blocker:
+        blocker.bind((dev.HOST, ports[occupied]))
+        blocker.listen()
+        process, log = launch({
+            "DATABASE_URL": os.environ["DINKYDASH_TEST_DATABASE_URL"],
+            "CONDUCTOR_PORT": str(ports[0]),
+        })
+        assert process.wait(timeout=20) == 1
+        assert ("Dashboard", "Website")[occupied] in log.read_text()
+        assert "Website:   http://" not in log.read_text()
+    assert_stopped(ports, log)
+
+
+def test_missing_config_starts_neither(launch):
+    process, log = launch({"DATABASE_URL": ""})
+    assert process.wait(timeout=10) == 1
+    assert "DATABASE_URL is required" in log.read_text()
+    assert "Starting " not in log.read_text()
+
+
+def test_unreachable_database_starts_neither(ports, launch):
+    process, log = launch({"DATABASE_URL": f"postgresql://127.0.0.1:{ports[0]}/missing"})
+    assert process.wait(timeout=10) == 1
+    assert "Database validation failed" in log.read_text()
+    assert "Starting " not in log.read_text()
+
+
+def test_unmigrated_database_starts_neither(pg_pool, launch):
+    from psycopg.conninfo import make_conninfo
+
+    url = make_conninfo(os.environ["DINKYDASH_TEST_DATABASE_URL"],
+                        options="-csearch_path=missing_schema")
+    process, log = launch({"DATABASE_URL": url})
+    assert process.wait(timeout=10) == 1
+    assert "Database validation failed" in log.read_text()
+    assert "Starting " not in log.read_text()
+
+
+def lifecycle_worker(name, port, ready):
+    """Real child processes for lifecycle cases a healthy Flask server won't cause."""
+    if port:
+        ready.send(True)
+    if port == 1:
+        return  # even status zero is unexpected for a long-running server
+    while True:
+        time.sleep(0.1)
+
+
+@pytest.mark.parametrize("ports, error", [
+    ({"Dashboard": 1, "Website": 2}, "Dashboard exited unexpectedly \\(status 0\\)"),
+    ({"Dashboard": 0, "Website": 0}, "Startup timed out"),
+])
+def test_early_exit_and_timeout_reap_children(monkeypatch, ports, error):
+    monkeypatch.setattr(dev, "serve", lifecycle_worker)
+    monkeypatch.setattr(dev, "START_TIMEOUT", 2)
+    with pytest.raises(RuntimeError, match=error):
+        dev.supervise(ports)
+    assert not dev.multiprocessing.active_children()

--- a/website/README.md
+++ b/website/README.md
@@ -68,6 +68,13 @@ pip install -r ../requirements-site.txt
 
 ### Running it
 
+For website and hosted dashboard development together, use Conductor's **dev**
+action or `venv/bin/python dev.py` from the repository root. It points all login
+and signup links at the local dashboard. See [local development](../doc/development.md)
+for database setup, port overrides and shutdown behavior.
+
+To serve only the marketing site:
+
 ```bash
 cd ..
 FLASK_APP=website.site flask run --port 5001


### PR DESCRIPTION
Replace separate Conductor runs with one `dev.py` action that starts the hosted dashboard on `CONDUCTOR_PORT` and the website on the next port, prints labeled URLs, and directs website login/signup links to the local dashboard.

The launcher validates configuration and database migrations, supports standalone port overrides, and stops both processes on shutdown, startup failure, or unexpected exit without adding dependencies or changing production hostname routing and Raspberry Pi entry points.

Update development documentation, environment examples, and Conductor settings, including nonconcurrent runs for potentially shared databases, explicit restart instructions instead of automatic reload, and the requirement to merge shared settings into remote `main` before Conductor picks them up.

Verified startup, link destinations, failure handling, and shutdown against isolated local Postgres: 1,169 tests passed; without a database, 820 passed and 349 skipped; production data was untouched.
