### PR TITLE
Refuse remote databases in dev.py and keep session settings out of the pooler

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -8,9 +8,8 @@
 #
 # **This spec is the whole app, not a patch.** `doctl apps update` replaces what
 # is there, so anything missing from this file is deleted from the running app.
-# `domains` is written out for that reason — it was absent until 8 September
-# 2026, and applying the file as documented above would have taken dinkydash.co
-# off its own domain.
+# `domains` is written out for that reason: applying a file without it takes
+# dinkydash.co off its own domain.
 #
 # **Do not apply this file as it stands. It will break the app.**
 #
@@ -19,10 +18,8 @@
 # omits them looks like it works — `doctl apps spec get` still shows `EV[...]`
 # afterwards, so the secret appears to have been preserved — but **the container
 # receives an empty variable**, and the pre-deploy migration job dies with
-# `DATABASE_URL_DIRECT is not set`. That was learned by doing it: two deploys
-# failed that way on 8 September 2026, and the spec looked correct throughout.
-# A canary test that only checked `spec get` is what missed it; the display and
-# the runtime disagree.
+# `DATABASE_URL_DIRECT is not set`. The display and the runtime disagree, so a
+# check that only reads `spec get` cannot catch it.
 #
 # So this file is the **shape** of the app, reviewed like code, and the values
 # are merged in at apply time from outside the working tree:
@@ -204,22 +201,21 @@ services:
 
     # Component-scoped, because `_self` means nothing in the app-level block
     # above. `${_self.COMMIT_HASH}` is a *bindable* variable: App Platform
-    # sets nothing in the environment on its own, so `/healthz` reported
-    # `"commit": "unknown"` on every deploy until this was bound. It is how
-    # you tell which code is actually running when a fix appears not to have
-    # shipped — `deploy_on_push` and `doctl apps update` are separate events,
-    # and this repo has already been caught out by that twice.
+    # sets nothing in the environment on its own, so without this binding
+    # `/healthz` reports `"commit": "unknown"`. It is how you tell which code
+    # is actually running when a fix appears not to have shipped —
+    # `deploy_on_push` and `doctl apps update` are separate events.
     envs:
       - key: GIT_SHA
         scope: RUN_TIME
         value: ${_self.COMMIT_HASH}
 
-    # 1 GB, not 0.5. Two gunicorn workers each kept ~250 MB after parsing an
-    # 8 MB personal calendar, and on 10 September 2026 that took the container
-    # past 512 MB and killed it — the site down for a minute, nothing in the log
-    # but the exit. `calendars._trim` now keeps the parse to a fortnight, so the
-    # headroom is for the next feed shape nobody has measured. $10 a month
-    # rather than $5; still the basic tier, still no autoscaling.
+    # 1 GB, not 0.5. Two gunicorn workers each keep ~250 MB after parsing an
+    # 8 MB personal calendar, which is more than a 512 MB container and shows
+    # in the log as nothing but the exit. `calendars._trim` keeps the parse to
+    # a fortnight, so the headroom is for the next feed shape nobody has
+    # measured. $10 a month rather than $5; still the basic tier, still no
+    # autoscaling.
     instance_size_slug: apps-s-1vcpu-1gb-fixed
     instance_count: 1
     http_port: 8080

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,12 +18,11 @@ jobs:
     services:
       postgres:
         # Pinned to the major version DigitalOcean's managed cluster runs, which
-        # is **17** — the `dinkydash` cluster in fra1 is on 17.11 as of
-        # 8 September 2026. This said 16 until then, written before the cluster
-        # existed, so CI was proving migrations against a major the app does not
-        # run. Postgres 15 changed who may write to the `public` schema; a
-        # difference of that size passing here and failing in production is
-        # exactly what this service container exists to prevent.
+        # is **17**. A CI database on any other major proves migrations against
+        # something the app does not run: Postgres 15 changed who may write to
+        # the `public` schema, and a difference of that size passing here and
+        # failing in production is exactly what this service container exists
+        # to prevent.
         #
         # When the cluster is upgraded, this line moves with it. `doctl
         # databases get <id> --format VersionSlug` is the check.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -428,7 +428,9 @@ generated files beside it.
 ```bash
 venv/bin/python dev.py              # also Conductor's default dev run action
 ```
-Requires a development `DATABASE_URL` with migrations applied and a
+Requires a development `DATABASE_URL` **on this machine** — loopback or a Unix socket; a remote
+database is refused before anything connects, because a workspace's `.env` can carry one — with
+migrations applied, and a
 `DINKYDASH_SECRET_KEY`. See [doc/development.md](doc/development.md) for setup,
 port overrides, sign-in and Conductor configuration pickup. Both processes stop
 together; the launcher always selects cloud mode and refuses invalid setup.
@@ -490,6 +492,12 @@ to tell you.
   a **dashboard** and the device showing it a **screen**. Keep the glossary in step with UI,
   email and website copy.
 
+- **Comments and docstrings state the rule and its reason, never the incident.** Say what a check
+  protects against, in general terms — not the date it went wrong, who pressed what, the Sentry
+  issue it opened, or what production did that day. That history goes in
+  [doc/operations.md](doc/operations.md), the log, or in Linear: the repo is public, and a war story
+  in code is operational detail published for ever. `tests/test_no_incident_notes.py` fails on a
+  dated narrative or a Sentry issue id in any comment, docstring, spec, workflow, migration or template.
 - **British English** throughout — UI copy, the model's system prompt, and `%-d %B` date formatting
   (`25 December`, not `December 25`).
 - **Times are 24-hour** on the dashboard (`08:20`).

--- a/PLAN.md
+++ b/PLAN.md
@@ -308,7 +308,8 @@ history are recorded in [doc/operations.md](doc/operations.md).
 There is no separate staging app. Tests and restores must use an explicit isolated
 database. The preview loads `.env` as defaults and preserves exported values, including
 an explicit scratch `DATABASE_URL`; missing/empty database configuration fails before
-Flask starts without printing the connection string ([DIN-48](https://linear.app/keepthescore/issue/DIN-48)).
+Flask starts without printing the connection string ([DIN-48](https://linear.app/keepthescore/issue/DIN-48)),
+and a database that is not on this machine is refused outright.
 
 #### Connection pooling
 

--- a/dev.py
+++ b/dev.py
@@ -3,8 +3,14 @@
 Uses two spawned processes in the launcher's process group. No reloader or
 debugger subprocesses: restart the run action after changing Python/content.
 Production uses wsgi.py; a self-hosted Pi continues to use app.py.
+
+**Only a database on this machine.** A workspace's `.env` can carry a remote
+`DATABASE_URL`, and a launcher that connects to whatever it finds is a local
+preview of somebody's production. `require_local_database` refuses anything
+that is not loopback or a Unix socket, before a connection is opened.
 """
 
+import ipaddress
 import logging
 import multiprocessing
 import os
@@ -26,6 +32,7 @@ def configure():
     for name in ("DATABASE_URL", "DINKYDASH_SECRET_KEY"):
         if not os.environ.get(name, "").strip():
             raise RuntimeError(f"{name} is required; set it in the environment or .env.")
+    require_local_database(os.environ["DATABASE_URL"])
     from web import SELF_HOSTED_KEY
 
     if os.environ["DINKYDASH_SECRET_KEY"] == SELF_HOSTED_KEY:
@@ -58,17 +65,64 @@ def configure():
     return {"Dashboard": dashboard, "Website": website}
 
 
+def require_local_database(url):
+    """Refuse a database that is not on this machine.
+
+    A workspace's `.env` may hold a remote `DATABASE_URL`, and this launcher
+    connects to whatever it is given. Without this check the default run
+    action can be a production database: the dashboard it then serves on
+    127.0.0.1 is that database, and its start-up check runs through a pooler
+    shared with the real service.
+
+    Only a loopback address or a Unix socket is accepted, with no override:
+    an escape hatch would end up in `.env` as well.
+    libpq's own parser is used because a host can hide in the query string
+    (`postgresql:///x?host=...`), in a comma-separated list or in `hostaddr`,
+    and an absent host falls back to `PGHOST`. The message names the variable
+    and never the value: a connection string carries a password.
+    """
+    from psycopg.conninfo import conninfo_to_dict
+
+    try:
+        params = conninfo_to_dict(url)
+    except Exception:
+        raise RuntimeError("DATABASE_URL is not a valid connection string.") from None
+    hosts = []
+    for key in ("host", "hostaddr"):
+        value = params.get(key) or os.environ.get("PG" + key.upper(), "")
+        hosts.extend(str(value).split(","))
+    if not all(_on_this_machine(host) for host in hosts):
+        raise RuntimeError(
+            "DATABASE_URL is not a database on this machine. The launcher only runs "
+            "against a local development database such as postgresql:///dinkydash_dev; "
+            "a copied .env may be pointing it at the hosted pool.")
+
+
+def _on_this_machine(host):
+    """Loopback, a Unix socket directory, or libpq's default socket."""
+    host = host.strip()
+    if not host or host.startswith("/") or host == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return False
+
+
 def validate_database():
-    """Read-only check: reachable database with all repository migrations applied."""
+    """Reachable database with every repository migration applied, and nothing else.
+
+    `require_local_database` has already refused a remote one. This is what runs
+    when the check goes ahead, so it has to be safe through a transaction-mode
+    pooler as well: see `applied_migrations`.
+    """
     from dinkydash import db
     from psycopg.conninfo import make_conninfo
 
     try:
         conninfo = make_conninfo(os.environ["DATABASE_URL"], connect_timeout=5)
         with db.connect(conninfo) as conn:
-            conn.execute("SET statement_timeout = '5s'")
-            conn.execute("SET default_transaction_read_only = on")
-            applied = {row[0] for row in conn.execute("SELECT name FROM schema_migrations")}
+            applied = applied_migrations(conn)
     except Exception as exc:
         # Driver exceptions can contain credentials or connection details.
         raise RuntimeError(
@@ -77,6 +131,20 @@ def validate_database():
         ) from None
     if any(path.name not in applied for path in db.migrations()):
         raise RuntimeError("Database migrations are missing; run migrate.py on your development database.")
+
+
+def applied_migrations(conn):
+    """The migration names the database records, read in one short read-only transaction.
+
+    `SET LOCAL`, never `SET`. A session-level setting outlives this connection
+    on a transaction-mode pooler and lands on whichever client is handed the
+    server connection next. Both settings end with the transaction, and
+    `tests/test_dev.py` asserts the session is left exactly as it was found.
+    """
+    with conn.transaction():
+        conn.execute("SET LOCAL transaction_read_only = on")
+        conn.execute("SET LOCAL statement_timeout = '5s'")
+        return {row[0] for row in conn.execute("SELECT name FROM schema_migrations")}
 
 
 def serve(name, port, ready):

--- a/dinkydash/CLAUDE.md
+++ b/dinkydash/CLAUDE.md
@@ -209,6 +209,10 @@ under transaction-mode pooling the next execution can land on a different backen
 full reasoning, and why KeepTheScore's clean record on psycopg2 does not transfer, is in PLAN.md
 under [Connection pooling](../PLAN.md#connection-pooling).
 
+**And never a session-level `SET` through `DATABASE_URL`.** The pooler hands a server connection to
+its next client exactly as the last one left it, so the setting lands on the worker or on somebody's
+request. `SET LOCAL` inside a transaction is the safe form, because it ends with the transaction.
+
 **`db.ready(pool)` is what makes a wrong `DATABASE_URL` a failed deploy rather than a live one.**
 A pool opens in the background and a connection string that goes nowhere is only a warning in its
 log — the process came up, `/healthz` answered, and every request that needed the database then
@@ -333,8 +337,8 @@ VEVENT that cannot fall inside `[start, end]`, and keeps whatever the parser nee
 itself: recurring events and their exceptions, extra dates, VTIMEZONE blocks, and any event whose
 dates it cannot read. The reason is memory, not speed: `icalendar` builds an object for every
 property of every event, a decade-long personal calendar is 8 MB and 14,000 of them, and parsing one
-cost ~200 MB with ~250 MB kept by the process afterwards — which is how two gunicorn workers took the
-hosted site past its 512 MB on 10 September 2026. The rule is that over-keeping is always safe and
+cost ~200 MB with ~250 MB kept by the process afterwards — more than two gunicorn workers can hold in
+a 512 MB container. The rule is that over-keeping is always safe and
 under-keeping is a hidden appointment, so every doubt resolves to keep, and `tests/test_feed_trim.py`
 asserts that the trimmed parse gives exactly what the untrimmed one gave.
 

--- a/dinkydash/calendars.py
+++ b/dinkydash/calendars.py
@@ -171,14 +171,14 @@ def _occurrences(ical_text, start, end):
     return list(recurring_events_of(cal).between(start, end + timedelta(days=1)))
 
 
-# A personal Google calendar is a decade of appointments in one file — the
-# owner's is 8 MB and 14,000 events — and `icalendar` builds an object for every
-# property of every one of them. Measured on that feed: ~200 MB to parse and
+# A personal Google calendar is a decade of appointments in one file — 8 MB and
+# 14,000 events is an ordinary one — and `icalendar` builds an object for every
+# property of every one of them. Measured on such a feed: ~200 MB to parse and
 # ~250 MB kept by the process afterwards, because Python does not hand arenas
-# back. Two gunicorn workers each holding that is how the hosted site went past
-# its 512 MB and was killed on 10 September 2026, with nothing in the log but
-# the exit. The dashboard only ever wants a fortnight, so `_trim` drops, as text and
-# before the parser sees them, the events that cannot fall in the window.
+# back. Two gunicorn workers each holding that is more than a 512 MB container,
+# and the container's log shows nothing but the exit. The dashboard only ever
+# wants a fortnight, so `_trim` drops, as text and before the parser sees them,
+# the events that cannot fall in the window.
 #
 # Whatever the parser needs to get the window right is kept regardless of its
 # date: recurring events (their EXDATEs ride on them), extra dates, the

--- a/dinkydash/db.py
+++ b/dinkydash/db.py
@@ -13,6 +13,11 @@ pooling):
                          CREATE INDEX CONCURRENTLY cannot run inside a
                          transaction block, and pg_dump errors against a
                          transaction-mode pool.
+
+Never send a session-level `SET` through DATABASE_URL. A transaction-mode
+pooler hands a server connection to its next client exactly as the last one
+left it, so the setting lands on the worker or on somebody's request.
+`SET LOCAL` inside a transaction is fine, because it ends with the transaction.
 """
 
 import logging
@@ -74,9 +79,9 @@ def ready(pool, timeout=None):
     A pool opens in the background, and a wrong connection string is only a
     warning in its log: the process comes up, `/healthz` answers, the deploy is
     declared healthy, and every request that needs the database then waits
-    thirty seconds and fails. This was demonstrated, not guessed — the cloud
-    entry point built in half a second against a closed port and answered
-    200 on both hostnames. Waiting here turns that into a process that never
+    thirty seconds and fails; an entry point built against a closed port
+    still comes up in half a second and answers 200 on both hostnames.
+    Waiting here turns that into a process that never
     starts, which under gunicorn is a container that never becomes healthy,
     which is a deploy that never goes live while the previous one carries on —
     and App Platform's own DEPLOYMENT_FAILED alert says so (DIN-54).

--- a/doc/development.md
+++ b/doc/development.md
@@ -20,6 +20,13 @@ does not change Conductor's environment. Explicit environment values override
 `.env`; inspect which database you selected before migrating or signing in.
 The launcher never applies migrations or creates sample accounts.
 
+**The launcher only accepts a database on this machine**: a loopback address or a
+Unix socket, with no override. A workspace's `.env` can carry a remote
+`DATABASE_URL`, and a launcher that connected to it would be a local preview of
+a real service, with its start-up check running through that service's pooler.
+A remote URL fails startup before anything connects; export a scratch database
+URL instead.
+
 The single **dev** run action starts both existing Flask apps:
 
 | App | In Conductor | Outside Conductor |

--- a/doc/operations.md
+++ b/doc/operations.md
@@ -657,3 +657,26 @@ issue.
 
 **Not done here.** Frontend error capture (DIN-35's third leg): the dashboard and the settings pages
 make no third-party request by design, and a first-party reporting path is separate work.
+
+## The worker went read-only for an hour, 11 September 2026
+
+**What happened.** At 11:19:41 UTC the `worker` logged `cannot execute UPDATE in a read-only
+transaction` from `lifecycle.expire_trials` and `cannot execute DELETE` from `accounts.sweep`, and
+again at 11:22:31 from the new container the PR #122 deploy had just started (Sentry DINKYDASH-2
+and DINKYDASH-3). Both handled: every pass completed and checked in, the families were ticked, and
+`site` logged no 5xx. No database maintenance or failover in the cluster's event log.
+
+**Why.** At 11:17 UTC a development launcher in a workspace was started with the `.env` copied from
+the main checkout, whose `DATABASE_URL` is the hosted pool on port 25061 (see *Secrets and `.env`*
+above). Its start-up check ran a session-level `SET default_transaction_read_only = on`.
+DigitalOcean's pooler runs in transaction mode, where PgBouncer never runs its reset query, so the
+pooled server connection kept the setting and handed it to its next client, the worker. Ten
+concurrent read-only transactions through the pool at 11:25 found exactly one such backend, born
+10:27:48; PgBouncer's 3600 s `server_lifetime` closed it at 11:27:48, the 11:27:31 pass was clean,
+and the launcher, still holding a socket to the pool, was killed at 11:41.
+
+**The fix,** in the same change as this note: `dev.py` refuses a `DATABASE_URL` that is not loopback
+or a Unix socket before anything connects, parsed by libpq so a host cannot hide in `?host=`, a
+comma list, `hostaddr` or `PGHOST`, with no override; its check is one transaction with `SET LOCAL`,
+asserted in `tests/test_dev.py` to leave the session as it found it; and the rule — never a
+session-level `SET` through `DATABASE_URL` — is written where the pool is built, in `dinkydash/db.py`.

--- a/tests/test_dev.py
+++ b/tests/test_dev.py
@@ -28,6 +28,9 @@ def isolated_config(monkeypatch, tmp_path):
     monkeypatch.setenv("DINKYDASH_APP_HOST", "app.example.test")
     monkeypatch.setenv("SENDGRID_API_KEY", "")
     monkeypatch.setenv("ANTHROPIC_API_KEY", "")
+    # libpq reads these when a URL names no host; a developer's shell must not decide the tests.
+    for name in ("PGHOST", "PGHOSTADDR"):
+        monkeypatch.delenv(name, raising=False)
 
 
 def test_dotenv_defaults_and_environment_precedence(monkeypatch, tmp_path):
@@ -55,6 +58,7 @@ def test_ports(monkeypatch, values, expected):
 
 @pytest.mark.parametrize("values, error", [
     ({"DATABASE_URL": " "}, "DATABASE_URL"),
+    ({"DATABASE_URL": "postgresql://nobody:hunter2@db.example.com/dinkydash"}, "on this machine"),
     ({"DINKYDASH_SECRET_KEY": ""}, "DINKYDASH_SECRET_KEY"),
     ({"DINKYDASH_SECRET_KEY": "dinkydash-self-hosted"}, "private development key"),
     ({"CONDUCTOR_PORT": ""}, "CONDUCTOR_PORT"),
@@ -71,6 +75,49 @@ def test_invalid_configuration(monkeypatch, values, error):
         monkeypatch.setenv(name, value)
     with pytest.raises(RuntimeError, match=error):
         dev.configure()
+
+
+@pytest.mark.parametrize("url", [
+    "postgresql:///dinkydash_dev",
+    "postgresql://localhost/dinkydash_dev",
+    "postgresql://dinkydash@127.0.0.1:54321/dinkydash_dev",
+    "postgresql://[::1]/dinkydash_dev",
+    "postgresql://%2Ftmp%2Fpg/dinkydash_dev",
+    "host=/tmp dbname=dinkydash_dev",
+    "dbname=dinkydash_dev",
+])
+def test_local_database_accepted(url):
+    dev.require_local_database(url)
+
+
+@pytest.mark.parametrize("url", [
+    "postgresql://nobody:hunter2@db.example.com:25061/pool?sslmode=require",
+    "postgresql://nobody@203.0.113.9/dinkydash_dev",
+    "postgresql://localhost,db.example.com/dinkydash_dev",
+    "postgresql:///dinkydash_dev?host=db.example.com",
+    "host=db.example.com dbname=dinkydash_dev",
+    "hostaddr=203.0.113.9 dbname=dinkydash_dev",
+])
+def test_remote_database_refused(url):
+    """A workspace's `.env` can hold a remote database, and the launcher must never reach it.
+
+    The refusal names the variable and nothing from the value: a connection
+    string carries a password, and this message is printed.
+    """
+    with pytest.raises(RuntimeError, match="on this machine") as refused:
+        dev.require_local_database(url)
+    message = str(refused.value)
+    assert "hunter2" not in message
+    assert "example.com" not in message
+    assert "203.0.113.9" not in message
+
+
+def test_pghost_counts_when_the_url_names_no_host(monkeypatch):
+    monkeypatch.setenv("PGHOST", "db.example.com")
+    with pytest.raises(RuntimeError, match="on this machine"):
+        dev.require_local_database("postgresql:///dinkydash_dev")
+    monkeypatch.setenv("PGHOST", "/tmp")
+    dev.require_local_database("postgresql:///dinkydash_dev")
 
 
 @pytest.fixture
@@ -216,6 +263,25 @@ def test_unmigrated_database_starts_neither(pg_pool, launch):
     assert process.wait(timeout=10) == 1
     assert "Database validation failed" in log.read_text()
     assert "Starting " not in log.read_text()
+
+
+def test_validation_leaves_the_session_as_it_found_it(pg_pool):
+    """What the check sets must end with its transaction.
+
+    Through a transaction-mode pooler a session-level SET outlives the
+    connection and lands on the next client. So the session is checked
+    before and after, and then written to.
+    """
+    from dinkydash import db
+
+    settings = ("transaction_read_only", "default_transaction_read_only", "statement_timeout")
+    with db.connect(os.environ["DINKYDASH_TEST_DATABASE_URL"]) as conn:
+        before = [conn.execute(f"SHOW {name}").fetchone()[0] for name in settings]
+        applied = dev.applied_migrations(conn)
+        after = [conn.execute(f"SHOW {name}").fetchone()[0] for name in settings]
+        conn.execute("CREATE TEMP TABLE still_writable (x int)")  # refused in a read-only session
+    assert after == before
+    assert {path.name for path in db.migrations()} <= applied
 
 
 def lifecycle_worker(name, port, ready):

--- a/tests/test_feed_trim.py
+++ b/tests/test_feed_trim.py
@@ -1,9 +1,9 @@
 """A decade-long feed is parsed a fortnight at a time.
 
 `icalendar` builds an object for every property of every event, and a personal
-Google calendar is ten years of them: the owner's is 8 MB and 14,000 events,
-measured at ~200 MB to parse and ~250 MB kept afterwards, which is how two
-gunicorn workers took the hosted site past 512 MB on 10 September 2026.
+Google calendar is ten years of them: 8 MB and 14,000 events is an ordinary one,
+measured at ~200 MB to parse and ~250 MB kept afterwards, which is more than two
+gunicorn workers can hold in a 512 MB container.
 `calendars._trim` drops, as text, every VEVENT that cannot touch the window
 before the parser sees it. These tests pin what must survive the trim: the
 trimmed parse has to give exactly what the untrimmed one gave.

--- a/tests/test_no_incident_notes.py
+++ b/tests/test_no_incident_notes.py
@@ -1,0 +1,92 @@
+"""Comments explain the rule, never the incident.
+
+This repo is public. A comment that says what a check protects against is
+documentation; one that says when it went wrong, who did what and which Sentry
+issue it opened is operational history published for ever, and it belongs in
+`doc/operations.md` or in Linear instead. This walks every comment, docstring,
+spec, workflow, migration and template comment for the two shapes such a note
+reliably has — a sentence dated to a day (a preposition, a day, a month and a
+year) and a Sentry issue id — so the rule in CLAUDE.md is a test rather than a
+preference. Dates in data and in content are not comments and are not scanned.
+"""
+
+import ast
+import io
+import os
+import re
+import tokenize
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SKIP_DIRS = {"venv", "node_modules", ".git", ".playwright-mcp", ".context", "__pycache__"}
+
+MONTH = "January|February|March|April|May|June|July|August|September|October|November|December"
+NARRATIVE = re.compile(
+    rf"\bDINKYDASH-\d+\b"
+    rf"|\b(?:on|until|since|before|after|from)\s+\d{{1,2}}\s+(?:{MONTH})\s+20\d\d\b")
+
+
+def walk(suffixes, under=ROOT):
+    for directory, dirnames, filenames in os.walk(under):
+        dirnames[:] = sorted(d for d in dirnames if d not in SKIP_DIRS)
+        for name in sorted(filenames):
+            if name.endswith(suffixes):
+                yield Path(directory) / name
+
+
+def runs(lines):
+    """Consecutive comment lines joined, so a sentence split over two lines still reads."""
+    run = []
+    for text in lines:
+        if text is None:
+            if run:
+                yield " ".join(run)
+            run = []
+        else:
+            run.append(text)
+    if run:
+        yield " ".join(run)
+
+
+def python_notes(path):
+    source = path.read_text()
+    tokens = tokenize.generate_tokens(io.StringIO(source).readline)
+    yield from runs(
+        token.string.lstrip("#").strip() if token.type == tokenize.COMMENT
+        else None if token.type not in (tokenize.NL, tokenize.NEWLINE, tokenize.INDENT, tokenize.DEDENT)
+        else ""
+        for token in tokens)
+    for node in ast.walk(ast.parse(source)):
+        if isinstance(node, (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+            doc = ast.get_docstring(node)
+            if doc:
+                yield " ".join(doc.split())
+
+
+def line_notes(path, marker):
+    yield from runs(
+        line.strip()[len(marker):].strip() if line.strip().startswith(marker) else None
+        for line in path.read_text().splitlines())
+
+
+def template_notes(path):
+    for match in re.finditer(r"\{#(.*?)#\}|<!--(.*?)-->", path.read_text(), re.S):
+        yield " ".join((match.group(1) or match.group(2) or "").split())
+
+
+def notes():
+    for path in walk((".py",)):
+        yield from ((path, note) for note in python_notes(path))
+    for path in list(walk((".yaml", ".yml"), ROOT / ".do")) + list(walk((".yml", ".yaml"), ROOT / ".github")) \
+            + list(walk((".toml",), ROOT / ".conductor")) + list(walk((".sh",))):
+        yield from ((path, note) for note in line_notes(path, "#"))
+    for path in walk((".sql",), ROOT / "migrations"):
+        yield from ((path, note) for note in line_notes(path, "--"))
+    for path in list(walk((".html",), ROOT / "web" / "templates")) + list(walk((".html",), ROOT / "website" / "templates")):
+        yield from ((path, note) for note in template_notes(path))
+
+
+def test_no_dated_narrative_or_sentry_ids_in_comments():
+    found = [(str(path.relative_to(ROOT)), NARRATIVE.search(note).group())
+             for path, note in notes() if NARRATIVE.search(note)]
+    assert not found, found

--- a/web/routes/board.py
+++ b/web/routes/board.py
@@ -138,11 +138,10 @@ def healthz():
     question it should be able to answer wrongly.
 
     The SHA comes from the environment because a deployed checkout has no
-    `.git` to ask. **App Platform does not set one on its own** — this read
-    "unknown" in production from the first deploy until 8 September 2026,
-    because the two fallbacks that used to be here (`APP_PLATFORM_COMPONENT_
-    COMMIT`, `SOURCE_COMMIT`) were guesses at variable names that do not
-    exist. What does exist is `${_self.COMMIT_HASH}`, a *bindable* variable:
+    `.git` to ask. **App Platform does not set one on its own**, and the two
+    fallbacks that used to be here (`APP_PLATFORM_COMPONENT_COMMIT`,
+    `SOURCE_COMMIT`) were guesses at variable names that do not exist, so
+    this read "unknown". What does exist is `${_self.COMMIT_HASH}`, a *bindable* variable:
     it has to be assigned to a key in the component's own `envs` before
     anything can read it, and it is component-scoped, so it cannot live in the
     app-level block with the rest. `.do/app.yaml` binds it to `GIT_SHA`, which


### PR DESCRIPTION
The development launcher now refuses any `DATABASE_URL` that is not a loopback address or a Unix socket, parsed by libpq so a host cannot hide in the query string, a comma list, `hostaddr` or `PGHOST`, and it fails before anything connects, with no override. Its start-up check runs as one transaction with `SET LOCAL`, so no session setting can outlive it on a transaction-mode pooler; tests cover the accepted and refused shapes, that the refusal never prints the value, and that the session is left exactly as it was found. Comments and docstrings now state the rule and its reason rather than the incident: the convention is in CLAUDE.md, a new test fails on a day-dated sentence or a Sentry issue id in any comment, docstring, spec, workflow, migration or template, and six older comments in the App Platform spec, the CI workflow, `board.py`, `db.py`, `calendars.py` and `test_feed_trim.py` are generalised to match. The account of the day itself is in `doc/operations.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
