### PR TITLE
Show who is signed in on the settings home, with a View admin link

### DIFF
--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -236,6 +236,61 @@ def pg_pool_of(app):
     return app.config["POOL"]
 
 
+# -- the way in: the settings home says who is signed in ---------------------
+
+class TestTheSettingsHomeSaysWhoIsSignedIn:
+    """The app bar carries the signed-in address and, for the listed address
+    and nobody else, the one link there is to the operator's page."""
+
+    def home(self, client):
+        response = client.get("/settings/")
+        assert response.status_code == 200
+        return response.get_data(as_text=True)
+
+    def test_the_address_is_on_the_page(self, cloud, user):
+        assert ADDRESS in self.home(signed_in(cloud, user))
+
+    def test_with_no_list_there_is_no_link_to_the_admin_page(self, cloud, user):
+        html = self.home(signed_in(cloud, user))
+        assert "View admin" not in html
+        assert 'href="/admin"' not in html
+
+    def test_somebody_else_on_the_list_gets_no_link_either(self, cloud, user, monkeypatch):
+        monkeypatch.setenv("DINKYDASH_ADMIN_EMAILS", "somebody@example.com")
+        html = self.home(signed_in(cloud, user))
+        assert ADDRESS in html
+        assert "View admin" not in html
+        assert 'href="/admin"' not in html
+
+    def test_the_listed_address_gets_the_link_and_it_opens(self, admin_client):
+        html = self.home(admin_client)
+        assert ADDRESS in html
+        assert "View admin" in html
+        assert 'href="/admin"' in html
+        assert admin_client.get("/admin").status_code == 200
+
+    def test_a_session_naming_a_user_that_is_gone_still_gets_its_settings(
+            self, cloud, user, monkeypatch):
+        monkeypatch.setenv("DINKYDASH_ADMIN_EMAILS", ADDRESS)
+        client = signed_in(cloud, user)
+        with pg_pool_of(cloud).connection() as conn, conn.transaction(), conn.cursor() as cur:
+            cur.execute("DELETE FROM users WHERE id = %s", (user[1],))
+        html = self.home(client)
+        assert ADDRESS not in html
+        assert "View admin" not in html
+
+    def test_a_self_hoster_sees_neither(self, tmp_path, monkeypatch):
+        """Single mode has nobody signed in and no pool to ask. With the list
+        set, the page must render rather than reach for a database."""
+        monkeypatch.delenv("DINKYDASH_MODE", raising=False)
+        monkeypatch.setenv("DINKYDASH_ADMIN_EMAILS", ADDRESS)
+        (tmp_path / "config.yaml").write_text('family_name: "The Wilsons"\n')
+        html = self.home(client_for(create_app(FileStore(tmp_path / "config.yaml"))))
+        assert ADDRESS not in html
+        assert "View admin" not in html
+        assert "/admin" not in html
+
+
 # -- what it shows -----------------------------------------------------------
 
 @pytest.fixture

--- a/web/CLAUDE.md
+++ b/web/CLAUDE.md
@@ -113,6 +113,15 @@ white with the dataviz palette validator (CVD ΔE 24.7, both above 3:1); a third
 running it again, not picking a colour. `tests/test_admin.py` covers the gate, the bounds on
 `?weeks=` and the drawing.
 
+**The settings home's app bar says who is signed in, and is the one place `/admin` is linked
+from.** Under the title sits the account's address — hosted only, there is nobody signed in on a
+Pi — and for an address on `DINKYDASH_ADMIN_EMAILS` a "View admin" action beside "Dashboard".
+Both come from `family.current_address()`, which reads the account's row at most once per
+request and answers None in single mode without touching a pool, so a self-hoster with the
+variable set still gets a page. `is_admin()` compares that address and takes no argument, so
+nothing a request carries can reach the comparison; `tests/test_admin.py` asserts the link is
+shown to the listed address and to nobody else, in either mode.
+
 **The app bar holds the way back and the title, and never a Save.** A page that saves ends its
 form with a full-width `.btn` Save, where the fields are, and the bar's left-hand button is
 `icons.back_to(href, label)` — the chevron plus the *name of the page it goes to* ("Settings",

--- a/web/family.py
+++ b/web/family.py
@@ -60,6 +60,30 @@ def current_screen_token():
     return screens.token_for(_the_pool(), _family_on_the_session())
 
 
+def current_address():
+    """The address on the signed-in account, or None.
+
+    The session carries ids and never the address (`web/session.py`), so this
+    is one read of the account's row. Read at most once per request and kept
+    on `g`: the settings home shows it and `is_admin` compares it, and one
+    page should not ask the database the same question twice.
+
+    None in single mode, which has nobody signed in, and None for a session
+    naming a user that is gone. Cloud mode only otherwise.
+    """
+    from . import CLOUD
+
+    if "_address" in g:
+        return g._address
+    user_id = session.get(USER_ID)
+    if current_app.config["MODE"] != CLOUD or not user_id:
+        g._address = None
+    else:
+        from dinkydash import accounts
+        g._address = accounts.address_for(_the_pool(), user_id)
+    return g._address
+
+
 def is_admin():
     """Is the person on the session on the `DINKYDASH_ADMIN_EMAILS` list?
 
@@ -71,17 +95,20 @@ def is_admin():
     missing list means nobody may, which is the safe way for a new deployment
     to be wrong.
 
+    Takes no argument on purpose. An address handed in by a caller is an
+    address that could have come from a request, and this is the one
+    comparison that must only ever see the session's.
+
     Cloud mode only. Callers answer `False` with a 404 and never a 403 —
     "forbidden" would say the page exists (`web/routes/admin.py`).
     """
     from dinkydash import accounts
 
     allowed = admin_addresses()
-    user_id = session.get(USER_ID)
-    if not allowed or not user_id:
+    if not allowed:
         return False
-    address = accounts.address_for(_the_pool(), user_id)
-    return accounts.normalise(address) in allowed
+    address = current_address()
+    return bool(address) and accounts.normalise(address) in allowed
 
 
 def admin_addresses():

--- a/web/routes/settings.py
+++ b/web/routes/settings.py
@@ -28,7 +28,8 @@ from dinkydash.runner import run as run_generation
 from web import CLOUD
 from web import manifest as manifest_module
 from web import setup as setup_module
-from web.family import current_access, current_budget, current_family_id, current_store
+from web.family import (current_access, current_address, current_budget,
+                        current_family_id, current_store, is_admin)
 from web import session as session_module
 from web.session import guard
 from web.urls import absolute_url, board_path
@@ -308,6 +309,9 @@ def home():
         setup=setup, setting_up=setting_up, screen=screen,
         calendars_on=any(c.get("enabled") for c in calendars if isinstance(c, dict)),
         board_link=board_path(),
+        # Who is signed in, for the app bar. None self-hosted, where nobody is;
+        # `admin` is the one place the operator's page is linked from.
+        address=current_address(), admin=is_admin(),
     )
 
 

--- a/web/templates/settings/base.html
+++ b/web/templates/settings/base.html
@@ -121,11 +121,13 @@
         }
         .appbar .back:focus-visible { border-color: var(--accent); color: var(--accent); }
         .appbar .back:active { background: var(--warm); }
+        /* An action never wraps or shrinks: when the bar is short of room it is
+           the title block that truncates, which is what its ellipsis is for. */
         .appbar .action {
-            display: inline-flex; align-items: center; justify-content: center;
+            display: inline-flex; align-items: center; justify-content: center; flex-shrink: 0;
             min-width: 2.75rem; height: 2.75rem; padding: 0 0.375rem;
             font-size: 0.9375rem; font-weight: 800; color: var(--accent);
-            border-radius: 0.625rem;
+            border-radius: 0.625rem; white-space: nowrap;
         }
         .appbar .action.muted { color: var(--text-muted); font-weight: 700; }
 

--- a/web/templates/settings/home.html
+++ b/web/templates/settings/home.html
@@ -24,11 +24,29 @@
     @media (max-width: 26rem) {
         .dashboard-actions { grid-template-columns: 1fr; }
     }
+    /* The bar's title block: the name, and under it who is signed in. Both
+       truncate rather than wrap, so a long address can neither push the
+       actions off the bar nor make it taller — the pair fits in its 3.5rem. */
+    .identity { flex-grow: 1; min-width: 0; }
+    .identity h1 { line-height: 1.25; }
+    .identity .who {
+        padding-left: 0.25rem; font-size: 0.75rem; font-weight: 700; line-height: 1.25;
+        color: var(--text-muted); white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+    }
 </style>
 {% endblock %}
 
 {% block appbar %}
-<h1 style="padding-left:0.25rem;color:var(--accent);font-size:1.15rem;">DinkyDash</h1>
+{# Under the title, who is signed in — hosted only, since a self-hoster has no
+   account. A phone two parents share should say whose settings these are, and
+   the account page is three taps away. For an address on DINKYDASH_ADMIN_EMAILS
+   the bar also carries the one link there is to the operator's page;
+   `tests/test_admin.py` asserts nobody else is shown it. #}
+<div class="identity">
+    <h1 style="padding-left:0.25rem;color:var(--accent);font-size:1.15rem;">DinkyDash</h1>
+    {% if address %}<div class="who">{{ address }}</div>{% endif %}
+</div>
+{% if admin %}<a class="action muted" href="{{ url_for('admin.growth_page') }}">View admin</a>{% endif %}
 {# The dashboard link is "View dashboard" by another name, so it waits with it and
    opens its own tab for the same reason — see the button. #}
 {% if not setting_up %}<a class="action muted" href="{{ board_link }}" target="_blank" rel="noopener">Dashboard</a>{% endif %}


### PR DESCRIPTION
The settings home's app bar now shows the signed-in address under the title, hosted only, and for an address on `DINKYDASH_ADMIN_EMAILS` a "View admin" action beside "Dashboard". A new `family.current_address()` reads the account's row at most once per request and answers None in single mode without touching a pool, and `is_admin` now compares through it and takes no argument. App-bar actions no longer wrap or shrink, so a long address truncates with an ellipsis instead of breaking "View admin" across two lines. Six tests in `tests/test_admin.py` cover the link being shown to the listed address and to nobody else in both modes; the whole suite passes with and without Postgres, and the bar was checked in a browser at 360, 390 and 1024 px. The rule is written down beside the admin gate in `web/CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
