### PR TITLE
Keep the last dashboard on screen when a refresh fails

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -156,8 +156,11 @@ app origin; single mode retains its local HTTP URLs.
 
 The app rate-limits invalid-token attempts. Additional Cloudflare edge hardening is Backlog ([DIN-40](https://linear.app/keepthescore/issue/DIN-40));
 this document does not claim an edge rule is deployed. Access-log redaction covers
-invalid, mistyped and encoded screen-token variants ([DIN-47](https://linear.app/keepthescore/issue/DIN-47)). Offline behaviour is deferred
-under [DIN-60](https://linear.app/keepthescore/issue/DIN-60); weakening shared-cache headers is not the implementation plan.
+invalid, mistyped and encoded screen-token variants ([DIN-47](https://linear.app/keepthescore/issue/DIN-47)). Offline behaviour: the page
+fetches its next copy and swaps it in rather than reloading, so a lost connection keeps the last
+dashboard on the wall with a "Reconnecting" badge and retries every minute (`board.html`). What
+stays open under [DIN-60](https://linear.app/keepthescore/issue/DIN-60) is a reboot during an outage, which only a service worker could
+cover; weakening shared-cache headers is not the implementation plan.
 
 ### The spend breaker
 
@@ -179,7 +182,7 @@ the model budget. Call counts and an output ceiling are not a currency-denominat
 
 | Clock | Current behaviour |
 |---|---|
-| Screen reload | Every five minutes or the configured refresh interval, whichever is shorter; waiting screens retry every minute. |
+| Screen refresh | Every five minutes or the configured refresh interval, whichever is shorter; waiting screens retry every minute. A refresh that fails keeps the last dashboard on screen and retries every minute. |
 | Calendar refresh | Due after `refresh_minutes`, default 60 minutes; chosen in settings. Provider-side caching can delay source changes. |
 | Daily brief | First brief immediately due; subsequent briefs after `brief_time`, default 06:00, on the family's local day. Manual rewrites are separate attempts. |
 
@@ -387,7 +390,8 @@ failed providers preserve useful last-good output; retries and paid calls obey t
 - [ ] Additional Cloudflare edge hardening ([DIN-40](https://linear.app/keepthescore/issue/DIN-40); Backlog).
 - [ ] Render the already-configured person colours ([DIN-8](https://linear.app/keepthescore/issue/DIN-8); feature backlog).
 - [ ] Verify TV, older iPad/tablet and Pi kiosk behaviour ([DIN-58](https://linear.app/keepthescore/issue/DIN-58)).
-- [ ] Define offline behaviour while preserving credential/cache controls ([DIN-60](https://linear.app/keepthescore/issue/DIN-60); deferred).
+- [x] Keep the last good dashboard on screen through a lost connection: fetch-and-swap with a "Reconnecting" badge, no cache and no change to `no-store`.
+- [ ] Decide whether a reboot while offline merits a service worker ([DIN-60](https://linear.app/keepthescore/issue/DIN-60); deferred).
 
 **Done when:** the shared dashboard works on the actual target devices, including the
 agreed failure behaviour. Device-specific guides are published ([DIN-13](https://linear.app/keepthescore/issue/DIN-13));

--- a/dinkydash/CLAUDE.md
+++ b/dinkydash/CLAUDE.md
@@ -292,7 +292,10 @@ with either.
 ceiling; only a `refresh_minutes` shorter than that lowers it, because reloading faster than the
 calendars are fetched just redraws the same thing. A parent picks "how soon does a change show up",
 not a browser knob — so there is no separate setting for it and the template reads
-`view.reload_seconds` rather than deciding.
+`view.reload_seconds` rather than deciding. The page acts on it by fetching a fresh copy and
+swapping it in, not by reloading, so a copy that never arrives leaves the last dashboard on the
+wall; `view.today` and `view.timezone` are there for the same script to say which day that
+dashboard was for (`web/CLAUDE.md`, "The dashboard's layout").
 
 These rules hold this together:
 

--- a/dinkydash/board.py
+++ b/dinkydash/board.py
@@ -85,6 +85,12 @@ def build_view(config, payload, today):
         "state": "waiting",
         "set_up": set_up,
         "reload_seconds": WAITING_RELOAD_SECONDS,
+        # Read by the page's own refresh (board.html): which day the dashboard
+        # on screen is for, and the zone its times are in, so a screen that
+        # has lost its connection can say "Showing Thursday's dashboard" once
+        # Thursday is over rather than letting the date in the corner lie.
+        "today": today.isoformat(),
+        "timezone": config.get("timezone") or "UTC",
     }
 
     if not payload:
@@ -145,4 +151,5 @@ def build_lapsed_view(config, payload, show_last_board):
     return {
         "state": "ended", "family_name": "", "reload_seconds": MAX_RELOAD_SECONDS,
         "theme": "dark" if config.get("theme") == "dark" else "light",
+        "timezone": config.get("timezone") or "UTC",
     }

--- a/doc/running-it.md
+++ b/doc/running-it.md
@@ -64,8 +64,10 @@ Two buttons on the settings home force the point:
 **How often it updates** sets both cadences — how often the calendars are fetched, and what time
 the daily message is written, on your own clock. They are the `refresh_minutes` and `brief_time` keys,
 so editing them by hand still works; the page is just the version you can reach from a phone. The
-dashboard's own reload follows: it redraws every five minutes, or every `refresh_minutes` if you set
-something shorter than that.
+dashboard's own refresh follows: it redraws every five minutes, or every `refresh_minutes` if you set
+something shorter than that. A redraw that cannot reach the server — the Pi's Wi-Fi is down, or you
+are looking at the hosted dashboard during a deploy — keeps the last good dashboard on screen with a
+"Reconnecting" note in the corner, and tries again every minute.
 
 ## Keeping settings on your phone
 
@@ -138,6 +140,13 @@ need replacing.
 it, the model has nothing to avoid. It refills itself over the next few days.
 
 **Emoji show as boxes.** `sudo apt install fonts-noto-color-emoji && fc-cache -fv`
+
+**"Reconnecting" in the bottom corner.** The dashboard could not fetch its next copy, so it is
+showing the last one it got and trying again every minute. On a Pi that means Flask stopped
+answering (`sudo systemctl status dinkydash`); on the hosted dashboard it means the screen has no
+route to app.dinkydash.co, which is nearly always the Wi-Fi. The note says when the dashboard on
+screen was last updated, and changes to "Showing Thursday's dashboard" once that day is over, because
+the turns and countdowns on it are then a day old. It goes away by itself the moment a copy arrives.
 
 ---
 

--- a/tests/test_board_refresh.py
+++ b/tests/test_board_refresh.py
@@ -1,0 +1,198 @@
+"""How the dashboard refreshes itself, and what a screen shows when it cannot.
+
+The dashboard used to reload itself with a `<meta http-equiv="refresh">`. A
+reload that fails — the Wi-Fi dropped, the hosted app is mid-deploy — replaces
+the dashboard with the browser's error page, and a kiosk on a wall has nobody
+to press Back. So the page now fetches its next copy in the background and
+swaps the body in only when one arrives; a copy that never arrives leaves the
+last good dashboard on the wall with a "Reconnecting" badge saying when it was
+last updated (DIN-60). The tag survives only inside `<noscript>`, for a browser
+with scripting off.
+
+The swapping and the badge need a browser, and are checked by hand — see
+"Measuring the dashboard" in `web/CLAUDE.md`. What pytest can pin is the
+contract between the template and its script: the values the script reads,
+the element it fills in, and that the reload is not two mechanisms racing.
+"""
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from dinkydash import config as config_module
+from dinkydash.store import FileStore
+from tests.conftest import client_for
+from web import create_app
+
+SET_UP = 'family_name: "The Wilsons"\ntimezone: "Europe/Berlin"\n'
+
+
+def page_for(directory, payload=None):
+    """A single-mode dashboard for a set-up family, with or without a board.
+
+    Each caller gets its own directory: a test that asks for both pages must
+    not have the waiting one find the ready one's `dashboard_data.json`.
+    """
+    directory.mkdir()
+    path = directory / "config.yaml"
+    path.write_text(SET_UP)
+    if payload is not None:
+        (directory / "dashboard_data.json").write_text(json.dumps(payload))
+    return client_for(create_app(FileStore(path))).get("/").get_data(as_text=True)
+
+
+@pytest.fixture
+def today(tmp_path):
+    (tmp_path / "config.yaml").write_text(SET_UP)
+    return config_module.today_for(config_module.load_config(tmp_path / "config.yaml"))
+
+
+@pytest.fixture
+def ready(tmp_path, today):
+    return page_for(tmp_path / "ready", {"generated_for_date": today.isoformat(),
+                                         "headline": "Hi", "note": "There", "events": []})
+
+
+@pytest.fixture
+def waiting(tmp_path):
+    return page_for(tmp_path / "waiting")
+
+
+def script_of(page):
+    return page.split("<script>", 1)[1].split("</script>", 1)[0]
+
+
+class TestOneReloadNotTwo:
+    def test_the_meta_refresh_survives_only_as_the_no_script_fallback(self, ready):
+        """Two timers would race: the tag's reload would land the error page
+        the script exists to avoid. So the tag lives inside <noscript>, where
+        a browser running the script never sees it."""
+        tags = [m.start() for m in re.finditer(r'http-equiv="refresh"', ready)]
+        assert tags, "a browser with scripting off still needs the reload"
+        for at in tags:
+            before = ready[:at]
+            assert before.count("<noscript>") == before.count("</noscript>") + 1, \
+                "a meta refresh outside <noscript> races the script"
+
+    def test_the_script_reads_the_interval_from_the_body(self, ready, waiting):
+        """The number is `board.reload_seconds`, derived in one place; the
+        script reads it after every swap, so a waiting screen that fills in
+        moves to the five-minute cadence on its own."""
+        assert 'data-reload="300"' in ready
+        assert 'data-reload="60"' in waiting
+        assert 'getAttribute("data-reload")' in script_of(ready)
+
+    def test_a_hung_request_cannot_stop_the_refreshing(self, ready):
+        """The deadline is a promise raced against the attempt, not only an
+        abort: on a browser whose fetch cannot be aborted (older WebKit) the
+        abort does nothing, and a request that stalls rather than failing
+        would otherwise hold the in-flight flag for ever — no badge, no retry,
+        and the online handler returning at once. The guard is time-based for
+        the same reason: an attempt past its deadline is abandoned, not awaited."""
+        script = script_of(ready)
+        assert "Promise.race([attempt, deadline])" in script
+        assert "Date.now() - started < TIMEOUT_MS" in script
+
+    def test_the_script_fetches_its_own_url_and_nothing_else(self, ready):
+        """`location.href`, so the same script serves `/` on a Pi and
+        `/s/<token>` on a wall, and the token is never written into the page a
+        second time. No host is named: the dashboard makes no third-party
+        request, and a screen token in a Referer would be one."""
+        script = script_of(ready)
+        assert "fetch(location.href" in script
+        for external in ("http://", "https://"):
+            assert external not in script
+
+
+class TestWhatTheBadgeCanSay:
+    def test_it_is_in_every_page_and_hidden_until_needed(self, ready, waiting):
+        for page in (ready, waiting):
+            assert '<div class="offline" role="status" hidden></div>' in page
+
+    def test_a_dated_dashboard_says_which_day_it_is_for(self, ready, today):
+        """Once that day is over, the badge escalates from "Last updated 08:20"
+        to "Showing Thursday's dashboard" — the date in the corner and the
+        turns beside it are then yesterday's, and the page has to say so.
+        The zone is the family's, because the device's clock may not be."""
+        assert f'data-today="{today.isoformat()}"' in ready
+        assert 'data-timezone="Europe/Berlin"' in ready
+
+    def test_a_waiting_screen_is_for_no_day_and_says_so(self, waiting):
+        assert "data-today=" not in waiting
+        assert 'data-timezone="Europe/Berlin"' in waiting
+
+    def test_the_badge_offers_no_way_out(self, ready):
+        """It sits on a wall, in a page that deliberately has no link out
+        (`tests/test_settings.py` asserts the same of the whole page)."""
+        assert "/settings" not in ready
+        assert "<a " not in ready
+
+
+class TestADeployReachesTheWall:
+    """A swap keeps the <head> — the CSS, the fonts, this script — so without
+    this a panel loaded in March would run March's page for ever, and could
+    draw a new body with old styles. The body carries the page's own version;
+    a copy whose version differs is a deploy and gets a real reload, at the one
+    moment a reload is safe: a copy has just arrived."""
+
+    def test_the_body_carries_the_page_version(self, ready, waiting):
+        from web import assets
+
+        page_version = re.search(r'data-version="([0-9a-f]{12})"', ready)
+        assert page_version, "no version on the body"
+        assert page_version.group(1) in waiting
+        with create_app(FileStore()).app_context():
+            assert page_version.group(1) == assets.board_version()
+
+    def test_the_script_reloads_on_a_version_it_does_not_know(self, ready):
+        script = script_of(ready)
+        assert 'next.body.getAttribute("data-version") !== document.body.getAttribute("data-version")' in script
+
+    def test_the_version_follows_the_files_it_names(self, tmp_path):
+        """Content, not commit: a Pi has no GIT_SHA, and a deploy that changes
+        none of these files should not reload a wall."""
+        from web import assets
+
+        one = tmp_path / "board.html"
+        one.write_text("<body>v1</body>")
+        before = assets._version_at(str(one))
+        one.write_text("<body>v2 with more</body>")
+        assert assets._version_at(str(one)) != before
+        assert assets._version_at(str(tmp_path / "missing.html")) is None
+
+    def test_every_dashboard_file_the_version_names_exists(self):
+        """A name that drifts — a font renamed, a template moved — would
+        silently hash to nothing, and every deploy would then look like no
+        deploy."""
+        from web import assets
+
+        app = create_app(FileStore())
+        with app.app_context():
+            for name in assets.BOARD_TEMPLATES:
+                assert (Path(app.root_path) / app.template_folder / name).is_file(), name
+            for name in assets.BOARD_STATIC:
+                assert assets.version_of(name), name
+
+
+class TestTheServerSideOfTheContract:
+    def test_build_view_carries_the_day_and_the_zone(self):
+        from datetime import date
+
+        from dinkydash.board import build_view
+
+        config = {"family_name": "The Wilsons", "timezone": "Europe/Berlin",
+                  "people": [{"name": "Mia", "date_of_birth": "2017-03-15"}]}
+        view = build_view(config, {"generated_for_date": "2026-09-03", "events": []},
+                          date(2026, 9, 3))
+        assert view["today"] == "2026-09-03"
+        assert view["timezone"] == "Europe/Berlin"
+
+    def test_an_unset_zone_is_utc_which_is_what_the_engine_uses_too(self):
+        from datetime import date
+
+        from dinkydash.board import build_view
+
+        view = build_view({"family_name": "x"}, None, date(2026, 9, 3))
+        assert view["timezone"] == "UTC"

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -203,7 +203,9 @@ def test_thirty_days_later_only_the_ended_message_is_rendered(hosted, pg_pool, p
     for content in ("Invented family", "Saved headline", "Saved appointment", "Saved note",
                     "Set the table", "A holiday"):
         assert content not in page
-    assert 'http-equiv="refresh"' in page  # An eventual reactivation reaches the wall.
+    # An eventual reactivation reaches the wall: the script's timer, and the
+    # <noscript> reload for a browser without one.
+    assert 'data-reload="300"' in page and 'http-equiv="refresh"' in page
     assert model.messages.calls == []
 
 

--- a/web/CLAUDE.md
+++ b/web/CLAUDE.md
@@ -164,11 +164,31 @@ reload timer. Export, deletion and settings remain accessible. Exports include b
 **Changing the dashboard layout.** Everything is sized in `rem` off one root value, so check all three
 sizes at `/preview` rather than just the one you are looking at.
 
-That root value is now *measured*, not guessed. A short script at the foot of `board.html` binary-
+That root value is now *measured*, not guessed. The script at the foot of `board.html` binary-
 searches the largest `html { font-size }` whose content still fits the viewport, capped at
 `min(26px, vh/24)`. The CSS `clamp()` stays as the no-JS fallback. Because `body` is
 `height:100vh;overflow:hidden`, nothing ever reports an overflow — so the script lets the page lay
 out freely for one measurement (`height:auto`) and puts it straight back.
+
+**The same script is what refreshes the dashboard, and it never reloads the page** (DIN-60). Every
+`view.reload_seconds` it fetches `location.href`, parses the copy, and swaps the `<body>` in — then
+re-fits, because the content changed. A copy that does not arrive (the fetch fails, times out at
+30 s, comes back 5xx, or is not a dashboard at all) leaves the last good one on the wall, shows the
+`.offline` badge — "Reconnecting · Last updated 08:20", or "Showing Thursday's dashboard" once the
+day in `data-today` is over in the family's `data-timezone` — and tries again in a minute. A 4xx or
+a redirect is a deliberate answer (the link was rotated, a session ended) and gets a real reload, so
+the server's own page shows the way it always did. **A swap keeps the `<head>`**, and with it the CSS,
+the fonts and the script itself, so the body carries `assets.board_version()` — a hash of the
+dashboard's templates and font files — and a copy whose version differs is a deploy and gets a real
+reload too, at the one moment that is safe: a copy has just arrived. The 30 s deadline is a promise
+raced against the attempt, not only an abort, because older WebKit cannot abort a fetch and a
+request that stalls would otherwise hold the in-flight guard for ever; the guard is time-based for
+the same reason. The `<meta http-equiv="refresh">` survives only
+inside `<noscript>`: a browser running the script must never see it, or the two race and the tag's
+reload lands the error page the script exists to avoid. `tests/test_board_refresh.py` pins that
+contract; the swap and the badge themselves are checked in a browser, below. What this does *not*
+cover is a reboot while offline — the browser then has nothing to show, and only a service worker
+would change that, which DIN-60 keeps open.
 
 **Nunito is served from `web/static/fonts/`, not from Google**, as one variable font per subset
 (`nunito-latin.woff2`, `nunito-latin-ext.woff2`, covering weights 200-1000 so every weight the dashboard
@@ -290,9 +310,16 @@ hard way.
   side of the `3/2` media query. Size the page with an **iframe of exactly the target dimensions**
   instead, the way `/preview` already does, and read the numbers out of `iframe.contentWindow`. That
   is deterministic; the flag is not.
-- **The dashboard's `<meta http-equiv="refresh">` stops headless Chrome ever exiting.** `--screenshot`
-  and `--dump-dom` both hang until the timeout, though they do write their output first. Strip the
-  tag when rendering a copy for measurement, and wrap the call in `timeout` regardless.
+- **Headless Chrome's `--screenshot` and `--dump-dom` hang until the timeout**, though they do
+  write their output first. This used to be blamed on the dashboard's `<meta http-equiv="refresh">`;
+  that tag now sits inside `<noscript>`, and on 11 September 2026 the Playwright-cached Chromium
+  build hung just the same on `/healthz`, a page with no script and no tag. So it is the tool, not
+  the page: always wrap the call in `timeout`, and prefer a driven browser (below) for anything that
+  has to wait for something.
+- **Checking the refresh needs a browser and a clock you control.** The script's timer is five
+  minutes; Playwright's `page.clock.install()` and `fastForward()` fire it on demand, and
+  `page.route()` can refuse, 503 or 404 the fetch to walk every branch — the memory note on
+  scripted Playwright checks has the cached Chromium and the `NODE_PATH` to use.
 - The honest check is `scrot` over SSH on the Pi itself: a real 800x480 panel, a real kiosk browser,
-  no capture artifacts. The dashboard reloads itself every 5 minutes on a default config, so a change
-  takes one reload to appear — check `refresh_minutes` before concluding it did not work.
+  no capture artifacts. The dashboard refreshes itself every 5 minutes on a default config, so a
+  change takes one refresh to appear — check `refresh_minutes` before concluding it did not work.

--- a/web/assets.py
+++ b/web/assets.py
@@ -50,10 +50,17 @@ VERSION_LENGTH = 12
 
 _versions = {}  # absolute path -> (mtime_ns, size, version)
 
+# What `board_version()` hashes: the templates that draw the dashboard, and the
+# fonts its head names. Nothing a family controls is in it, so every family on
+# one deploy shares one version.
+BOARD_TEMPLATES = ("board.html", "_fonts.html")
+BOARD_STATIC = ("fonts/nunito-latin.woff2", "fonts/nunito-latin-ext.woff2")
+
 
 def configure(app):
     """`static_url()` for the templates, and the cache header for what it emits."""
     app.jinja_env.globals["static_url"] = static_url
+    app.jinja_env.globals["board_version"] = board_version
     app.after_request(_cache_versioned)
 
 
@@ -69,7 +76,31 @@ def static_url(filename):
 def version_of(filename):
     """The current version of a static file, or None if there is no such file."""
     path = safe_join(current_app.static_folder, filename)
-    if path is None or not os.path.isfile(path):
+    return _version_at(path) if path else None
+
+
+def board_version():
+    """The version of the dashboard page, as opposed to any one file in it.
+
+    The dashboard refreshes itself by fetching a copy and swapping the <body>
+    in; the <head> — the CSS, the fonts, the script doing the swapping — stays
+    as it was when the page loaded, which on a wall panel is months ago. A
+    deploy that changes any of that would never reach the panel, and could
+    hand old styles new markup. So the body carries this, the script compares
+    each copy's against its own, and a difference is the one thing that earns
+    a real reload (`board.html`). Content rather than commit, for the reasons
+    `static_url` gives: a Pi has no `GIT_SHA`, and a deploy that changes none
+    of these files should not reload a wall.
+    """
+    folder = Path(current_app.root_path) / current_app.template_folder
+    parts = [_version_at(str(folder / name)) or "" for name in BOARD_TEMPLATES]
+    parts += [version_of(name) or "" for name in BOARD_STATIC]
+    return hashlib.sha256("|".join(parts).encode()).hexdigest()[:VERSION_LENGTH]
+
+
+def _version_at(path):
+    """The content version of the file at that absolute path, or None without one."""
+    if not os.path.isfile(path):
         return None
     stat = os.stat(path)
     known = _versions.get(path)

--- a/web/routes/screen.py
+++ b/web/routes/screen.py
@@ -68,9 +68,11 @@ SCREEN_HEADERS = {
     # on it.
     "X-Robots-Tag": "noindex, nofollow",
     # A shared cache holding a family's day under a URL anyone downstream can
-    # replay is not a cache, it is a leak. Offline tolerance for a panel on
-    # flaky wifi is a real want and its own job (PLAN.md phase 3): it needs a
-    # service worker, not a weaker header here.
+    # replay is not a cache, it is a leak. A panel on flaky wifi keeps its last
+    # dashboard in memory instead — the page fetches its next copy and only
+    # swaps it in when one arrives (board.html) — so nothing about that needs
+    # a weaker header. Surviving a reboot while offline would need a service
+    # worker, and is still open (DIN-60).
     "Cache-Control": "no-store, private",
 }
 

--- a/web/templates/board.html
+++ b/web/templates/board.html
@@ -14,7 +14,11 @@
     <title>{{ view.family_name or "DinkyDash" }}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="robots" content="noindex, nofollow">
-    <meta http-equiv="refresh" content="{{ view.reload_seconds }}">
+    {# The page refreshes itself from the script at the foot of the body, which
+       keeps the last good dashboard on screen when a copy cannot be fetched.
+       With scripting off, this tag does what that script does, minus the
+       keeping: a reload that fails shows the browser's error page. #}
+    <noscript><meta http-equiv="refresh" content="{{ view.reload_seconds }}"></noscript>
     <link rel="icon" href="{{ static_url('favicon.svg') }}" type="image/svg+xml">
     <!-- On a tablet used as the panel, saving this to the home screen gives a
          full-screen dashboard with no browser around it. -->
@@ -259,9 +263,40 @@
         .waiting-sub { font-size: 1.05rem; color: var(--text-mid); max-width: 32rem; line-height: 1.6; }
         .bar { width: 20rem; height: 0.4rem; border-radius: 999px; background: var(--box); overflow: hidden; }
         .bar span { display: block; width: 40%; height: 100%; border-radius: 999px; background: var(--accent); }
+
+        /* Shown by the script when a refresh fails; the last good dashboard
+           stays above it. In the flow rather than floating, so the fit
+           measurement makes room for it and it covers nothing — floated in a
+           corner it sat on the last countdown of a Pi panel. Amber, like the
+           stale banner: the same "something is off", at the other edge. */
+        .offline {
+            display: flex;
+            align-items: center;
+            gap: 0.7rem;
+            background: var(--warn-bg);
+            color: var(--warn-fg);
+            padding: 0.55rem 2.8rem;
+            font-size: 0.88rem;
+            font-weight: 700;
+            flex-shrink: 0;
+        }
+        .offline[hidden] { display: none; }
+        .offline::before {
+            content: "";
+            width: 0.55rem;
+            height: 0.55rem;
+            border-radius: 50%;
+            background: currentColor;
+            flex-shrink: 0;
+        }
     </style>
 </head>
-<body>
+{# What the refresh script reads. `data-version` is the page's own
+   (`assets.board_version`): a copy with a different one is a deploy, and gets
+   a real reload. `data-today` is only on a dashboard that is *for* a day — a
+   waiting screen has no date on it, and a frozen one says its dates are paused
+   — so only those escalate to "Showing Thursday's dashboard". #}
+<body data-reload="{{ view.reload_seconds }}" data-version="{{ board_version() }}"{% if view.state in ('ready', 'stale') %} data-today="{{ view.today }}"{% endif %} data-timezone="{{ view.timezone }}">
 
 {% if view.state == 'ended' %}
 <div class="waiting">
@@ -391,17 +426,32 @@
 
 {% endif %}
 
-<script>
-/* One root value still drives every size — it is just measured now instead of
-   guessed. The CSS clamp above stays as the no-JS fallback.
+{# Filled in and shown by the script below when a copy of the page could not
+   be fetched; hidden again by the next copy that arrives, which brings its
+   own. Text only, no way out: it sits on a wall. #}
+<div class="offline" role="status" hidden></div>
 
-   Body is height:100vh;overflow:hidden, so nothing ever reports an overflow.
-   To find the content's natural height we let it lay out freely for one
-   measurement, then put it back. */
+<script>
+/* Two jobs in one script, because the second has to call the first.
+
+   1. Fitting. One root value still drives every size — it is just measured now
+   instead of guessed. The CSS clamp above stays as the no-JS fallback. Body is
+   height:100vh;overflow:hidden, so nothing ever reports an overflow. To find
+   the content's natural height we let it lay out freely for one measurement,
+   then put it back.
+
+   2. Refreshing. The page fetches its next copy and swaps the body in, rather
+   than reloading. A reload that fails — the Wi-Fi dropped, the hosted app is
+   mid-deploy — replaces the dashboard with the browser's error page, and a
+   kiosk has nobody to press Back. A fetch that fails leaves the last good
+   dashboard where it is, with a badge saying when it was last updated, and
+   tries again in a minute. The <noscript> meta refresh in the head does what
+   this used to do for a browser with scripting off. */
 (function () {
-    var root = document.documentElement, body = document.body;
+    var root = document.documentElement;
 
     function naturalHeight() {
+        var body = document.body;   // read each time: a refresh replaces it
         var h = body.style.height, o = body.style.overflow;
         body.style.height = "auto";
         body.style.overflow = "visible";
@@ -433,6 +483,143 @@
        fallback, so a size measured before it lands can overflow once it swaps
        in — measured at 557px of content in a 480px panel. Re-fit when it does. */
     if (document.fonts && document.fonts.ready) { document.fonts.ready.then(fit); }
+
+    /* ---- the refresh ---------------------------------------------------- */
+
+    var RETRY_SECONDS = 60;      // after a failure: a router takes about that long to come back
+    var TIMEOUT_MS = 30000;      // a request that hangs is a request that failed
+    var fetchedAt = new Date();  // when what is on screen arrived
+    var timer = null;
+    var started = 0;             // when the attempt in flight began; 0 between attempts
+
+    function reloadSeconds() {
+        return parseInt(document.body.getAttribute("data-reload"), 10) || 300;
+    }
+
+    // A browser too old to fetch and swap gets the reload it always had, on
+    // the same timer. Everything below is written to parse in it regardless.
+    if (!window.fetch || !window.DOMParser || !window.Intl) {
+        setTimeout(function () { location.reload(); }, reloadSeconds() * 1000);
+        return;
+    }
+
+    function later(seconds) {
+        clearTimeout(timer);
+        timer = setTimeout(refresh, seconds * 1000);
+    }
+
+    function refresh() {
+        // One attempt at a time — but one that has outlived its deadline is
+        // abandoned, not waited for. On a browser whose fetch cannot be
+        // aborted it may never settle, and waiting on it would be the end of
+        // refreshing.
+        if (started && Date.now() - started < TIMEOUT_MS) { return; }
+        started = Date.now();
+        var controller = window.AbortController ? new AbortController() : null;
+        var expiry = null;
+        // The deadline is a promise of its own rather than the abort alone.
+        // Aborting stops the request where the browser supports it; where it
+        // does not (older WebKit), the rejection still counts the attempt as
+        // failed, so the badge shows and the retry is scheduled.
+        var deadline = new Promise(function (resolve, reject) {
+            expiry = setTimeout(function () {
+                if (controller) { controller.abort(); }
+                reject(new Error("timed out"));
+            }, TIMEOUT_MS);
+        });
+        var attempt = fetch(location.href, {
+            cache: "no-store",
+            credentials: "same-origin",
+            signal: controller ? controller.signal : undefined
+        }).then(function (response) {
+            if (response.status >= 500) { throw new Error("server error"); }
+            // A deliberate answer — the link was changed, a session ended —
+            // is the server's page to show, the way a reload would show it.
+            if (!response.ok || response.redirected) { return null; }
+            return response.text();
+        });
+        Promise.race([attempt, deadline])
+            .then(function (html) {
+                if (html === null) { location.reload(); return; }
+                var next = new DOMParser().parseFromString(html, "text/html");
+                // Not a dashboard — some box between here and the server
+                // answered instead — counts as no copy at all.
+                if (!next.body || !next.body.hasAttribute("data-reload")) { throw new Error("not a dashboard"); }
+                // A different version of the page is a deploy. The CSS and
+                // this script live in the head, which a swap keeps, so only a
+                // real reload brings them — safe now, and only now, because
+                // the copy has just arrived and the network is there to
+                // reload over.
+                if (next.body.getAttribute("data-version") !== document.body.getAttribute("data-version")) {
+                    location.reload();
+                    return;
+                }
+                swap(next);
+                fetchedAt = new Date();
+                later(reloadSeconds());
+            })
+            .catch(function () {
+                offline();
+                later(RETRY_SECONDS);
+            })
+            .then(function () {
+                clearTimeout(expiry);
+                started = 0;
+            });
+    }
+
+    function swap(next) {
+        root.setAttribute("data-theme", next.documentElement.getAttribute("data-theme") || "light");
+        document.title = next.title;
+        var colour = document.querySelector('meta[name="theme-color"]');
+        var nextColour = next.querySelector('meta[name="theme-color"]');
+        if (colour && nextColour) { colour.setAttribute("content", nextColour.getAttribute("content")); }
+        // A parsed document's scripts never run, and this one is already running.
+        var scripts = next.body.querySelectorAll("script");
+        for (var i = 0; i < scripts.length; i++) { scripts[i].parentNode.removeChild(scripts[i]); }
+        document.body.parentNode.replaceChild(next.body, document.body);
+        fit();
+    }
+
+    function offline() {
+        var badge = document.querySelector(".offline");
+        if (!badge) { return; }
+        var body = document.body;
+        var zone = body.getAttribute("data-timezone") || undefined;
+        var today = body.getAttribute("data-today");
+        var detail = (today && today !== dateIn(zone))
+            ? "Showing " + weekday(today) + "\u2019s dashboard"
+            : "Last updated " + clock(fetchedAt, zone);
+        badge.textContent = "Reconnecting \u00b7 " + detail;
+        badge.hidden = false;
+        fit();   // it takes a line, and the dashboard above it has to give one up
+    }
+
+    // Times in the family's zone, which is what every other time on the
+    // dashboard is in. A zone name this browser does not know throws, and the
+    // device's own clock is then close enough.
+    function formatter(options) {
+        try { return new Intl.DateTimeFormat("en-GB", options); }
+        catch (e) { delete options.timeZone; return new Intl.DateTimeFormat("en-GB", options); }
+    }
+    function clock(date, zone) {
+        return formatter({hour: "2-digit", minute: "2-digit", hourCycle: "h23", timeZone: zone}).format(date);
+    }
+    function dateIn(zone) {
+        var parts = formatter({year: "numeric", month: "2-digit", day: "2-digit", timeZone: zone}).formatToParts(new Date());
+        var part = function (type) {
+            for (var i = 0; i < parts.length; i++) { if (parts[i].type === type) { return parts[i].value; } }
+            return "";
+        };
+        return part("year") + "-" + part("month") + "-" + part("day");
+    }
+    function weekday(iso) {
+        return new Intl.DateTimeFormat("en-GB", {weekday: "long", timeZone: "UTC"}).format(new Date(iso + "T00:00:00Z"));
+    }
+
+    later(reloadSeconds());
+    // The network coming back is the one moment worth not waiting for.
+    window.addEventListener("online", function () { later(1); });
 })();
 </script>
 </body>

--- a/website/content/android-tablet-calendar-display.md
+++ b/website/content/android-tablet-calendar-display.md
@@ -77,9 +77,11 @@ That is the only extra piece of software in this whole build, and it is optional
 - **Countdowns** to birthdays, Christmas and the school holidays.
 - **A daily note written each morning** by Claude, around your family's actual day.
 
-The dashboard reloads itself every five minutes with a plain HTML refresh, so it keeps itself
-current even on a browser with JavaScript switched off. Nothing to tap, nothing to maintain —
-you keep editing events in your normal calendar app and the wall follows.
+The dashboard refreshes itself every five minutes. If the Wi-Fi drops, it keeps the last
+dashboard on screen with a small "Reconnecting" note rather than an error page, and catches up
+when the connection returns; with JavaScript switched off it falls back to a plain HTML refresh.
+Nothing to tap, nothing to maintain — you keep editing events in your normal calendar app and
+the wall follows.
 
 ## What it costs
 

--- a/website/content/fire-tv-calendar-display.md
+++ b/website/content/fire-tv-calendar-display.md
@@ -86,8 +86,11 @@ calendar display](/smart-tv-calendar-display/) for Samsung and LG.
 - **Countdowns** to birthdays, Christmas and the school holidays.
 - **A daily note written each morning** by Claude, around your family's actual day.
 
-The dashboard reloads itself every five minutes with a plain HTML refresh rather than JavaScript.
-That matters on a TV stick, where the browser is the least capable one in the house.
+The dashboard refreshes itself every five minutes, and if the Wi-Fi drops it keeps the last
+dashboard on screen with a small "Reconnecting" note rather than an error page. The script that
+does it is written for old browsers, and one too old for it, or with JavaScript switched off,
+falls back to a plain HTML refresh. That matters on a TV stick, where the browser is the least
+capable one in the house.
 
 ## What it costs
 

--- a/website/content/ipad-calendar-display.md
+++ b/website/content/ipad-calendar-display.md
@@ -82,9 +82,11 @@ Nothing is hidden and nothing breaks.
 - **Countdowns** to birthdays, Christmas and the school holidays.
 - **A daily note written each morning** by Claude, around your family's actual day.
 
-The dashboard reloads itself every five minutes using a plain HTML refresh, so it stays current
-even in a browser with JavaScript switched off. There is nothing to tap and nothing to
-maintain — you keep editing events in your normal calendar app, and the wall follows.
+The dashboard refreshes itself every five minutes. If the Wi-Fi drops, it keeps the last
+dashboard on screen with a small "Reconnecting" note rather than an error page, and catches up
+when the connection returns; with JavaScript switched off it falls back to a plain HTML refresh.
+There is nothing to tap and nothing to maintain — you keep editing events in your normal
+calendar app, and the wall follows.
 
 ## What it costs
 

--- a/website/content/smart-tv-calendar-display.md
+++ b/website/content/smart-tv-calendar-display.md
@@ -85,9 +85,11 @@ a television.
 - **Countdowns** to birthdays, Christmas and the school holidays.
 - **A daily note written each morning** by Claude, around your family's actual day.
 
-The dashboard reloads itself every five minutes with a plain HTML refresh rather than JavaScript,
-which matters here more than anywhere: TV browsers are the oldest browsers in the house, and
-this one keeps working in them.
+The dashboard refreshes itself every five minutes, and if the Wi-Fi drops it keeps the last
+dashboard on screen with a small "Reconnecting" note rather than an error page. The script that
+does it is written for old browsers, and one too old for it, or with JavaScript switched off,
+falls back to a plain HTML refresh — which matters here more than anywhere: TV browsers are the
+oldest browsers in the house, and this one keeps working in them.
 
 ## What it costs
 


### PR DESCRIPTION
The dashboard used to reload itself with a meta refresh, so a lost connection replaced it with the browser's error page on a wall nobody can press Back on. It now fetches its next copy and swaps the body in only when one arrives; a copy that does not arrive leaves the last good dashboard up with a "Reconnecting · Last updated 08:20" strip (escalating to "Showing Thursday's dashboard" once that day is over in the family's timezone) and retries every minute, while a 4xx or a redirect still gets a real reload so a rotated link lands on the same 404 page as before. The body carries a content version of the dashboard's templates and fonts (`assets.board_version`) so a deploy triggers one real reload at the moment a copy has just arrived, and the 30 s deadline is raced against the attempt so a stalled request fails even where fetch cannot be aborted. Verified by `tests/test_board_refresh.py`, the full suite in both modes, and a Playwright run driving every branch on a fake clock (network down, back up with changed content, 503, midnight rollover, a non-dashboard 200, a 404, a new page version, and a hung request with and without abort support). Docs follow the code: the device guides drop the "plain HTML refresh rather than JavaScript" claim, PLAN.md and DIN-60 record the remaining gap (a reboot while offline), and web/CLAUDE.md corrects the headless Chrome hang, which happens on a page with no script at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)