### PR TITLE
Draw the settings app bar once, in base.html (DIN-72)

### DIFF
--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -988,9 +988,80 @@ class TestRefreshingTheCalendarsByHand:
         assert "Could not refresh the calendars: the disk is full" in page.get_data(as_text=True)
 
 
+class TestTheAppBar:
+    """The bar across the top of every settings page is drawn once, in `settings/base.html`,
+    from two facts a page states at its top level — where back goes and what it is called —
+    and the page's own title block. A page overrides the block only to put something other
+    than a heading there."""
+
+    TEMPLATES = pathlib.Path(__file__).resolve().parent.parent / "web" / "templates"
+
+    def pages(self):
+        for path in sorted(self.TEMPLATES.rglob("*.html")):
+            yield str(path.relative_to(self.TEMPLATES)), path.read_text()
+
+    def test_the_bar_is_drawn_in_one_place(self):
+        # Changing what the bar holds is a one-file change. The three pages that override it
+        # put the brand where the heading would be, and the home adds its links beside it;
+        # a fourth has to say here what else it needs.
+        overriding = [name for name, text in self.pages()
+                      if "{% block appbar %}" in text and name != "settings/base.html"]
+        assert overriding == ["auth/login.html", "auth/sent.html", "settings/home.html"]
+
+    def test_every_back_link_names_where_it_goes(self):
+        # The way back is the chevron and the name of the page it goes to. A bare
+        # `<a class="back">` in a page is a chevron with no name again, and so is a
+        # `back_href` with no `back_label` beside it.
+        bare, unnamed, seen = [], [], 0
+        for name, text in self.pages():
+            if name == "settings/base.html":
+                continue
+            if re.search(r'<a\b[^>]*class="back"', text):
+                bare.append(name)
+            href = re.search(r"{%\s*set\s+back_href\s*=", text)
+            label = re.search(r"{%\s*set\s+back_label\s*=", text)
+            if bool(href) != bool(label):
+                unnamed.append(name)
+            seen += bool(href)
+        assert bare == []
+        assert unnamed == []
+        assert seen >= 7
+        base = (self.TEMPLATES / "settings" / "base.html").read_text()
+        assert '<a class="back" href="{{ back_href }}">' in base
+        assert "<span>{{ back_label }}</span>" in base
+
+    def test_a_page_names_itself_once(self, client, config_path):
+        # The heading is the title block, so the tab and the bar cannot disagree; the way
+        # back is drawn from what the page set, and not at all where it set nothing.
+        page = client.get("/settings/system").get_data(as_text=True)
+        assert "<title>Family &amp; system · DinkyDash</title>" in page
+        assert "<h1>Family &amp; system</h1>" in page
+        assert '<a class="back" href="/settings/">' in page
+        assert "<span>Settings</span>" in page
+        assert 'class="back"' not in client.get("/settings/").get_data(as_text=True)
+
+    def test_the_way_back_names_the_page_it_goes_to(self, client, config_path):
+        # On an edit form it is the section; on a confirmation it is the form being left.
+        client.get("/settings/people")  # the first load gives every item its id
+        pid = ids_for(config_path)[0]
+        edit = client.get(f"/settings/people/{pid}").get_data(as_text=True)
+        assert '<a class="back" href="/settings/people">' in edit
+        assert "<span>People</span>" in edit
+        confirm = client.post(f"/settings/people/{pid}/delete").get_data(as_text=True)
+        assert f'<a class="back" href="/settings/people/{pid}">' in confirm
+        assert "<span>Cancel</span>" in confirm
+
+    def test_the_colours_page_is_called_that_in_the_tab_too(self, client):
+        # A self-hoster has no screen link, so the page is only its colours (see
+        # `TestTheWayBackFromTheBoard`), and the tab agrees with the bar.
+        page = client.get("/settings/screen").get_data(as_text=True)
+        assert "<title>Colours · DinkyDash</title>" in page
+        assert "<h1>Colours</h1>" in page
+
+
 class TestTheControlsUnderAPointer:
     """The settings UI is used from a desk as well as a phone. Every control has a hover, a
-    press and a keyboard state in `settings/base.html`; the three things below are the ones a
+    press and a keyboard state in `settings/base.html`; the two things below are the ones a
     stylesheet cannot enforce on its own."""
 
     TEMPLATES = pathlib.Path(__file__).resolve().parent.parent / "web" / "templates"
@@ -999,21 +1070,6 @@ class TestTheControlsUnderAPointer:
         # The name beside a chore's checkbox was a span, so clicking it did nothing.
         page = client.get("/settings/recurring/new").get_data(as_text=True)
         assert '<label for="p-1">Mia</label>' in page
-
-    def test_every_back_link_names_where_it_goes(self):
-        # The way back is `icons.back_to(href, label)`: the chevron and the name of the page
-        # it goes to. A bare `<a class="back">` in a page is a chevron with no name again.
-        bare, seen = [], 0
-        for path in self.TEMPLATES.rglob("*.html"):
-            if path.name == "_icons.html":
-                continue
-            text = path.read_text()
-            if re.search(r'<a\b[^>]*class="back"', text):
-                bare.append(str(path.relative_to(self.TEMPLATES)))
-            seen += len(re.findall(r"icons\.back_to\(", text))
-        assert bare == []
-        assert seen >= 6
-        assert "<span>{{ label }}</span>" in (self.TEMPLATES / "settings" / "_icons.html").read_text()
 
     def test_no_button_carries_its_look_inline(self):
         # An inline style beats every hover, press and disabled rule in the sheet, which is how

--- a/web/CLAUDE.md
+++ b/web/CLAUDE.md
@@ -146,14 +146,19 @@ variable set still gets a page. `is_admin()` compares that address and takes no 
 nothing a request carries can reach the comparison; `tests/test_admin.py` asserts the link is
 shown to the listed address and to nobody else, in either mode.
 
-**The app bar holds the way back and the title, and never a Save.** A page that saves ends its
-form with a full-width `.btn` Save, where the fields are, and the bar's left-hand button is
-`icons.back_to(href, label)` — the chevron plus the *name of the page it goes to* ("Settings",
-or the section title on an edit form), drawn as a bordered pill so the tap target is visible.
-A header Save was tried and taken out: it sat in the shared chrome rather than with the form
-it saved, and the bare chevron beside it was too small to read as a button. The calendar
-form carries one unseen submit button ahead of "Test calendar link", because Enter presses
-a form's first submit button and Enter should save there as it does everywhere else.
+**The app bar is drawn once, in `settings/base.html`, and holds the way back and the title,
+never a Save.** A page draws none of it; it states two facts at its top level. `{% set back_href
+%}` and `{% set back_label %}` say where back goes and what it is called — the *name of the page
+it goes to* ("Settings", or the section title on an edit form), never "Back" — and the heading
+is the page's own `title` block, so the tab and the bar cannot disagree. The base draws the way
+back as a bordered pill so the tap target is visible, or nothing where the page set no
+`back_href`. Only the settings home and the two sign-in pages override `{% block appbar %}`, to
+put the brand where the heading would be; `tests/test_settings.py` pins that list, so a fourth
+override has to say why. A page that saves ends its form with a full-width `.btn` Save, where
+the fields are. A header Save was tried and taken out: it sat in the shared chrome rather than
+with the form it saved, and the bare chevron beside it was too small to read as a button. The
+calendar form carries one unseen submit button ahead of "Test calendar link", because Enter
+presses a form's first submit button and Enter should save there as it does everywhere else.
 
 **Every form that writes needs one hidden field.** `<input type="hidden" name="csrf_token"
 value="{{ csrf_token() }}">`, right inside the `<form>`. `csrf_token()` is a Jinja global set up by

--- a/web/templates/admin/growth.html
+++ b/web/templates/admin/growth.html
@@ -3,8 +3,9 @@
    gets a 404 before this renders. Nothing here belongs to any one family:
    the numbers are counts, and the page takes no id from anywhere. #}
 {% extends "settings/base.html" %}
-{% import "settings/_icons.html" as icons %}
 {% block title %}Growth{% endblock %}
+{% set back_href = url_for('settings.home') %}
+{% set back_label = 'Settings' %}
 {# No pre-rendering from here: the operator's page carries no script at all,
    and a test holds it to that. It links nowhere a family would go anyway. #}
 {% block speculation %}{% endblock %}
@@ -59,11 +60,6 @@
     .account .row-sub { white-space: normal; }
     .pill.good { background: rgba(22, 163, 74, 0.12); color: #15803d; }
 </style>
-{% endblock %}
-
-{% block appbar %}
-{{ icons.back_to(url_for('settings.home'), 'Settings') }}
-<h1>Growth</h1>
 {% endblock %}
 
 {% block content %}

--- a/web/templates/settings/_icons.html
+++ b/web/templates/settings/_icons.html
@@ -1,9 +1,5 @@
 {% macro chevron() %}<svg class="chev" style="width:1.125em;height:1.125em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"></polyline></svg>{% endmacro %}
 {% macro back() %}<svg style="width:1.375em;height:1.375em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"></polyline></svg>{% endmacro %}
-{# The way back: the chevron and the name of the page it goes to, drawn as a button.
-   `label` is the destination, never "Back" — a person on the edit form should know
-   that the arrow returns them to People and drops what they typed. #}
-{% macro back_to(href, label) %}<a class="back" href="{{ href }}">{{ back() }}<span>{{ label }}</span></a>{% endmacro %}
 {% macro plus() %}<svg style="width:1.1875em;height:1.1875em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round"><path d="M12 5v14"></path><path d="M5 12h14"></path></svg>{% endmacro %}
 {% macro refresh() %}<svg style="width:1.0625em;height:1.0625em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.1" stroke-linecap="round" stroke-linejoin="round"><path d="M20.5 12a8.5 8.5 0 1 1-2.7-6.2"></path><polyline points="20.8 4.2 20.8 9.4 15.6 9.4"></polyline></svg>{% endmacro %}
 {% macro screen() %}<svg style="width:1.0625em;height:1.0625em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.1" stroke-linecap="round" stroke-linejoin="round"><rect x="2.5" y="4" width="19" height="13" rx="2"></rect><path d="M8 20.5h8"></path></svg>{% endmacro %}

--- a/web/templates/settings/account.html
+++ b/web/templates/settings/account.html
@@ -5,8 +5,9 @@
    each other: one is a link, the other is a form that will not submit until an
    address has been typed into it. #}
 {% extends "settings/base.html" %}
-{% import "settings/_icons.html" as icons %}
 {% block title %}Your data{% endblock %}
+{% set back_href = url_for('settings.home') %}
+{% set back_label = 'Settings' %}
 
 {% block head %}
 <style>
@@ -17,11 +18,6 @@
     .confirm-field > label { text-transform: none; letter-spacing: 0; font-size: 0.8125rem; }
     .confirm-field > label strong { word-break: break-all; }
 </style>
-{% endblock %}
-
-{% block appbar %}
-{{ icons.back_to(url_for('settings.home'), 'Settings') }}
-<h1>Your data</h1>
 {% endblock %}
 
 {% block content %}

--- a/web/templates/settings/base.html
+++ b/web/templates/settings/base.html
@@ -1,3 +1,4 @@
+{% import "settings/_icons.html" as icons -%}
 <!doctype html>
 <html lang="en">
 <head>
@@ -426,7 +427,20 @@
 <body>
 <div class="shell">
     <div class="appbar">
-        {% block appbar %}{% endblock %}
+        {# Drawn here, once, from two facts a page states at its top level: where back
+           goes and what it is called (`back_href` and `back_label`), and its heading,
+           which is the `title` block it already has for the browser tab — so a page
+           names itself once. A page with no way back sets neither. The three pages
+           whose bar is something else (the settings home, and the two sign-in pages,
+           with the brand where the heading would be) override the block instead. #}
+        {% block appbar %}
+        {# The way back: the chevron and the name of the page it goes to, drawn as a
+           button. `back_label` is the destination, never "Back" — a person on the edit
+           form should know that the arrow returns them to People and drops what they
+           typed. #}
+        {% if back_href %}<a class="back" href="{{ back_href }}">{{ icons.back() }}<span>{{ back_label }}</span></a>{% endif %}
+        <h1>{{ self.title() }}</h1>
+        {% endblock %}
     </div>
     <div class="content">
         {% with messages = get_flashed_messages(with_categories=true) %}

--- a/web/templates/settings/confirm.html
+++ b/web/templates/settings/confirm.html
@@ -1,10 +1,7 @@
 {% extends "settings/base.html" %}
-{% import "settings/_icons.html" as icons %}
 {% block title %}{{ prompt.title }}{% endblock %}
-{% block appbar %}
-{{ icons.back_to(cancel_url, 'Cancel') }}
-<h1>{{ prompt.title }}</h1>
-{% endblock %}
+{% set back_href = cancel_url %}
+{% set back_label = 'Cancel' %}
 {% block content %}
 <div class="note-box">{{ prompt.message }}</div>
 <form method="post" class="confirmation-actions">

--- a/web/templates/settings/edit.html
+++ b/web/templates/settings/edit.html
@@ -1,11 +1,8 @@
 {% extends "settings/base.html" %}
 {% import "settings/_icons.html" as icons %}
 {% block title %}{{ ("New " ~ section.singular) if is_new else (item.name or item.title or item.label or section.singular) }}{% endblock %}
-
-{% block appbar %}
-{{ icons.back_to(url_for('settings.section_list', section_name=section_name), section.title) }}
-<h1>{{ ("New " ~ section.singular) if is_new else (item.name or item.title or item.label or section.singular) }}</h1>
-{% endblock %}
+{% set back_href = url_for('settings.section_list', section_name=section_name) %}
+{% set back_label = section.title %}
 
 {% macro field_access(name, help) -%}
     {% if help or problems.get(name) %}aria-describedby="{{ ('hint-' ~ name ~ ' ') if help }}{{ ('error-' ~ name) if problems.get(name) }}"{% endif %}

--- a/web/templates/settings/list.html
+++ b/web/templates/settings/list.html
@@ -1,11 +1,8 @@
 {% extends "settings/base.html" %}
 {% import "settings/_icons.html" as icons %}
 {% block title %}{{ section.title }}{% endblock %}
-
-{% block appbar %}
-{{ icons.back_to(url_for('settings.home'), 'Settings') }}
-<h1>{{ section.title }}</h1>
-{% endblock %}
+{% set back_href = url_for('settings.home') %}
+{% set back_label = 'Settings' %}
 
 {% block content %}
 {% if items %}

--- a/web/templates/settings/refresh.html
+++ b/web/templates/settings/refresh.html
@@ -1,11 +1,7 @@
 {% extends "settings/base.html" %}
-{% import "settings/_icons.html" as icons %}
 {% block title %}How often it updates{% endblock %}
-
-{% block appbar %}
-{{ icons.back_to(url_for('settings.home'), 'Settings') }}
-<h1>How often it updates</h1>
-{% endblock %}
+{% set back_href = url_for('settings.home') %}
+{% set back_label = 'Settings' %}
 
 {% block content %}
 {% if problems %}

--- a/web/templates/settings/screen.html
+++ b/web/templates/settings/screen.html
@@ -1,6 +1,10 @@
 {% extends "settings/base.html" %}
-{% import "settings/_icons.html" as icons %}
-{% block title %}The screen{% endblock %}
+{# Hosted, the page is about the screen and its link; on a Pi there is no link
+   to show and it is only the colours. The title says which, and the bar's
+   heading follows it. #}
+{% block title %}{{ "The screen" if screen_link else "Colours" }}{% endblock %}
+{% set back_href = url_for('settings.home') %}
+{% set back_label = 'Settings' %}
 
 {% block head %}
 <style>
@@ -22,11 +26,6 @@
         .theme-choice input:not(:checked) + .theme-card:hover { background: var(--warm); border-color: var(--border-strong); }
     }
 </style>
-{% endblock %}
-
-{% block appbar %}
-{{ icons.back_to(url_for('settings.home'), 'Settings') }}
-<h1>{{ "The screen" if screen_link else "Colours" }}</h1>
 {% endblock %}
 
 {% block content %}

--- a/web/templates/settings/system.html
+++ b/web/templates/settings/system.html
@@ -1,11 +1,7 @@
 {% extends "settings/base.html" %}
-{% import "settings/_icons.html" as icons %}
 {% block title %}Family &amp; system{% endblock %}
-
-{% block appbar %}
-{{ icons.back_to(url_for('settings.home'), 'Settings') }}
-<h1>Family &amp; system</h1>
-{% endblock %}
+{% set back_href = url_for('settings.home') %}
+{% set back_label = 'Settings' %}
 
 {% block content %}
 <form data-dirty-guard id="system-form" method="post" class="card pad" style="display:flex;flex-direction:column;gap:1rem;">


### PR DESCRIPTION
Every settings page drew the shared top bar itself, so `settings/base.html` now draws it from two facts a page states at its top level (`back_href` and `back_label`) and the page's own title block, and eight pages (the seven in DIN-72 plus the admin growth page) drop their copy along with the now-callerless `icons.back_to` macro. Only the settings home and the two sign-in pages still override `{% block appbar %}`, which `tests/test_settings.py` now pins, alongside checks that every `back_href` has a label and that the rendered bar on the system, edit and confirm pages is what it was. One visible change beyond whitespace: the screen page's title block now carries the "Colours" wording a self-hoster already saw in the heading, so the browser tab agrees with the bar in single mode (cloud mode is unchanged). Verified by snapshotting 22 pages in both modes before and after and diffing with whitespace, item ids and tokens normalised, and `web/CLAUDE.md` describes the new mechanism. Linear: DIN-72.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
