### PR TITLE
Fix annual dates, chore ordering and settings accessibility

### DIFF
--- a/dinkydash/context.py
+++ b/dinkydash/context.py
@@ -65,9 +65,18 @@ def compute_birthday_info(person, today):
     }
 
 
+def parse_monthday(value):
+    """Validate an annual MM/DD date, using a leap year to allow 29 February."""
+    month, day = (int(part) for part in str(value).split("/"))
+    if not (1 <= month <= 12 and 1 <= day <= 31):
+        raise ValueError("Month or day is out of range")
+    return date(2000, month, day)
+
+
 def compute_special_date_info(special_date, today):
     """Return countdown info for one recurring special date (MM/DD)."""
-    month, day = [int(part) for part in str(special_date["date"]).split("/")]
+    annual = parse_monthday(special_date["date"])
+    month, day = annual.month, annual.day
     target = anniversary(today.year, month, day)
     if target < today:
         # Recompute from month/day rather than bumping the year: a Feb 28 that
@@ -127,7 +136,12 @@ def build_countdowns(people, special_dates, today, limit=None):
             "days": info["days_until_birthday"],
         })
     for special_date in special_dates or []:
-        info = compute_special_date_info(special_date, today)
+        try:
+            info = compute_special_date_info(special_date, today)
+        except (ValueError, KeyError):
+            # Old or hand-edited dates stay available for repair in settings;
+            # one invalid entry must not stop every countdown or the daily run.
+            continue
         countdowns.append({
             "emoji": info["emoji"] or "📅",
             "title": info["title"],

--- a/doc/terminology.md
+++ b/doc/terminology.md
@@ -28,7 +28,7 @@ A **calendar** is one source of events, not the whole dashboard.
 | Person / People | A household member | “People”, “Add a person”, “New person”, “Remove this person”. Birth date supplies the age and birthday countdown; names can participate in chores. |
 | Pet / Pets | A household animal | “Pets”, “Add a pet”, “New pet”, “Kind of animal”. A pet can be mentioned in the generated daily note. |
 | Chore / Chores | A household task assigned on a daily rotation | The section is “Chores”. Existing add/edit/remove copy still uses “job”; see the outstanding differences below. There is no completion checkbox. |
-| Rotation order | The sequence of people who take a chore | The editor currently labels participants “Whose turn, in order”; lists use arrows between names. Do not describe these checkboxes as functioning ordering controls: that editor has an open rotation-order defect. |
+| Rotation order | The sequence of people who take a chore | “Whose turn, in order” shows the saved sequence. Checkboxes select people; arrows move them earlier or later. Newly selected people join at the end, and Save keeps the changes. This is separate from reordering People or the chore list. |
 | Whose turn | The current chore assignments | The dashboard section heading. Turns change daily; this is not task completion or an on-demand swap feature. |
 | Calendar / Calendars | A connected source of events | “Calendars”, “Calendar name”, “Add a calendar”, “Save calendar”. Multiple enabled calendars merge into the agenda. The name is for recognising the source in settings. |
 | Calendar link | The calendar provider's iCal/ICS subscription address | Field label: “Calendar link (iCal / ICS)”. HTTPS and `webcal://` are accepted; a provider's ordinary webpage or sharing page is not necessarily a calendar feed. |
@@ -37,7 +37,7 @@ A **calendar** is one source of events, not the whole dashboard.
 | Agenda | The combined event list | The dashboard labels it “Today” and, when there is room, “Tomorrow”. It is assembled from calendars; it is not AI-generated. |
 | Headline | The large heading on the dashboard | Normally generated with the daily note. A stale dashboard can use a computed headline instead. |
 | Daily note | The short generated text accompanying the agenda | Also called the “daily line” or “day's line” in current copy. Interests, pets and the agenda inform it. “Brief” is used internally for the generated headline and note together. |
-| Special date / Special dates | A named annual occasion | “Special dates”, “Add a date”, “What is it”, “Date”. Day and month repeat every year; this is not a one-off calendar event. |
+| Special date / Special dates | A named annual occasion | “Special dates”, “Add a date”, “What is it”, with “Day” and “Month” under “Date”. Lists use named months, such as “1 July”. Invalid stored dates are flagged for repair and omitted from countdowns; 29 February is allowed. |
 | Countdown | Days remaining until a birthday or special date | Appears under “Coming up”. Birthday countdowns come from People and need no duplicate special-date entry. |
 | Refresh calendars | Fetch the latest events from enabled calendars | Updates the agenda; it does not rewrite the daily note. “Fetch the calendars” sets this interval under “How often it updates”. |
 | Rewrite now | Generate a fresh headline and daily note | Also fetches calendars first. Before the first generation the action is “Write the first dashboard”. “Write the daily line at” sets the daily generation time. |

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -186,7 +186,7 @@ class TestDeleting:
 
 
 class TestReordering:
-    """Chore rotation follows list order, so moving a job has to be exact."""
+    """Moving a chore changes its display position, not its participant rotation."""
 
     def test_moving_down_swaps_with_the_next_one(self, client, config_path):
         client.get("/settings/recurring")

--- a/tests/test_settings_improvements.py
+++ b/tests/test_settings_improvements.py
@@ -1,0 +1,228 @@
+"""Date recovery, rotation integrity and accessible form errors in both modes."""
+
+from copy import deepcopy
+from datetime import date
+from html.parser import HTMLParser
+
+import pytest
+from werkzeug.datastructures import MultiDict
+
+from dinkydash import config as config_module
+from dinkydash.context import build_countdowns, compute_chore_assignments
+from dinkydash.store import FileStore
+from tests.conftest import board_path, client_for
+from web import create_app
+
+CONFIG = {
+    "family_name": "The Wilsons", "timezone": "Europe/Berlin",
+    "people": [
+        {"id": "averyaaa", "name": "Avery", "date_of_birth": "1990-03-15"},
+        {"id": "rileyaaa", "name": "Riley", "date_of_birth": "1992-06-20"},
+        {"id": "jordanaa", "name": "Jordan", "date_of_birth": "1994-07-21"},
+    ],
+    "recurring": [
+        {"id": "tableaaa", "title": "Set the table", "choices": ["Riley", "Avery"]},
+        {"id": "plantsaa", "title": "Water the plants", "choices": ["Avery", "Riley"]},
+    ],
+    "special_dates": [{"id": "holidaya", "title": "Camping", "date": "07/01"}],
+    "calendars": [],
+}
+
+
+class Form(HTMLParser):
+    """Read the controls a browser would submit, without assuming their order."""
+
+    def __init__(self, html):
+        super().__init__()
+        self.elements = []
+        self.feed(html)
+
+    def handle_starttag(self, tag, attrs):
+        self.elements.append((tag, dict(attrs)))
+
+    def controls(self, **attributes):
+        return [attrs for tag, attrs in self.elements
+                if tag in ("input", "select", "textarea", "fieldset", "button")
+                and all(attrs.get(k) == v for k, v in attributes.items())]
+
+    def checked_people(self):
+        return [x['value'] for x in self.controls(name='choices') if 'checked' in x]
+
+
+@pytest.fixture(params=['file', 'postgres'])
+def household(request, tmp_path, monkeypatch):
+    if request.param == 'file':
+        monkeypatch.setenv('DINKYDASH_MODE', 'single')
+        store = FileStore(tmp_path / 'config.yaml')
+        app = create_app(store)
+        client = client_for(app)
+        dashboard = '/'
+    else:
+        from dinkydash.pgstore import PostgresStore
+        pool = request.getfixturevalue('pg_pool')
+        family = request.getfixturevalue('pg_family')
+        store = PostgresStore(pool, family)
+        with pool.connection() as conn, conn.transaction():
+            user = conn.execute('INSERT INTO users (family_id, email) VALUES (%s, %s) RETURNING id',
+                                (family, 'ux-test@example.com')).fetchone()[0]
+        monkeypatch.setenv('DINKYDASH_MODE', 'cloud')
+        monkeypatch.setenv('DINKYDASH_SECRET_KEY', 'isolated-test-key')
+        client = client_for(create_app(pool=pool))
+        with client.session_transaction() as session:
+            session['family_id'] = str(family)
+            session['user_id'] = user
+        dashboard = board_path(pool, family)
+    config = config_module.with_defaults(deepcopy(CONFIG))
+    store.save_config(config)
+    today = config_module.today_for(config).isoformat()
+    store.save_brief(config, {'generated_for_date': today, 'headline': 'A good day', 'note': 'Hello.'})
+    return client, store, dashboard
+
+
+@pytest.mark.parametrize('item_id', ['new', 'holidaya'])
+@pytest.mark.parametrize('month,day', [('2', '31'), ('4', '31'), ('13', '1'), ('0', '1'),
+                                      ('2', ''), ('', '1'), ('oops', '3'), ('2', '0'),
+                                      ('2.5', '3'), ('9' * 100, '1')])
+def test_invalid_annual_dates_are_not_saved(household, item_id, month, day):
+    client, store, dashboard = household
+    before = store.load_config()['special_dates']
+    page = client.post(f'/settings/special_dates/{item_id}',
+                       data={'title': 'Keep this title', 'date_month': month, 'date_day': day})
+    assert page.status_code == 200
+    html = page.get_data(as_text=True)
+    assert 'Choose a valid day and month' in html
+    assert 'Keep this title' in html
+    form = Form(html)
+    for part in ('day', 'month'):
+        control = form.controls(id=f'f-date-{part}')[0]
+        assert control['aria-invalid'] == 'true'
+        assert 'error-date' in control['aria-describedby'].split()
+    assert store.load_config()['special_dates'] == before
+    assert client.get(dashboard).status_code == 200
+
+
+@pytest.mark.parametrize('month,day,display', [('2', '29', '29 February'), ('2', '28', '28 February'),
+                                             ('4', '30', '30 April'), ('12', '31', '31 December')])
+def test_valid_dates_save_and_use_named_months(household, month, day, display):
+    client, store, dashboard = household
+    response = client.post('/settings/special_dates/holidaya',
+                           data={'title': 'Camping', 'date_month': month, 'date_day': day})
+    assert response.status_code == 302
+    assert store.load_config()['special_dates'][0]['date'] == f'{int(month):02}/{int(day):02}'
+    assert display in client.get('/settings/special_dates').get_data(as_text=True)
+    assert client.get(dashboard).status_code == 200
+
+
+@pytest.mark.parametrize('value', ['02/31', '04/31', 'nonsense', None, '99/99', '2/3/4'])
+def test_bad_stored_date_is_repairable_without_breaking_dashboard(household, value):
+    client, store, dashboard = household
+    config = store.load_config()
+    config['special_dates'][0]['date'] = value
+    store.save_config(config)
+    assert client.get(dashboard).status_code == 200
+    html = client.get('/settings/special_dates').get_data(as_text=True)
+    assert 'Check this date' in html
+    assert client.get('/settings/special_dates/holidaya').status_code == 200
+    assert store.load_config()['special_dates'][0]['date'] == value
+    assert client.post('/settings/special_dates/holidaya',
+                       data={'title': 'Camping', 'date_month': '7', 'date_day': '1'}).status_code == 302
+    assert '1 July' in client.get('/settings/special_dates').get_data(as_text=True)
+
+
+def test_invalid_countdown_does_not_hide_other_dates_or_coerce_leap_day():
+    dates = [{'title': 'Invalid', 'date': '02/31'}, {'title': 'Leap day', 'date': '02/29'},
+             {'title': 'Camping', 'date': '03/01'}]
+    assert build_countdowns([], dates, date(2027, 2, 28)) == [
+        {'emoji': '📅', 'title': 'Leap day', 'days': 0},
+        {'emoji': '📅', 'title': 'Camping', 'days': 1},
+    ]
+    assert build_countdowns([], dates, date(2028, 2, 28))[0]['days'] == 1
+
+
+def test_unchanged_and_cosmetic_chore_edits_keep_each_rotation(household):
+    client, store, _ = household
+    config = store.load_config()
+    today = config_module.today_for(config)
+    before = compute_chore_assignments(config['recurring'], today)
+    # Rendering after the People list moves must still follow each chore's own order.
+    client.post('/settings/people/averyaaa/move', data={'direction': 'down'})
+    for chore in config['recurring']:
+        url = '/settings/recurring/' + chore['id']
+        html = client.get(url).get_data(as_text=True)
+        posted_choices = Form(html).checked_people()
+        assert posted_choices == chore['choices']
+        data = MultiDict([('title', chore['title']), ('emoji', '🌱')]
+                         + [('choices', p) for p in posted_choices])
+        assert client.post(url, data=data).status_code == 302
+    after = store.load_config()['recurring']
+    assert [c['choices'] for c in after] == [c['choices'] for c in config['recurring']]
+    assert [c['assigned_to'] for c in compute_chore_assignments(after, today)] == [c['assigned_to'] for c in before]
+
+
+def test_reordering_a_draft_keeps_other_fields_and_only_save_persists(household):
+    client, store, _ = household
+    url = '/settings/recurring/tableaaa'
+    draft = MultiDict([('title', 'New title'), ('choices', 'Riley'), ('choices', 'Avery'),
+                      ('choices', 'Jordan'), ('move_choice', 'up:Jordan')])
+    html = client.post(url, data=draft).get_data(as_text=True)
+    assert Form(html).checked_people() == ['Riley', 'Jordan', 'Avery']
+    assert Form(html).controls(name='title')[0]['value'] == 'New title'
+    assert store.load_config()['recurring'][0]['choices'] == ['Riley', 'Avery']
+    assert store.load_config()['recurring'][0]['title'] == 'Set the table'
+    # Save the explicit new order while removing Riley.
+    data = MultiDict([('title', 'New title'), ('choices', 'Jordan'), ('choices', 'Avery')])
+    assert client.post(url, data=data).status_code == 302
+    assert store.load_config()['recurring'][0]['choices'] == ['Jordan', 'Avery']
+    assert store.load_config()['recurring'][1]['choices'] == ['Avery', 'Riley']
+
+
+def test_no_script_membership_update_is_not_a_save(household):
+    client, store, _ = household
+    data = MultiDict([('title', 'New chore'), ('choices', 'Jordan'), ('action', 'update_choices')])
+    html = client.post('/settings/recurring/new', data=data).get_data(as_text=True)
+    assert Form(html).checked_people() == ['Jordan']
+    assert len(store.load_config()['recurring']) == 2
+
+
+def test_enter_defaults_to_save_not_a_rotation_action(household):
+    client, _, _ = household
+    controls = Form(client.get('/settings/recurring/tableaaa').get_data(as_text=True))
+    first = controls.controls(type='submit')[0]
+    assert (first['name'], first['value']) == ('action', 'save')
+    assert 'disabled' not in first
+
+
+def test_empty_participants_and_bad_email_link_errors_to_controls(household):
+    client, store, _ = household
+    html = client.post('/settings/recurring/tableaaa', data={'title': 'Keep this'}).get_data(as_text=True)
+    assert 'Choose at least one person.' in html
+    for field in Form(html).controls(name='choices'):
+        assert field['aria-invalid'] == 'true'
+        assert 'error-choices' in field['aria-describedby'].split()
+    assert store.load_config()['recurring'][0]['choices'] == ['Riley', 'Avery']
+    html = client.post('/settings/calendars/new', data={
+        'label': 'Family', 'url': 'https://example.com/calendar.ics', 'shared_with': 'bad-address',
+    }).get_data(as_text=True)
+    field = Form(html).controls(name='shared_with')[0]
+    assert field['value'] == 'bad-address'
+    assert field['aria-invalid'] == 'true'
+    assert 'error-shared_with' in field['aria-describedby'].split()
+    assert 'href="#f-shared_with"' in html
+    assert 'id="form-errors" role="alert" tabindex="-1"' in html
+    assert not store.load_config()['calendars']
+
+
+def test_picker_names_and_disabled_list_boundaries(household):
+    client, _, _ = household
+    html = client.get('/settings/people/new').get_data(as_text=True)
+    assert '<legend>Colour</legend>' in html
+    for colour in config_module.AVATAR_COLORS:
+        assert f'<span class="sr-only">{colour.capitalize()}</span>' in html
+    html = client.get('/settings/special_dates/new').get_data(as_text=True)
+    assert '<legend>Date</legend>' in html
+    assert 'for="f-date-day">Day</label>' in html
+    assert 'for="f-date-month">Month</label>' in html
+    controls = Form(client.get('/settings/recurring').get_data(as_text=True)).controls(type='submit')
+    assert 'disabled' in controls[0] and 'disabled' not in controls[1]
+    assert 'disabled' not in controls[2] and 'disabled' in controls[3]
+    assert controls[1]['aria-label'] == 'Move Set the table down'

--- a/web/CLAUDE.md
+++ b/web/CLAUDE.md
@@ -12,6 +12,18 @@ form both render from it, and `parse_field` reads it back. `kind` is one of `tex
 `monthday`, `textarea`, `checkbox`, `emoji`, `color`, `people`, `emails`. A new `kind` needs a
 branch in `parse_field` and a branch in `web/templates/settings/edit.html`; nothing else.
 
+**Validation errors belong to fields.** `validate` maps field names to messages. The editor links
+an error summary to each control or fieldset, focuses the summary, and connects inline errors
+with `aria-describedby` and `aria-invalid`. Grouped controls use legends; date parts and colour
+choices also have individual names. Annual dates validate through `context.parse_monthday`,
+which accepts 29 February but rejects impossible combinations. Invalid stored dates remain
+editable in settings and are omitted from countdowns until repaired.
+
+**A chore owns its participant order.** Render saved choices before unselected people and submit
+them in that order. Reordering People or chores must not change it. The rotation picker moves
+checked inputs in the DOM; without JavaScript, its update/move buttons redisplay the submitted
+draft. Only Save persists it. Keep an initial hidden Save button so Enter still saves.
+
 **`date` means a date of birth, and it is bounded.** The input carries `min` and `max` of
 1900-01-01 and today, and `validate` refuses anything outside them, naming the year it received.
 Both halves are needed: a phone's year wheel scrolls down to the year 1, and a mistyped year

--- a/web/routes/settings.py
+++ b/web/routes/settings.py
@@ -22,7 +22,7 @@ from dinkydash import config as config_module
 from dinkydash import lifecycle, schedule, screens
 from dinkydash.calendars import FeedError, addresses, describe_feed, feed_label
 from dinkydash.claude_client import GenerationError
-from dinkydash.context import compute_birthday_info, upcoming_for
+from dinkydash.context import compute_birthday_info, parse_monthday, upcoming_for
 from dinkydash.runner import refresh_calendars
 from dinkydash.runner import run as run_generation
 from web import CLOUD
@@ -190,9 +190,11 @@ def parse_field(field, form, existing):
     if kind == "monthday":
         month = form.get(f"{name}_month", "").strip()
         day = form.get(f"{name}_day", "").strip()
-        if not (month and day):
-            return existing.get(name, "")
-        return f"{int(month):02d}/{int(day):02d}"
+        try:
+            return f"{int(month):02d}/{int(day):02d}"
+        except ValueError:
+            # Keep incomplete/malformed input for validation and redisplay.
+            return f"{month}/{day}"
     value = form.get(name, "").strip()
     if kind == "date" and value:
         # <input type="date"> already gives YYYY-MM-DD.
@@ -201,34 +203,41 @@ def parse_field(field, form, existing):
 
 
 def validate(section, item, today):
-    """Return a list of human-readable problems with a submitted item.
+    """Return field names mapped to human-readable validation errors.
 
     `today` is the family's own date: a date of birth after it is a typo,
     and so is one before EARLIEST_BIRTH_YEAR. The message names the year the
     form received, because the input itself can show "0017" quite quietly.
     """
-    problems = []
+    problems = {}
     for name, label, kind, required, _help in section["fields"]:
         value = item.get(name)
         if required and not value:
-            problems.append(f"{label} is needed.")
+            problems[name] = ("Choose at least one person." if kind == "people"
+                              else f"{label} is needed.")
         if kind == "date" and value:
             try:
                 dob = datetime.strptime(str(value), "%Y-%m-%d").date()
             except ValueError:
-                problems.append(f"{label} should look like 2017-03-15.")
+                problems[name] = f"{label} should look like 2017-03-15."
             else:
                 if dob.year < EARLIEST_BIRTH_YEAR:
-                    problems.append(f"{label} has the year {dob.year:04d}. "
-                                    f"Check the year and try again.")
+                    problems[name] = (f"{label} has the year {dob.year:04d}. "
+                                      "Check the year and try again.")
                 elif dob > today:
-                    problems.append(f"{label} is in the future. "
-                                    f"Check the year and try again.")
+                    problems[name] = (f"{label} is in the future. "
+                                      "Check the year and try again.")
+        if kind == "monthday":
+            try:
+                parse_monthday(value)
+            except ValueError:
+                problems[name] = "Choose a valid day and month. February can have up to 29 days."
         if kind == "emails":
             for address in value or []:
                 if "@" not in address:
-                    problems.append(f"“{address}” is not an email address. Use the address "
-                                    f"on the invitation, like sam@example.com.")
+                    problems[name] = (f"“{address}” is not an email address. Use the address "
+                                      "on the invitation, like sam@example.com.")
+                    break
     return problems
 
 
@@ -418,6 +427,14 @@ def section_list(section_name):
         extras["birthdays"] = [compute_birthday_info(p, today) for p in items]
     if section_name == "recurring":
         extras["turns"] = [upcoming_for(c, today, days=1) for c in items]
+    if section_name == "special_dates":
+        extras["dates"] = []
+        for item in items:
+            try:
+                display = parse_monthday(item.get("date")).strftime("%-d %B")
+            except ValueError:
+                display = "Check this date — it is not shown on the dashboard"
+            extras["dates"].append(display)
 
     return render_template(
         "settings/list.html", section=section, section_name=section_name,
@@ -443,14 +460,25 @@ def section_edit(section_name, item_id):
         if item is None:
             abort(404)
 
-    problems, checked = [], None
+    problems, checked = {}, None
 
     if request.method == "POST":
         submitted = dict(item)
         for field in section["fields"]:
             submitted[field[0]] = parse_field(field, request.form, item)
 
-        if request.form.get("action") == "check":
+        if section_name == "recurring" and (request.form.get("move_choice")
+                                            or request.form.get("action") == "update_choices"):
+            # No-JavaScript ordering edits the submitted draft, never storage.
+            direction, _, person = request.form.get("move_choice", "").partition(":")
+            choices = submitted["choices"]
+            if person in choices and direction in ("up", "down"):
+                position = choices.index(person)
+                target = position + (-1 if direction == "up" else 1)
+                if 0 <= target < len(choices):
+                    choices[position], choices[target] = choices[target], choices[position]
+            item = submitted
+        elif request.form.get("action") == "check":
             checked = check_feed(submitted, config)
             item = submitted
         else:
@@ -484,13 +512,15 @@ def section_edit(section_name, item_id):
                 return redirect(url_for("settings.section_list", section_name=section_name))
             item = submitted
 
+    selected = item.get("choices") or []
+    participants = list(dict.fromkeys([*selected, *config_module.people_names(config)]))
     return render_template(
         "settings/edit.html", section=section, section_name=section_name,
         item=item, item_id=item_id, is_new=is_new, problems=problems,
         checked=checked, config=config, months=MONTHS,
         date_min=f"{EARLIEST_BIRTH_YEAR}-01-01", date_max=today.isoformat(),
         emoji=EMOJI_SUGGESTIONS.get(section_name, []),
-        colors=config_module.AVATAR_COLORS, people=config_module.people_names(config),
+        colors=config_module.AVATAR_COLORS, people=participants,
     )
 
 
@@ -614,7 +644,7 @@ def section_delete(section_name, item_id):
 
 @bp.route("/<section_name>/<item_id>/move", methods=["POST"])
 def section_move(section_name, item_id):
-    """Reorder within a list — chore rotation order is the reason this exists."""
+    """Reorder displayed items; this does not change a chore's participants."""
     section = section_or_404(section_name)
     config = current_config()
     items = config.get(section["key"]) or []

--- a/web/templates/board.html
+++ b/web/templates/board.html
@@ -36,11 +36,11 @@
             --box: #fff5ec;
             --text: #2d2319;
             --text-mid: #5c4a3a;
-            --text-muted: #9a8677;
-            --text-faint: #c4b3a3;
-            --accent: #e85d24;
+            --text-muted: #786658;
+            --text-faint: #786658;
+            --accent: #b44314;
             --chore-1-bg: rgba(232, 93, 36, 0.1);
-            --chore-1-fg: #c44d1a;
+            --chore-1-fg: #b44314;
             --chore-2-bg: rgba(124, 92, 191, 0.1);
             --chore-2-fg: #6b4fa8;
             --warn-bg: #fdf6e7;
@@ -53,8 +53,8 @@
             --box: #241c17;
             --text: #f6efe7;
             --text-mid: #cbb9a7;
-            --text-muted: #93816f;
-            --text-faint: #6f6053;
+            --text-muted: #9d8a78;
+            --text-faint: #9d8a78;
             --accent: #ff7a45;
             --chore-1-bg: rgba(255, 122, 69, 0.16);
             --chore-1-fg: #ffa477;

--- a/web/templates/settings/_rotation.html
+++ b/web/templates/settings/_rotation.html
@@ -1,0 +1,80 @@
+{% set selected = item.get(name) or [] %}
+{% if people %}
+<div class="rotation-list">
+    {% for person in people %}
+    <div class="rotation-person" data-person="{{ person }}">
+        <span class="rotation-position" aria-hidden="true">{{ (loop.index ~ '.') if person in selected else '—' }}</span>
+        <div class="checkline">
+            <input type="checkbox" id="p-{{ loop.index }}" name="{{ name }}" value="{{ person }}" {{ 'checked' if person in selected }} {{ field_access(name, help) }}>
+            <label for="p-{{ loop.index }}">{{ person }}</label>
+        </div>
+        <div class="move">
+            <button type="submit" name="move_choice" value="up:{{ person }}" formnovalidate
+                    aria-label="Move {{ person }} earlier in the rotation" {{ 'disabled' if person not in selected or loop.first }}>&#9650;</button>
+            <button type="submit" name="move_choice" value="down:{{ person }}" formnovalidate
+                    aria-label="Move {{ person }} later in the rotation" {{ 'disabled' if person not in selected or loop.index == selected | length }}>&#9660;</button>
+        </div>
+    </div>
+    {% endfor %}
+</div>
+<p class="hint">Choose people, then use the arrows to set their turn order. Newly selected people join at the end. Save to keep your changes.</p>
+<div class="sr-only rotation-status" role="status"></div>
+<noscript>
+    <button class="btn outline" type="submit" name="action" value="update_choices" formnovalidate>Update selected people</button>
+    <p class="hint">After changing the selection, update it to enable the ordering arrows. Your changes are kept only when you press Save.</p>
+</noscript>
+<script>
+(() => {
+    const group = document.currentScript.closest('fieldset');
+    const list = group.querySelector('.rotation-list');
+    const rows = () => Array.from(list.children);
+    const chosen = row => row.querySelector('input').checked;
+    const update = () => {
+        const selected = rows().filter(chosen);
+        rows().forEach(row => {
+            const position = selected.indexOf(row);
+            row.querySelector('.rotation-position').textContent = position < 0 ? '—' : `${position + 1}.`;
+            const buttons = row.querySelectorAll('button');
+            buttons[0].disabled = position <= 0;
+            buttons[1].disabled = position < 0 || position === selected.length - 1;
+        });
+    };
+    const announce = row => {
+        const selected = rows().filter(chosen);
+        group.querySelector('.rotation-status').textContent = chosen(row)
+            ? `${row.dataset.person} is position ${selected.indexOf(row) + 1} of ${selected.length}.`
+            : `${row.dataset.person} is no longer in the rotation.`;
+    };
+    list.addEventListener('change', event => {
+        const row = event.target.closest('.rotation-person');
+        if (chosen(row)) {
+            list.insertBefore(row, rows().find(other => !chosen(other)) || null);
+        } else {
+            list.appendChild(row);
+        }
+        update();
+        event.target.focus();
+        announce(row);
+    });
+    list.addEventListener('click', event => {
+        const button = event.target.closest('button');
+        if (!button) return;
+        event.preventDefault();
+        const row = button.closest('.rotation-person');
+        const selected = rows().filter(chosen);
+        const position = selected.indexOf(row);
+        if (button.value.startsWith('up:') && position > 0) {
+            list.insertBefore(row, selected[position - 1]);
+        } else if (position < selected.length - 1) {
+            list.insertBefore(selected[position + 1], row);
+        }
+        update();
+        (button.disabled ? row.querySelector('input') : button).focus();
+        announce(row);
+    });
+    update();
+})();
+</script>
+{% else %}
+<div class="hint">Add someone under People first.</div>
+{% endif %}

--- a/web/templates/settings/base.html
+++ b/web/templates/settings/base.html
@@ -54,10 +54,10 @@
             --border-strong: #e2d7c9;
             --text: #2d2319;
             --text-mid: #5c4a3a;
-            --text-muted: #9a8677;
+            --text-muted: #786658;
             --faint: #c4b3a3;
-            --accent: #e85d24;
-            --accent-dark: #c44d1a;
+            --accent: #b44314;
+            --accent-dark: #94360f;
             --purple: #7c5cbf;
             --green: #16a34a;
             --amber: #d97706;
@@ -197,7 +197,7 @@
         .btn:disabled { opacity: 0.45; cursor: not-allowed; box-shadow: none; }
 
         .field { display: flex; flex-direction: column; gap: 0.375rem; }
-        .field > label { font-size: 0.6875rem; font-weight: 800; letter-spacing: 0.07em; text-transform: uppercase; color: var(--text-muted); }
+        .field > label, .field > legend { font-size: 0.6875rem; font-weight: 800; letter-spacing: 0.07em; text-transform: uppercase; color: var(--text-muted); }
         .field input[type=text], .field input[type=url], .field input[type=date],
         .field input[type=time], .field input[type=email],
         .field select, .field textarea {
@@ -206,6 +206,20 @@
             background: var(--surface); color: var(--text);
             font-family: inherit; font-size: 0.9375rem; font-weight: 600;
         }
+        fieldset.field { border: 0; min-width: 0; }
+        .field > legend { margin-bottom: 0.375rem; }
+        .field-error { color: var(--danger); font-size: 0.8125rem; }
+        .field [aria-invalid="true"] { border-color: var(--danger); }
+        .date-parts { display: grid; grid-template-columns: minmax(0, 2fr) minmax(0, 3fr); gap: 0.625rem; }
+        .date-parts select { padding: 0.75rem 0.375rem; }
+        .sr-only { position: absolute; width: 0.0625rem; height: 0.0625rem; padding: 0; overflow: hidden; clip-path: inset(50%); white-space: nowrap; }
+        .rotation-person { display: flex; align-items: center; gap: 0.5rem; }
+        .rotation-person .checkline { flex: 1; min-width: 0; }
+        .rotation-person label { overflow-wrap: anywhere; }
+        .rotation-person input { flex-shrink: 0; }
+        .rotation-person .move { flex-direction: row; }
+        .rotation-position { font-size: 0.8125rem; color: var(--text-muted); }
+        .rotation-list { display: flex; flex-direction: column; gap: 0.5rem; }
         .field textarea { min-height: 4.75rem; resize: vertical; }
         .field select { cursor: pointer; }
         .field input:not([type=checkbox]):focus, .field select:focus, .field textarea:focus {
@@ -266,6 +280,9 @@
         .flash.ok { background: rgba(22, 163, 74, 0.1); color: #15803d; }
         .flash.error { background: rgba(192, 57, 43, 0.09); color: var(--danger); }
         .problems { background: rgba(192, 57, 43, 0.07); border-radius: 0.875rem; padding: 0.8125rem 0.9375rem; color: var(--danger); font-size: 0.8125rem; }
+        .problems h2 { font-size: 1rem; }
+        .problems a { color: inherit; text-decoration: underline; }
+        .problems, .field, .field input, .field select { scroll-margin-top: 4.5rem; }
         .problems li { margin-left: 1.125rem; }
 
         .dot { width: 0.5rem; height: 0.5rem; border-radius: 50%; flex-shrink: 0; display: inline-block; }
@@ -292,11 +309,13 @@
         .screen-actions .btn { flex: 1; }
         .qr-code { background: #ffffff; border-radius: 0.875rem; padding: 0.75rem; }
         .qr-code svg { display: block; width: 100%; height: auto; }
-        .move { display: flex; flex-direction: column; gap: 0.125rem; position: relative; z-index: 1; }
+        .move { display: flex; flex-direction: column; flex-shrink: 0; gap: 0.375rem; position: relative; z-index: 1; }
         .move button {
-            width: 1.875rem; height: 1.5rem; border: 1px solid var(--border); background: var(--surface);
+            width: 2.75rem; height: 2.75rem; border: 1px solid var(--border); background: var(--surface);
             border-radius: 0.4375rem; cursor: pointer; color: var(--text-muted); font-size: 0.7rem; line-height: 1;
         }
+
+        .move button:disabled { opacity: 0.4; cursor: default; }
 
         /* ---- A pointer, a press, and a keyboard ----
            Hover is for a mouse. On a phone a "hover" is a tap that never ends,
@@ -331,7 +350,7 @@
             .row:has(> a.row-main:hover) { background: var(--warm); }
             .row:has(> a.row-main:hover) .chev { color: var(--text-muted); transform: translateX(0.125rem); }
 
-            .move button:hover { background: var(--warm); border-color: var(--border-strong); color: var(--text); }
+            .move button:not(:disabled):hover { background: var(--warm); border-color: var(--border-strong); color: var(--text); }
             .picker input:not(:checked) + label:hover { background: var(--warm); border-color: var(--border-strong); }
             .picker.colors input:not(:checked) + label:hover { background: transparent; box-shadow: 0 0 0 2px var(--bg), 0 0 0 4px var(--border-strong); }
             .checkline label:hover, .calendar-help summary:hover { color: var(--accent-dark); }
@@ -351,7 +370,7 @@
         .appbar .action:active { background: rgba(232, 93, 36, 0.14); }
         a.row:active { background: var(--border); }
         .row:has(> a.row-main:active) { background: var(--border); }
-        .move button:active { background: var(--border); }
+        .move button:not(:disabled):active { background: var(--border); }
         /* Keyboard focus: one ring throughout, and only from the keyboard —
            :focus-visible never draws for a click. Text inputs keep their own
            cue (the border goes accent, above). The invisible radio behind a

--- a/web/templates/settings/edit.html
+++ b/web/templates/settings/edit.html
@@ -7,9 +7,17 @@
 <h1>{{ ("New " ~ section.singular) if is_new else (item.name or item.title or item.label or section.singular) }}</h1>
 {% endblock %}
 
+{% macro field_access(name, help) -%}
+    {% if help or problems.get(name) %}aria-describedby="{{ ('hint-' ~ name ~ ' ') if help }}{{ ('error-' ~ name) if problems.get(name) }}"{% endif %}
+    {% if problems.get(name) %}aria-invalid="true"{% endif %}
+{%- endmacro %}
+
 {% block content %}
 {% if problems %}
-<div class="problems"><ul>{% for problem in problems %}<li>{{ problem }}</li>{% endfor %}</ul></div>
+<div class="problems" id="form-errors" role="alert" tabindex="-1">
+    <h2>Check these fields</h2>
+    <ul>{% for name, problem in problems.items() %}<li><a href="#f-{{ name }}{{ '-day' if name == 'date' }}">{{ problem }}</a></li>{% endfor %}</ul>
+</div>
 {% endif %}
 
 {% if section_name == 'calendars' %}
@@ -18,23 +26,23 @@
 
 <form id="edit-form" method="post" class="card pad" style="display:flex;flex-direction:column;gap:1rem;">
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-    {% if section_name == 'calendars' %}
-    {# Enter in a field presses the form's first submit button, and on this form the
-       first one a reader meets is "Test calendar link". This unseen one comes ahead
-       of it so that Enter still saves, as it does on every other page. #}
+    {% if section_name in ('calendars', 'recurring') %}
+    {# Enter saves even when calendar testing or rotation controls come before Save. #}
     <button type="submit" name="action" value="save" hidden tabindex="-1"></button>
     {% endif %}
     {% for name, label, kind, required, help in section.fields %}
-    <div class="field">
-        {% if kind != 'checkbox' %}<label for="f-{{ name }}">{{ label }}</label>{% endif %}
+    {% set grouped = kind in ('monthday', 'color', 'emoji', 'people') %}
+    <{{ 'fieldset' if grouped else 'div' }} class="field" {% if grouped %}id="f-{{ name }}" tabindex="-1" {{ field_access(name, help) }}{% endif %}>
+        {% if grouped %}<legend>{{ label }}</legend>
+        {% elif kind != 'checkbox' %}<label for="f-{{ name }}">{{ label }}</label>{% endif %}
 
         {% if kind == 'text' %}
             <input type="text" id="f-{{ name }}" name="{{ name }}" value="{{ item.get(name, '') }}" {{ 'required' if required }}
-                   {% if section_name == 'calendars' and name == 'label' %}placeholder="e.g. Family or School" aria-describedby="hint-{{ name }}"{% endif %}>
+                   {{ field_access(name, help) }} {% if section_name == 'calendars' and name == 'label' %}placeholder="e.g. Family or School"{% endif %}>
 
         {% elif kind == 'url' %}
             <input type="url" id="f-{{ name }}" name="{{ name }}" value="{{ item.get(name, '') }}" {{ 'required' if required }}
-                   placeholder="https://…" autocapitalize="none" autocorrect="off" spellcheck="false" aria-describedby="hint-{{ name }}">
+                   placeholder="https://…" autocapitalize="none" autocorrect="off" spellcheck="false" {{ field_access(name, help) }}>
 
         {% elif kind == 'emails' %}
             {# Stored as a list, typed as one line. A hand-edited file may hold a string; show it as it is. #}
@@ -42,34 +50,48 @@
             <input type="text" id="f-{{ name }}" name="{{ name }}"
                    value="{{ current if current is string else (current or []) | join(', ') }}"
                    inputmode="email" autocapitalize="none" autocorrect="off" spellcheck="false"
-                   placeholder="sam@example.com">
+                   placeholder="sam@example.com" {{ field_access(name, help) }}>
 
         {% elif kind == 'date' %}
             <input type="date" id="f-{{ name }}" name="{{ name }}" value="{{ item.get(name, '') }}"
-                   min="{{ date_min }}" max="{{ date_max }}" {{ 'required' if required }}>
+                   min="{{ date_min }}" max="{{ date_max }}" {{ 'required' if required }} {{ field_access(name, help) }}>
 
         {% elif kind == 'textarea' %}
-            <textarea id="f-{{ name }}" name="{{ name }}">{{ item.get(name, '') }}</textarea>
+            <textarea id="f-{{ name }}" name="{{ name }}" {{ field_access(name, help) }}>{{ item.get(name, '') }}</textarea>
 
         {% elif kind == 'checkbox' %}
             <div class="checkline">
-                <input type="checkbox" id="f-{{ name }}" name="{{ name }}" {{ 'checked' if item.get(name) }}>
+                <input type="checkbox" id="f-{{ name }}" name="{{ name }}" {{ 'checked' if item.get(name) }} {{ field_access(name, help) }}>
                 <label for="f-{{ name }}">{{ label }}</label>
             </div>
 
         {% elif kind == 'monthday' %}
-            {% set parts = (item.get(name) or '/').split('/') %}
-            <div style="display:flex;gap:0.625rem;">
-                <select name="{{ name }}_day" style="flex:0 0 32%;">
-                    {% for day in range(1, 32) %}
-                    <option value="{{ day }}" {{ 'selected' if parts[1] and day == parts[1] | int }}>{{ day }}</option>
-                    {% endfor %}
-                </select>
-                <select name="{{ name }}_month" style="flex:1;">
-                    {% for month in months %}
-                    <option value="{{ loop.index }}" {{ 'selected' if parts[0] and loop.index == parts[0] | int }}>{{ month }}</option>
-                    {% endfor %}
-                </select>
+            {% set parts = (item.get(name, '') | string).split('/') %}
+            {% set selected_month = parts[0] %}
+            {% set selected_day = parts[1] if parts | length > 1 else '' %}
+            {% set valid_day = selected_day.isdigit() and selected_day | int in range(1, 32) %}
+            {% set valid_month = selected_month.isdigit() and selected_month | int in range(1, 13) %}
+            <div class="date-parts">
+                <div class="field">
+                    <label for="f-{{ name }}-day">Day</label>
+                    <select id="f-{{ name }}-day" name="{{ name }}_day" required {{ field_access(name, help) }}>
+                        <option value="">Choose day</option>
+                        {% if selected_day and not valid_day %}<option value="{{ selected_day }}" selected>{{ selected_day }}</option>{% endif %}
+                        {% for day in range(1, 32) %}
+                        <option value="{{ day }}" {{ 'selected' if valid_day and day == selected_day | int }}>{{ day }}</option>
+                        {% endfor %}
+                    </select>
+                </div>
+                <div class="field">
+                    <label for="f-{{ name }}-month">Month</label>
+                    <select id="f-{{ name }}-month" name="{{ name }}_month" required {{ field_access(name, help) }}>
+                        <option value="">Choose month</option>
+                        {% if selected_month and not valid_month %}<option value="{{ selected_month }}" selected>{{ selected_month }}</option>{% endif %}
+                        {% for month in months %}
+                        <option value="{{ loop.index }}" {{ 'selected' if valid_month and loop.index == selected_month | int }}>{{ month }}</option>
+                        {% endfor %}
+                    </select>
+                </div>
             </div>
 
         {% elif kind == 'emoji' %}
@@ -90,30 +112,20 @@
             <div class="picker colors">
                 {% for choice in colors %}
                 <input type="radio" id="c-{{ choice }}" name="{{ name }}" value="{{ choice }}" {{ 'checked' if item.get(name) == choice or (not item.get(name) and loop.first) }}>
-                <label for="c-{{ choice }}"><span class="swatch avatar {{ choice }}"></span></label>
+                <label for="c-{{ choice }}"><span class="swatch avatar {{ choice }}" aria-hidden="true"></span><span class="sr-only">{{ choice | capitalize }}</span></label>
                 {% endfor %}
             </div>
 
         {% elif kind == 'people' %}
-            {% if people %}
-            <div style="display:flex;flex-direction:column;gap:0.5rem;">
-                {% for person in people %}
-                <div class="checkline">
-                    <input type="checkbox" id="p-{{ loop.index }}" name="{{ name }}" value="{{ person }}" {{ 'checked' if person in (item.get(name) or []) }}>
-                    <label for="p-{{ loop.index }}">{{ person }}</label>
-                </div>
-                {% endfor %}
-            </div>
-            {% else %}
-            <div class="hint">Add someone under People first.</div>
-            {% endif %}
+            {% include "settings/_rotation.html" %}
         {% endif %}
 
+        {% if problems.get(name) %}<div class="field-error" id="error-{{ name }}">{{ problems[name] }}</div>{% endif %}
         {% if help %}<div class="hint" id="hint-{{ name }}">{{ help }}</div>{% endif %}
         {% if section_name == 'calendars' and name == 'url' %}
             {% include "settings/_calendar_help.html" %}
         {% endif %}
-    </div>
+    </{{ 'fieldset' if grouped else 'div' }}>
     {% endfor %}
 
     {% if section_name == 'calendars' %}
@@ -137,6 +149,10 @@
 
 {% if section_name == 'calendars' %}
 {% include "settings/_calendar_wait.html" %}
+{% endif %}
+
+{% if problems %}
+<script>document.getElementById('form-errors').focus();</script>
 {% endif %}
 
 {% if checked %}

--- a/web/templates/settings/list.html
+++ b/web/templates/settings/list.html
@@ -29,7 +29,7 @@
                 {% elif section_name == 'recurring' %}
                     {{ item.choices | join(' → ') if item.choices else "Nobody assigned" }}
                 {% elif section_name == 'special_dates' %}
-                    {{ item.date }}
+                    {{ extras.dates[loop.index0] }}
                 {% elif section_name == 'calendars' %}
                     {% if item.shared_with %}
                     Only events shared with {{ item.shared_with if item.shared_with is string else item.shared_with | join(', ') }}
@@ -54,11 +54,11 @@
         <div class="move">
             <form class="inline-form" method="post" action="{{ url_for('settings.section_move', section_name=section_name, item_id=item.id) }}">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                <input type="hidden" name="direction" value="up"><button type="submit" title="Move up">&#9650;</button>
+                <input type="hidden" name="direction" value="up"><button type="submit" title="Move up" aria-label="Move {{ item.name or item.title or item.label }} up" {{ 'disabled' if loop.first }}>&#9650;</button>
             </form>
             <form class="inline-form" method="post" action="{{ url_for('settings.section_move', section_name=section_name, item_id=item.id) }}">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                <input type="hidden" name="direction" value="down"><button type="submit" title="Move down">&#9660;</button>
+                <input type="hidden" name="direction" value="down"><button type="submit" title="Move down" aria-label="Move {{ item.name or item.title or item.label }} down" {{ 'disabled' if loop.last }}>&#9660;</button>
             </form>
         </div>
     </div>

--- a/web/templates/settings/screen.html
+++ b/web/templates/settings/screen.html
@@ -87,10 +87,10 @@
                 {# A miniature of the real dashboard, in that theme's actual palette. #}
                 <div style="height:4rem;border-radius:0.5625rem;padding:0.5625rem 0.625rem;display:flex;flex-direction:column;gap:0.3125rem;
                             {% if theme == 'dark' %}background:#17120f;{% else %}background:#ffffff;border:1px solid #f0e6da;{% endif %}">
-                    <div style="width:2.125rem;height:0.25rem;border-radius:0.125rem;background:{{ '#ff7a45' if theme == 'dark' else '#e85d24' }};"></div>
+                    <div style="width:2.125rem;height:0.25rem;border-radius:0.125rem;background:{{ '#ff7a45' if theme == 'dark' else '#b44314' }};"></div>
                     <div style="width:100%;height:0.5rem;border-radius:0.1875rem;background:{{ '#f6efe7' if theme == 'dark' else '#2d2319' }};"></div>
-                    <div style="width:72%;height:0.3125rem;border-radius:0.1875rem;background:{{ '#6f6053' if theme == 'dark' else '#c4b3a3' }};"></div>
-                    <div style="width:86%;height:0.3125rem;border-radius:0.1875rem;background:{{ '#6f6053' if theme == 'dark' else '#c4b3a3' }};"></div>
+                    <div style="width:72%;height:0.3125rem;border-radius:0.1875rem;background:{{ '#9d8a78' if theme == 'dark' else '#786658' }};"></div>
+                    <div style="width:86%;height:0.3125rem;border-radius:0.1875rem;background:{{ '#9d8a78' if theme == 'dark' else '#786658' }};"></div>
                 </div>
                 <div class="theme-name">{{ theme | capitalize }}</div>
             </div>


### PR DESCRIPTION
Fixes [DIN-73](https://linear.app/keepthescore/issue/DIN-73): rejects impossible annual dates while allowing 29 February, shows named months, and keeps invalid stored entries repairable without crashing the dashboard.
Fixes [DIN-74](https://linear.app/keepthescore/issue/DIN-74): preserves each chore's participant sequence, adds explicit ordering with a JavaScript-free fallback, and enlarges move controls with disabled boundaries.
Fixes [DIN-75](https://linear.app/keepthescore/issue/DIN-75): names and groups form controls, associates validation errors with fields and focuses an error summary, improves contrast in settings and both dashboard themes, and updates the terminology and developer documentation.
Validation: 1,278 tests passed and one skipped with real PostgreSQL; Chrome verified desktop/mobile layouts, keyboard and touch interactions, Enter-to-save, JavaScript-free ordering, and 42 targeted accessibility scans with zero violations.
