### PR TITLE
Clarify hosting processors and international data transfers

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -410,6 +410,10 @@ expiry is implemented; checkout, payment and cancellation still need that verifi
 - [x] Include every retained historical generation in the export ([DIN-50](https://linear.app/keepthescore/issue/DIN-50)).
 - [x] Keep generated family text and bearer credentials out of service logs ([DIN-47](https://linear.app/keepthescore/issue/DIN-47)).
 - [ ] Verify DigitalOcean/Cloudflare agreement status and record private evidence ([DIN-59](https://linear.app/keepthescore/issue/DIN-59)).
+  Live hosting regions and DNS routing checked on 11 September 2026; the privacy
+  policy distinguishes DigitalOcean hosting from Cloudflare's global delivery
+  network. Published terms incorporate the providers' DPAs; confirmation of the
+  accounts' governing agreements remains in DIN-59, with private evidence there.
 - [ ] Implement and then disclose old-brief and lapsed-family retention sweeps ([DIN-57](https://linear.app/keepthescore/issue/DIN-57)).
 
 **Done when:** disclosures match actual collection, retention, export and deletion,

--- a/website/content/privacy.md
+++ b/website/content/privacy.md
@@ -76,13 +76,22 @@ API key at all, and simply goes without the written line.
 | **Anthropic** | Writes the daily note from the day's agenda | United States |
 | **DigitalOcean** | Runs the app and the database | Frankfurt, Germany (US company) |
 | **SendGrid** (Twilio) | Delivers sign-in emails | United States |
-| **Cloudflare** | DNS, and TLS at the edge | Global (US company) |
+| **Cloudflare** | DNS; website and app delivery through DigitalOcean's App Platform | Global (US company) |
 | **Sentry** (Functional Software) | Error reports, and the checks that the app and the worker are running | United States |
 
-The app and the database are in **Frankfurt**. DigitalOcean and Cloudflare are
-United States companies operating them, and SendGrid and Sentry are in the
-United States, so transfers outside the EU are covered by standard contractual
-clauses.
+The app and the database run on DigitalOcean in **Frankfurt**. Cloudflare
+provides our DNS and, as one of
+[DigitalOcean's sub-processors](https://www.digitalocean.com/trust/subprocessors),
+delivers website and app traffic through its global network. Hosting in
+Frankfurt does not mean all processing stays in Germany: requests pass through
+that network, and Anthropic, SendGrid and Sentry process data in the United
+States as listed above.
+
+DigitalOcean and Cloudflare are United States companies. Their published
+[data processing agreement](https://www.digitalocean.com/legal/data-processing-agreement)
+and [data processing addendum](https://www.cloudflare.com/cloudflare-customer-dpa/)
+set out safeguards for international transfers, including the EU–US Data
+Privacy Framework and standard contractual clauses where applicable.
 
 **Google Fonts is not on this list, and that is deliberate.** The typeface is
 served from our own servers, so no page of DinkyDash — not the dashboard, not the


### PR DESCRIPTION
The privacy policy conflates Frankfurt hosting with Cloudflare’s global delivery and says all international transfers use standard contractual clauses. Clarify each provider’s role and the transfer safeguards described in their published DPAs, linking the public agreements and subprocessor list.

Record the remaining account-agreement verification in PLAN.md; private evidence is attached to [DIN-59](https://linear.app/keepthescore/issue/DIN-59), with owner confirmation of the governing terms still pending.

Validation: local tests passed (900 passed, 407 skipped), and GitHub CI passed for both database backends and the self-hosted configuration, including secret scans.
